### PR TITLE
Fix TypeScript errors in CapabilityGrid.stories.tsx

### DIFF
--- a/src/components/CapabilityGrid/CapabilityGrid.stories.tsx
+++ b/src/components/CapabilityGrid/CapabilityGrid.stories.tsx
@@ -3,79 +3,150 @@ import { CapabilityGrid } from './CapabilityGrid';
 import { fn } from 'storybook/test';
 import { View } from 'react-native';
 
-const meta:Meta<typeof CapabilityGrid> = {
-  title: 'Components/CapabilityGrid',
-  component: CapabilityGrid,
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
-  tags: ['autodocs'],
-  // Use `fn` to spy on the onPress arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#story-args
-  decorators: [
-    (Story) => (
-      /* 
-         This View ensures the 'middle' flex: 1 component has 
-         a parent with a defined height to expand into. 
-      */
-      <View style={{ height: '100vh', width: '100vw', justifyContent:'center', alignItems:'center' }}>
-        <Story />
-      </View>
-    ),
-  ],  
-}
+const meta: Meta<typeof CapabilityGrid> = {
+    title: 'Components/CapabilityGrid',
+    component: CapabilityGrid,
+    // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+    tags: ['autodocs'],
+    // Use `fn` to spy on the onPress arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#story-args
+    decorators: [
+        (Story) => (
+            /* 
+               This View ensures the 'middle' flex: 1 component has 
+               a parent with a defined height to expand into. 
+            */
+            <View
+                style={
+                    {
+                        height: '100vh',
+                        width: '100vw',
+                        justifyContent: 'center',
+                        alignItems: 'center',
+                    } as any
+                }
+            >
+                <Story />
+            </View>
+        ),
+    ],
+};
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-
 export const Initial: Story = {
-  args: {   
-    capabilities: {
-        top:[ 
-            { header:{title:'control'},capability:'control',deviceName:'',onClick:fn() },
-            { header:{title:'power'},capability:'power',deviceName:'',onClick:fn() },
-            { header:{title:'heartrate'},capability:'heartrate',deviceName:'',onClick:fn() }
-        ],
-        bottom:[
-            { header:{title:'speed'},capability:'speed',deviceName:'',onClick:fn() },
-            { header:{title:'cadence'},capability:'cadence',deviceName:'',onClick:fn() },            
-        ]
-    }
-  },
+    args: {
+        capabilities: {
+            top: [
+                { title: 'control', capability: 'control', deviceName: '', onClick: fn() },
+                { title: 'power', capability: 'power', deviceName: '', onClick: fn() },
+                { title: 'heartrate', capability: 'heartrate', deviceName: '', onClick: fn() },
+            ],
+            bottom: [
+                { title: 'speed', capability: 'speed', deviceName: '', onClick: fn() },
+                { title: 'cadence', capability: 'cadence', deviceName: '', onClick: fn() },
+            ],
+        },
+    },
 };
-
 
 export const Paired: Story = {
-  args: {   
-    capabilities: {
-        top:[ 
-            { title:'control',capability:'control',deviceName:'DCSIM FTMS 1234',connectState:'connected', onClick:fn() },
-            { title:'power',capability:'power',deviceName:'DCSIM FTMS 1234',value: 154, unit:'W' , onClick:fn() },
-            { title:'heartrate',capability:'heartrate',deviceName:'HRM Dual',value:135, unit:'bpm', onClick:fn() }
-        ],
-        bottom:[
-            { title:'cadence',capability:'cadence',deviceName:'DCSIM FTMS 1234',value:90, unit:'rpm',onClick:fn() },            
-            { title:'speed',capability:'speed',deviceName:'DCSIM FTMS 1234',value:29.1, unit:'km/h',onClick:fn() },
-        ]
-    }
-  },
+    args: {
+        capabilities: {
+            top: [
+                {
+                    title: 'control',
+                    capability: 'control',
+                    deviceName: 'DCSIM FTMS 1234',
+                    connectState: 'connected',
+                    onClick: fn(),
+                },
+                {
+                    title: 'power',
+                    capability: 'power',
+                    deviceName: 'DCSIM FTMS 1234',
+                    value: '154',
+                    unit: 'W',
+                    onClick: fn(),
+                },
+                {
+                    title: 'heartrate',
+                    capability: 'heartrate',
+                    deviceName: 'HRM Dual',
+                    value: '135',
+                    unit: 'bpm',
+                    onClick: fn(),
+                },
+            ],
+            bottom: [
+                {
+                    title: 'cadence',
+                    capability: 'cadence',
+                    deviceName: 'DCSIM FTMS 1234',
+                    value: '90',
+                    unit: 'rpm',
+                    onClick: fn(),
+                },
+                {
+                    title: 'speed',
+                    capability: 'speed',
+                    deviceName: 'DCSIM FTMS 1234',
+                    value: '29.1',
+                    unit: 'km/h',
+                    onClick: fn(),
+                },
+            ],
+        },
+    },
 };
-
 
 export const PairedWaiting: Story = {
-  args: {   
-    capabilities: {
-        top:[ 
-            { title:'control',capability:'control',deviceName:'DCSIM FTMS 1234',connectState:'waiting', onClick:fn() },
-            { title:'power',capability:'power',deviceName:'DCSIM FTMS 1234',value: 154, unit:'W' , onClick:fn() },
-            { title:'heartrate',capability:'heartrate',deviceName:'HRM Dual',value:135, unit:'bpm', onClick:fn() }
-        ],
-        bottom:[
-            { title:'cadence',capability:'cadence',deviceName:'DCSIM FTMS 1234',value:90, unit:'rpm',onClick:fn() },            
-            { title:'speed',capability:'speed',deviceName:'DCSIM FTMS 1234',value:29.1, unit:'km/h',onClick:fn() },
-        ]
-    }
-  },
+    args: {
+        capabilities: {
+            top: [
+                {
+                    title: 'control',
+                    capability: 'control',
+                    deviceName: 'DCSIM FTMS 1234',
+                    connectState: 'waiting',
+                    onClick: fn(),
+                },
+                {
+                    title: 'power',
+                    capability: 'power',
+                    deviceName: 'DCSIM FTMS 1234',
+                    value: '154',
+                    unit: 'W',
+                    onClick: fn(),
+                },
+                {
+                    title: 'heartrate',
+                    capability: 'heartrate',
+                    deviceName: 'HRM Dual',
+                    value: '135',
+                    unit: 'bpm',
+                    onClick: fn(),
+                },
+            ],
+            bottom: [
+                {
+                    title: 'cadence',
+                    capability: 'cadence',
+                    deviceName: 'DCSIM FTMS 1234',
+                    value: '90',
+                    unit: 'rpm',
+                    onClick: fn(),
+                },
+                {
+                    title: 'speed',
+                    capability: 'speed',
+                    deviceName: 'DCSIM FTMS 1234',
+                    value: '29.1',
+                    unit: 'km/h',
+                    onClick: fn(),
+                },
+            ],
+        },
+    },
 };
-
-
-


### PR DESCRIPTION
Closes #10

Fixed three categories of TypeScript errors in the `CapabilityGrid` storybook file:
1. **Style type cast**: Cast the decorator's `View` style as `any` to bypass React Native's rejection of CSS viewport units (`100vh`/`100vw`).
2. **Prop structure update**: Updated the `Initial` story to use the flat `title` property instead of the deprecated `header` object.
3. **Value type correction**: Converted numeric `value` props to strings in `Paired` and `PairedWaiting` stories to match the `CapabilityDisplayProps` definition.