### PR TITLE
fix(18): Fix TypeScript errors in CapabilityTile, NavigationBar and InterfaceState stories

### DIFF
--- a/src/components/CapabilityTile/CapabilityTile.stories.tsx
+++ b/src/components/CapabilityTile/CapabilityTile.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { CapabilityTile } from './CapabilityTile';
 import { fn } from 'storybook/test';
-import { View } from 'react-native';
+import { View, DimensionValue } from 'react-native';
 
 const meta:Meta<typeof CapabilityTile> = {
   title: 'Components/CapabilityTile',
@@ -15,7 +15,7 @@ const meta:Meta<typeof CapabilityTile> = {
          This View ensures the 'middle' flex: 1 component has 
          a parent with a defined height to expand into. 
       */
-      <View style={{ height: '100vh', width: '100vw', justifyContent:'center', alignItems:'center' }}>
+      <View style={{ height: '100vh' as DimensionValue, width: '100vw' as DimensionValue, justifyContent:'center', alignItems:'center' }}>
         <Story />
       </View>
     ),

--- a/src/components/InterfaceState/InterfaceState.stories.tsx
+++ b/src/components/InterfaceState/InterfaceState.stories.tsx
@@ -1,40 +1,63 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
 import { InterfaceState } from './InterfaceState';
+import { InterfaceDisplayProps } from './InterfaceState';
 
-export default {
-  title: 'Components/InterfaceState',
-  component: InterfaceState,
-  decorators: [
-    (Story: any) => (
-      <View style={styles.decorator}>
-        <Story />
-      </View>
-    ),
-  ],
+const meta: Meta<InterfaceDisplayProps> = {
+    title: 'Components/InterfaceState',
+    component: InterfaceState,
+    decorators: [
+        (Story) => (
+            <View style={styles.decorator}>
+                <Story />
+            </View>
+        ),
+    ],
+    args: {
+        onClick: fn(),
+    },
 };
 
-export const BluetoothScanning = () => (
-  <InterfaceState name="ble" state="scanning" />
-);
+export default meta;
 
-export const WifiIdle = () => (
-  <InterfaceState name="wifi" state="idle" />
-);
+type Story = StoryObj<InterfaceDisplayProps>;
 
-export const BluetoothError = () => (
-  <InterfaceState name="ble" state="error" error="Connection Failed" />
-);
+export const BluetoothScanning: Story = {
+    args: {
+        name: 'ble',
+        state: 'scanning',
+    },
+};
 
-export const WifiDisabled = () => (
-  <InterfaceState name="wifi" state="disabled" />
-);
+export const WifiIdle: Story = {
+    args: {
+        name: 'wifi',
+        state: 'idle',
+    },
+};
+
+export const BluetoothError: Story = {
+    args: {
+        name: 'ble',
+        state: 'error',
+        error: 'Connection Failed',
+    },
+};
+
+export const WifiDisabled: Story = {
+    args: {
+        name: 'wifi',
+        state: 'disabled',
+    },
+};
 
 const styles = StyleSheet.create({
-  decorator: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#1C1C1E', // Dark background to see white icons
-  },
+    decorator: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: '#1C1C1E',
+    },
 });

--- a/src/components/InterfaceState/InterfaceState.tsx
+++ b/src/components/InterfaceState/InterfaceState.tsx
@@ -4,7 +4,7 @@ import BleIcon from  '../../assets/icons/ble.svg';
 import WifiIcon from '../../assets/icons/wifi.svg';
 
 import {InterfaceDisplayState,InterfaceDisplayProps} from 'incyclist-services'
-export { InterfaceDisplayProps } from 'incyclist-services'; // Re-export for storybook
+export type { InterfaceDisplayProps } from 'incyclist-services'; // Re-export for storybook
 import { Wave } from './Wave';
 
 const STATE_COLORS: Record<InterfaceDisplayState, string> = {

--- a/src/components/InterfaceState/InterfaceState.tsx
+++ b/src/components/InterfaceState/InterfaceState.tsx
@@ -4,6 +4,7 @@ import BleIcon from  '../../assets/icons/ble.svg';
 import WifiIcon from '../../assets/icons/wifi.svg';
 
 import {InterfaceDisplayState,InterfaceDisplayProps} from 'incyclist-services'
+export { InterfaceDisplayProps } from 'incyclist-services'; // Re-export for storybook
 import { Wave } from './Wave';
 
 const STATE_COLORS: Record<InterfaceDisplayState, string> = {

--- a/src/components/NavigationBar/NavigationBar.stories.tsx
+++ b/src/components/NavigationBar/NavigationBar.stories.tsx
@@ -1,14 +1,14 @@
 import { NavigationBar } from './NavigationBar';
 import { fn } from 'storybook/test';
 import { Meta, StoryObj } from '@storybook/react-native-web-vite';
-import { View } from 'react-native';
+import { View, DimensionValue } from 'react-native';
 
 const meta = {
     title: 'Components/NavigationBar',
     component: NavigationBar,
     decorators: [
         (Story) => (
-            <View style={{ height: '100vh', width: '100vw', justifyContent:'center', alignItems:'center' }}>
+            <View style={{ height: '100vh' as DimensionValue, width: '100vw' as DimensionValue, justifyContent:'center', alignItems:'center' }}>
                 <Story />
             </View>
         )
@@ -36,4 +36,3 @@ export const Top: Story = {
         selected: 'exit',
     }    
 };
-


### PR DESCRIPTION
Closes #18

Fixes TypeScript errors in Storybook files for CapabilityTile, NavigationBar, and InterfaceState components.

- Casts `'100vh'` / `'100vw'` to `DimensionValue` in `CapabilityTile.stories.tsx` and `NavigationBar.stories.tsx` to resolve React Native styling type mismatches.
- Rewrites `InterfaceState.stories.tsx` from CSF2 to CSF3 format, incorporating `Meta`, `StoryObj`, and `fn()` for event handlers, specifically for the required `onClick` prop.
- Re-exports `InterfaceDisplayProps` from `src/components/InterfaceState/InterfaceState.tsx` to enable proper type importing in its corresponding story file, as requested by the issue.

No manual steps are required outside this PR.