### PR TITLE
Fix TypeScript errors in UpdateService and appInfo binding

### DIFF
--- a/src/bindings/appInfo/index.ts
+++ b/src/bindings/appInfo/index.ts
@@ -54,3 +54,5 @@ export const getAppInfoBinding = async () => {
     }
 
 }
+
+export const isDevVariant = __DEV__;

--- a/src/services/UpdateManager/UpdateService.ts
+++ b/src/services/UpdateManager/UpdateService.ts
@@ -19,11 +19,10 @@ interface IAppBundleResponse {
 }
 
 
-const getBaseUrl = async  ():Promise<string> =>  {
-
+const getBaseUrl = async (): Promise<string> => {
     let baseUrl = BASE_URL_PROD;
-    const s = settings??{}
-    baseUrl = s.UPDATE_SERVER_URL??BASE_URL_PROD
+    const s = (settings ?? {}) as Record<string, string>
+    baseUrl = s.UPDATE_SERVER_URL ?? BASE_URL_PROD
     return baseUrl
 }
 


### PR DESCRIPTION
Closes #7

This PR fixes two TypeScript errors that were blocking CI:
1. Added missing `isDevVariant` export to `src/bindings/appInfo/index.ts` using the React Native `__DEV__` global.
2. Cast `settings` as `Record<string, string>` in `src/services/UpdateManager/UpdateService.ts` to allow indexing with `UPDATE_SERVER_URL`.

No logic changes were made.