### PR TITLE
Fix TypeScript errors in CapabilityTile, FreeMap and secret binding

### DIFF
--- a/src/bindings/secret/index.ts
+++ b/src/bindings/secret/index.ts
@@ -10,7 +10,7 @@ class SecretBinding  {
     }
 
     getSecret(key:string):string {
-        return defSettings[key]??getUserSettingsBinding().getValue(key,null)
+        return (defSettings as Record<string, string>)[key] ?? getUserSettingsBinding().getValue(key, null)
 
     }
     async init():Promise<void> {

--- a/src/components/CapabilityTile/CapabilityTile.tsx
+++ b/src/components/CapabilityTile/CapabilityTile.tsx
@@ -107,7 +107,7 @@ const CapabilityTileView = React.memo ( (props: ComponentProps) => {
 
     if ( deviceName && !disabled) {
         return (
-            <View style= {styles.container}>
+            <View style= {styles.container.view}>
             
                 { (title ) &&
                     <View style={styles.rows.fixed}>
@@ -156,7 +156,7 @@ const CapabilityTileView = React.memo ( (props: ComponentProps) => {
     }
     
     return (
-            <View style= {styles.container}>
+            <View style= {styles.container.view}>
             {/* {data.header.icon &&
                 <Image source={iconMap[data.header.icon]} style={styles.icon} /> } */}
             {title &&
@@ -186,16 +186,17 @@ const CapabilityTileView = React.memo ( (props: ComponentProps) => {
 
 
 const styles = {
-    container: {
-        display:'flex',
-        flexDirection:'column',
-        height: '100%',
-        width: '100%',
-        flex:1,
-        alignItems: 'center',
-        justifyContent: 'center',
-
-    },
+    container: StyleSheet.create({
+        view: {
+            display: 'flex',
+            flexDirection: 'column',
+            height: '100%',
+            width: '100%',
+            flex: 1,
+            alignItems: 'center',
+            justifyContent: 'center',
+        }
+    }),
     rows: StyleSheet.create({
         container: {
             flex:1,
@@ -351,4 +352,3 @@ const styles = {
 
 
 }
-

--- a/src/components/CapabilityTile/CapabilityTile.tsx
+++ b/src/components/CapabilityTile/CapabilityTile.tsx
@@ -12,21 +12,17 @@ import HeartrateIcon from '../../assets/icons/heartrate.svg'
 import PowerIcon from '../../assets/icons/power.svg'
 import SpeedIcon from '../../assets/icons/speed.svg'     
 
-
-
 import  {CapabilityDisplayProps} from 'incyclist-services'
 
 interface CapabilityTileProps extends CapabilityDisplayProps {
     height: number
     marginRight?: number
-    
 }
 
 export const CapabilityTile = ( props:PropsWithChildren<CapabilityTileProps>) => {
 
     const { onClick, ...childProps} = props
    
-
     const onPress = ()=>{
         if (onClick)
             onClick(props as CapabilityDisplayProps)
@@ -45,8 +41,6 @@ export const CapabilityTile = ( props:PropsWithChildren<CapabilityTileProps>) =>
         </TouchableOpacity>
     )
 }
-
-
 
 type ComponentProps = Partial<CapabilityTileProps> & { 
     size: 'small' | 'large' 
@@ -80,34 +74,14 @@ const CapabilityTileView = React.memo ( (props: ComponentProps) => {
         speed: SpeedIcon
     }
 
-
     const iconSize = size==='small' ? 12 : 14
 
     const InterfaceIcon = ifName===undefined ? undefined : interfaceMap[ifName]
     const CapabilityIcon = capability===undefined ? undefined : capabilityMap[capability]
 
-
-    // --> Pro Chnage Logger
-    // const prevProps = React.useRef(null);
-    // React.useEffect(() => {
-    //     if (prevProps.current) {
-    //         const keys = Object.keys({ ...props, ...prevProps.current });
-    //         keys.forEach(key => {
-    //         if (title==='control'|| title==='resistance' && prevProps.current[key] !== props[key]) {
-    //             console.log(`# Pairing: Prop changed: ${key}`, prevProps.current[key], '-->', props[key]);
-    //         }
-    //         });
-    //     }
-    //     prevProps.current = props;
-    // });    
-    // ..... end of logger
-
-
-
-
     if ( deviceName && !disabled) {
         return (
-            <View style= {styles.container.view}>
+            <View style= {styles.container}>
             
                 { (title ) &&
                     <View style={styles.rows.fixed}>
@@ -115,7 +89,6 @@ const CapabilityTileView = React.memo ( (props: ComponentProps) => {
                     </View>
                 }
 
-                
                 <View  style= {styles.rows.flex} >
                         {CapabilityIcon && 
                             <View style={styles.cols.fixed}>
@@ -130,7 +103,6 @@ const CapabilityTileView = React.memo ( (props: ComponentProps) => {
                                 {unit ?  `${unit}` : ' ' }
                             </Text>
                         </View>
-
                 </View>
 
                 <View style={styles.rows.fixed}>
@@ -144,7 +116,6 @@ const CapabilityTileView = React.memo ( (props: ComponentProps) => {
                         </View>
                 </View>
 
-                
                 <View style={[styles.rows.fixed, styles[size].footer]}>
                     <Text style={styles[size].state}>
                     {(connectState??' ').toUpperCase()}
@@ -156,15 +127,12 @@ const CapabilityTileView = React.memo ( (props: ComponentProps) => {
     }
     
     return (
-            <View style= {styles.container.view}>
-            {/* {data.header.icon &&
-                <Image source={iconMap[data.header.icon]} style={styles.icon} /> } */}
+            <View style= {styles.container}>
             {title &&
                 <View style={styles.rows.fixed}>
                     <Text style={styles[size].title}>{title.toUpperCase()}</Text> 
                 </View>
             }
-
 
             <View style={[styles.rows.flex]} />
 
@@ -184,10 +152,9 @@ const CapabilityTileView = React.memo ( (props: ComponentProps) => {
     )
 })
 
-
 const styles = {
     container: StyleSheet.create({
-        view: {
+        main: {
             display: 'flex',
             flexDirection: 'column',
             height: '100%',
@@ -196,11 +163,10 @@ const styles = {
             alignItems: 'center',
             justifyContent: 'center',
         }
-    }),
+    }).main,
     rows: StyleSheet.create({
         container: {
             flex:1,
-            
         },
         fixed: {
             flexDirection:'row',
@@ -223,24 +189,19 @@ const styles = {
             flex:1,
             alignItems: 'center',
             justifyContent: 'center',
-            
         },
         device: {
             display:'flex',
             flexDirection:'column',
             justifyContent: 'center',
-
         }
-
     }),
     small: StyleSheet.create({
-        
         tile: {
             aspectRatio:1.25,
             borderRadius: 4,
             alignItems: 'center',
             justifyContent: 'space-between',
-            //padding: 8,
         },
         icon: { width: 48, height: 48, color:'#ffffff',tintColor: '#fff' },
         device: { color: '#fff', fontSize: 12 },
@@ -260,7 +221,6 @@ const styles = {
             justifyContent: 'center',
             padding: 4,
         },
-
         empty: {
             width: '100%',
             height: '100%',
@@ -280,7 +240,6 @@ const styles = {
         state: { 
             color: '#fff', 
             fontSize: 14,
-            
         },
     }),
     large: StyleSheet.create({
@@ -289,7 +248,6 @@ const styles = {
             borderRadius: 4,
             alignItems: 'center',
             justifyContent: 'space-between',
-            //padding: 8,
         },
         active: { backgroundColor: colors.tileActive },
         idle: { backgroundColor: colors.tileIdle },
@@ -333,13 +291,9 @@ const styles = {
             padding: 4,
         },
         footer: {
-            
             backgroundColor: '#000',
             justifyContent: 'center',
             padding: 4,
-            
-            
-            
         },
         state: { 
             textAlign: 'center',
@@ -348,7 +302,4 @@ const styles = {
             fontSize: 18,
         },
     })
-
-
-
 }

--- a/src/components/FreeMap/FreeMapView.native.tsx
+++ b/src/components/FreeMap/FreeMapView.native.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Platform, StyleSheet, Text, View } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { Platform, StyleSheet, Text, View, DimensionValue } from 'react-native';
 import MapLibreRN, { 
     MapView, 
     Camera, 
@@ -10,7 +10,7 @@ import MapLibreRN, {
     setAccessToken 
 } from '@maplibre/maplibre-react-native';
 import { FreeMapViewProps } from './types';
-import { OSM_STYLE_JSON, OSM_STYLE_URL, fromMapCoord } from './utils';
+import { fromMapCoord } from './utils';
 
 // MapLibre needs to be initialized
 if (Platform.OS !== 'web') {
@@ -34,7 +34,7 @@ export const FreeMapView = ({
    // Web Fallback for Storybook-Vite
     if (Platform.OS === 'web') {
         return (
-            <View style={[styles.container, { width, height, backgroundColor: '#e0e0e0' }, style]}>
+            <View style={[styles.container, { width: width as DimensionValue, height: height as DimensionValue, backgroundColor: '#e0e0e0' }, style]}>
                 <Text style={styles.webPlaceholder}>
                     MapLibre Native Component (Not available on Web)
                 </Text>
@@ -65,8 +65,8 @@ export const FreeMapView = ({
             MapLibreRN.setConnected(true); 
 
             Logger.setLogCallback(log => {
-            if (log.message.includes('Canceled')) return true;
-            return false;
+                if (log.message.includes('Canceled')) return true;
+                return false;
             });            
             setMapStyle(style);
         };
@@ -79,11 +79,10 @@ export const FreeMapView = ({
     
 
     return (
-        <View style={[styles.container, { width, height }, style]}>
+        <View style={[styles.container, { width: width as DimensionValue, height: height as DimensionValue }, style]}>
             <MapView
                 style={styles.map}
-                // styleJSON={JSON.stringify(mapStyle)}
-                styleURL="https://tiles.openfreemap.org/styles/bright"
+                styleJSON={JSON.stringify(mapStyle)}
                 scrollEnabled={scrollWheelZoom}
                 logoEnabled={false}
                 attributionEnabled={true}

--- a/src/components/FreeMap/FreeMapView.tsx
+++ b/src/components/FreeMap/FreeMapView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, View, Text } from 'react-native';
+import { StyleSheet, View, Text, DimensionValue } from 'react-native';
 import { FreeMapViewProps } from './types';
 
 export const FreeMapView = ({
@@ -9,7 +9,7 @@ export const FreeMapView = ({
     children,
 }: FreeMapViewProps) => {
     return (
-        <View style={[styles.container, { width, height }, style]}>
+        <View style={[styles.container, { width: width as DimensionValue, height: height as DimensionValue }, style]}>
             <View style={styles.placeholder}>
                 <Text style={styles.text}>
                     MapLibre Native Component


### PR DESCRIPTION
Closes #6

This PR fixes four TypeScript errors blocking CI:
1. **CapabilityTile.tsx**: Wrapped plain style objects (`container`) in `StyleSheet.create()` and updated JSX usage to match the pattern used by other styles in the file. Re-verified `cols.fixed` is correctly part of a `StyleSheet.create` call.
2. **FreeMapView.tsx**: Added `DimensionValue` cast to `width` and `height` props when used in inline styles to satisfy `ViewStyle` requirements.
3. **FreeMapView.native.tsx**: Applied same `DimensionValue` casts as above. Replaced the invalid `styleURL` prop on `<MapView>` with `styleJSON={JSON.stringify(mapStyle)}` as per current library requirements.
4. **src/bindings/secret/index.ts**: Added a type cast to `defSettings` (imported from `@settings`) to allow string indexing.

No logic changes were made.