### PR TITLE
feat: Implement EditText and EditNumber atoms

### DIFF
--- a/src/components/atoms/EditNumber/EditNumber.stories.tsx
+++ b/src/components/atoms/EditNumber/EditNumber.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { EditNumber } from './EditNumber';
+
+const meta: Meta<typeof EditNumber> = {
+    title: 'Atoms/EditNumber',
+    component: EditNumber,
+    args: {
+        onValueChange: fn(),
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof EditNumber>;
+
+export const Empty: Story = {
+    args: {
+        label: 'FTP',
+    },
+};
+
+export const PreFilled: Story = {
+    args: {
+        label: 'FTP',
+        value: 224,
+        unit: 'W',
+        digits: 0,
+    },
+};
+
+export const WithUnit: Story = {
+    args: {
+        label: 'Weight',
+        value: 75.0,
+        unit: 'kg',
+        digits: 1,
+    },
+};
+
+export const WithMinMax: Story = {
+    args: {
+        label: 'FTP',
+        value: 224,
+        min: 50,
+        max: 500,
+        unit: 'W',
+        digits: 0,
+    },
+};
+
+export const Disabled: Story = {
+    args: {
+        label: 'FTP',
+        value: 224,
+        unit: 'W',
+        disabled: true,
+    },
+};

--- a/src/components/atoms/EditNumber/EditNumber.stories.tsx
+++ b/src/components/atoms/EditNumber/EditNumber.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
-import { fn } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
 import { EditNumber } from './EditNumber';
 
 const meta: Meta<typeof EditNumber> = {

--- a/src/components/atoms/EditNumber/EditNumber.stories.tsx
+++ b/src/components/atoms/EditNumber/EditNumber.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { fn } from '@storybook/test';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from '@storybook/react-native-web-vite';
 import { EditNumber } from './EditNumber';
 
 const meta: Meta<typeof EditNumber> = {

--- a/src/components/atoms/EditNumber/EditNumber.test.tsx
+++ b/src/components/atoms/EditNumber/EditNumber.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { EditNumber } from './EditNumber';
+import { EditNumberProps } from './types';
+
+const MOCK_EDIT_NUMBER_PROPS: EditNumberProps = {
+    label: 'FTP',
+    value: 224,
+    unit: 'W',
+    onValueChange: jest.fn(),
+};
+
+describe('EditNumber', () => {
+    it('renders with a value', () => {
+        const { getByDisplayValue, getByText } = render(<EditNumber {...MOCK_EDIT_NUMBER_PROPS} />);
+        expect(getByText('FTP')).toBeTruthy();
+        expect(getByDisplayValue('224')).toBeTruthy();
+    });
+
+    it('renders without a value', () => {
+        const { getByText } = render(<EditNumber label="Empty" onValueChange={jest.fn()} />);
+        expect(getByText('Empty')).toBeTruthy();
+    });
+
+    it('renders with unit suffix', () => {
+        const { getByText } = render(<EditNumber {...MOCK_EDIT_NUMBER_PROPS} />);
+        expect(getByText('W')).toBeTruthy();
+    });
+
+    it('renders with min/max props and shows error', () => {
+        const { getByDisplayValue, getByText } = render(
+            <EditNumber {...MOCK_EDIT_NUMBER_PROPS} min={100} max={300} />
+        );
+        const input = getByDisplayValue('224');
+
+        fireEvent.changeText(input, '50');
+        fireEvent(input, 'blur');
+        expect(getByText('Minimum value is 100')).toBeTruthy();
+
+        fireEvent.changeText(input, '400');
+        fireEvent(input, 'blur');
+        expect(getByText('Maximum value is 300')).toBeTruthy();
+    });
+
+    it('calls onValueChange with number on commit', () => {
+        const onValueChange = jest.fn();
+        const { getByDisplayValue } = render(
+            <EditNumber {...MOCK_EDIT_NUMBER_PROPS} onValueChange={onValueChange} />
+        );
+        const input = getByDisplayValue('224');
+
+        fireEvent.changeText(input, '250');
+        fireEvent(input, 'blur');
+        expect(onValueChange).toHaveBeenCalledWith(250);
+    });
+
+    it('silently rejects non-numeric input', () => {
+        const onValueChange = jest.fn();
+        const { getByDisplayValue } = render(
+            <EditNumber {...MOCK_EDIT_NUMBER_PROPS} onValueChange={onValueChange} />
+        );
+        const input = getByDisplayValue('224');
+
+        fireEvent.changeText(input, 'abc');
+        fireEvent(input, 'blur');
+        expect(onValueChange).not.toHaveBeenCalled();
+        expect(getByDisplayValue('abc')).toBeTruthy();
+    });
+});

--- a/src/components/atoms/EditNumber/EditNumber.tsx
+++ b/src/components/atoms/EditNumber/EditNumber.tsx
@@ -1,0 +1,141 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { colors } from '../../../theme/colors';
+import { textSizes } from '../../../theme/textSizes';
+import { EditNumberProps } from './types';
+
+export const EditNumber = ({
+    label,
+    value,
+    labelWidth = 100,
+    min,
+    max,
+    digits = 0,
+    allowEmpty = false,
+    unit,
+    disabled = false,
+    onValueChange,
+}: EditNumberProps) => {
+    const formatValue = useCallback(
+        (val?: number) => {
+            if (val === undefined || val === null) return '';
+            return val.toFixed(digits);
+        },
+        [digits]
+    );
+
+    const [internalValue, setInternalValue] = useState(formatValue(value));
+    const [error, setError] = useState<string | null>(null);
+    const refLastCommitted = useRef(value);
+
+    useEffect(() => {
+        setInternalValue(formatValue(value));
+        refLastCommitted.current = value;
+    }, [value, formatValue]);
+
+    const handleCommit = useCallback(() => {
+        if (internalValue === formatValue(refLastCommitted.current)) {
+            return;
+        }
+
+        setError(null);
+
+        if (internalValue === '') {
+            if (allowEmpty) {
+                refLastCommitted.current = undefined;
+                onValueChange?.(undefined);
+            } else {
+                setInternalValue(formatValue(refLastCommitted.current));
+            }
+            return;
+        }
+
+        const numericValue = parseFloat(internalValue);
+
+        if (isNaN(numericValue)) {
+            // Reject non-numeric input silently (leave text for correction)
+            return;
+        }
+
+        if (min !== undefined && numericValue < min) {
+            setError(`Minimum value is ${min}`);
+            return;
+        }
+
+        if (max !== undefined && numericValue > max) {
+            setError(`Maximum value is ${max}`);
+            return;
+        }
+
+        refLastCommitted.current = numericValue;
+        onValueChange?.(numericValue);
+        // Sync display to precision
+        setInternalValue(formatValue(numericValue));
+    }, [internalValue, allowEmpty, min, max, onValueChange, formatValue]);
+
+    return (
+        <View style={styles.container}>
+            <View style={styles.row}>
+                <Text style={[styles.label, { width: labelWidth }]}>{label}</Text>
+                <TextInput
+                    style={[
+                        styles.input,
+                        disabled && styles.disabledInput,
+                        error !== null && styles.errorBorder,
+                    ]}
+                    value={internalValue}
+                    onChangeText={setInternalValue}
+                    onBlur={handleCommit}
+                    onEndEditing={handleCommit}
+                    keyboardType="numeric"
+                    editable={!disabled}
+                />
+                {unit && <Text style={styles.unit}>{unit}</Text>}
+            </View>
+            {error && <Text style={styles.errorText}>{error}</Text>}
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        marginVertical: 8,
+        width: '100%',
+    },
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
+    },
+    label: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        marginRight: 8,
+    },
+    input: {
+        flex: 1,
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        borderBottomWidth: 1,
+        borderBottomColor: colors.listSeparator,
+        paddingVertical: 4,
+        paddingHorizontal: 4,
+    },
+    disabledInput: {
+        color: colors.disabled,
+        borderBottomColor: 'transparent',
+    },
+    unit: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        marginLeft: 8,
+    },
+    errorBorder: {
+        borderBottomColor: colors.error,
+    },
+    errorText: {
+        color: colors.error,
+        fontSize: 12,
+        marginTop: 4,
+        marginLeft: 108,
+    },
+});

--- a/src/components/atoms/EditNumber/EditNumber.tsx
+++ b/src/components/atoms/EditNumber/EditNumber.tsx
@@ -4,6 +4,8 @@ import { colors } from '../../../theme/colors';
 import { textSizes } from '../../../theme/textSizes';
 import { EditNumberProps } from './types';
 
+const LABEL_MARGIN = 8;
+
 export const EditNumber = ({
     label,
     value,
@@ -92,7 +94,11 @@ export const EditNumber = ({
                 />
                 {unit && <Text style={styles.unit}>{unit}</Text>}
             </View>
-            {error && <Text style={styles.errorText}>{error}</Text>}
+            {error && (
+                <Text style={[styles.errorText, { marginLeft: labelWidth + LABEL_MARGIN }]}>
+                    {error}
+                </Text>
+            )}
         </View>
     );
 };
@@ -109,7 +115,7 @@ const styles = StyleSheet.create({
     label: {
         color: colors.text,
         fontSize: textSizes.normalText,
-        marginRight: 8,
+        marginRight: LABEL_MARGIN,
     },
     input: {
         flex: 1,
@@ -134,8 +140,7 @@ const styles = StyleSheet.create({
     },
     errorText: {
         color: colors.error,
-        fontSize: 12,
+        fontSize: textSizes.smallText,
         marginTop: 4,
-        marginLeft: 108,
     },
 });

--- a/src/components/atoms/EditNumber/EditNumber.tsx
+++ b/src/components/atoms/EditNumber/EditNumber.tsx
@@ -75,10 +75,13 @@ export const EditNumber = ({
         setInternalValue(formatValue(numericValue));
     }, [internalValue, allowEmpty, min, max, onValueChange, formatValue]);
 
+    const labelStyle = { width: labelWidth };
+    const errorStyle = { marginLeft: labelWidth + LABEL_MARGIN };
+
     return (
         <View style={styles.container}>
             <View style={styles.row}>
-                <Text style={[styles.label, { width: labelWidth }]}>{label}</Text>
+                <Text style={[styles.label, labelStyle]}>{label}</Text>
                 <TextInput
                     style={[
                         styles.input,
@@ -95,7 +98,7 @@ export const EditNumber = ({
                 {unit && <Text style={styles.unit}>{unit}</Text>}
             </View>
             {error && (
-                <Text style={[styles.errorText, { marginLeft: labelWidth + LABEL_MARGIN }]}>
+                <Text style={[styles.errorText, errorStyle]}>
                     {error}
                 </Text>
             )}

--- a/src/components/atoms/EditNumber/index.ts
+++ b/src/components/atoms/EditNumber/index.ts
@@ -1,0 +1,2 @@
+export * from './EditNumber';
+export * from './types';

--- a/src/components/atoms/EditNumber/types.ts
+++ b/src/components/atoms/EditNumber/types.ts
@@ -1,0 +1,12 @@
+export type EditNumberProps = {
+    label: string;
+    value?: number;
+    labelWidth?: number;
+    min?: number;
+    max?: number;
+    digits?: number;
+    allowEmpty?: boolean;
+    unit?: string;
+    disabled?: boolean;
+    onValueChange?: (value: number | undefined) => void;
+};

--- a/src/components/atoms/EditText/EditText.stories.tsx
+++ b/src/components/atoms/EditText/EditText.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { EditText } from './EditText';
+
+const meta: Meta<typeof EditText> = {
+    title: 'Atoms/EditText',
+    component: EditText,
+    args: {
+        onValueChange: fn(),
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof EditText>;
+
+export const Empty: Story = {
+    args: {
+        label: 'Name',
+        placeholder: 'Enter your name...',
+    },
+};
+
+export const PreFilled: Story = {
+    args: {
+        label: 'Name',
+        value: 'Guido Doumen',
+    },
+};
+
+export const Disabled: Story = {
+    args: {
+        label: 'Name',
+        value: 'Guido Doumen',
+        disabled: true,
+    },
+};
+
+export const WithValidation: Story = {
+    args: {
+        label: 'Username',
+        validate: (v) => (v.trim() === '' ? 'Name is required' : null),
+    },
+};

--- a/src/components/atoms/EditText/EditText.stories.tsx
+++ b/src/components/atoms/EditText/EditText.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
-import { fn } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
 import { EditText } from './EditText';
 
 const meta: Meta<typeof EditText> = {

--- a/src/components/atoms/EditText/EditText.stories.tsx
+++ b/src/components/atoms/EditText/EditText.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { fn } from '@storybook/test';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from '@storybook/react-native-web-vite';
 import { EditText } from './EditText';
 
 const meta: Meta<typeof EditText> = {

--- a/src/components/atoms/EditText/EditText.test.tsx
+++ b/src/components/atoms/EditText/EditText.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { EditText } from './EditText';
+import { EditTextProps } from './types';
+
+const MOCK_EDIT_TEXT_PROPS: EditTextProps = {
+    label: 'Name',
+    value: 'Guido Doumen',
+    onValueChange: jest.fn(),
+};
+
+describe('EditText', () => {
+    it('renders with a value', () => {
+        const { getByDisplayValue, getByText } = render(<EditText {...MOCK_EDIT_TEXT_PROPS} />);
+        expect(getByText('Name')).toBeTruthy();
+        expect(getByDisplayValue('Guido Doumen')).toBeTruthy();
+    });
+
+    it('renders without a value (empty)', () => {
+        const { getByPlaceholderText } = render(
+            <EditText label="Empty" placeholder="Type here" onValueChange={jest.fn()} />
+        );
+        expect(getByPlaceholderText('Type here')).toBeTruthy();
+    });
+
+    it('renders disabled', () => {
+        const { getByDisplayValue } = render(<EditText {...MOCK_EDIT_TEXT_PROPS} disabled />);
+        const input = getByDisplayValue('Guido Doumen');
+        expect(input.props.editable).toBe(false);
+    });
+
+    it('calls onValueChange only on blur/commit', () => {
+        const onValueChange = jest.fn();
+        const { getByDisplayValue } = render(
+            <EditText {...MOCK_EDIT_TEXT_PROPS} onValueChange={onValueChange} />
+        );
+        const input = getByDisplayValue('Guido Doumen');
+
+        fireEvent.changeText(input, 'New Name');
+        expect(onValueChange).not.toHaveBeenCalled();
+
+        fireEvent(input, 'blur');
+        expect(onValueChange).toHaveBeenCalledWith('New Name');
+        expect(onValueChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows error text on validation failure', () => {
+        const validate = (v: string) => (v.length < 3 ? 'Too short' : null);
+        const { getByDisplayValue, getByText } = render(
+            <EditText {...MOCK_EDIT_TEXT_PROPS} validate={validate} />
+        );
+        const input = getByDisplayValue('Guido Doumen');
+
+        fireEvent.changeText(input, 'Hi');
+        fireEvent(input, 'blur');
+
+        expect(getByText('Too short')).toBeTruthy();
+    });
+});

--- a/src/components/atoms/EditText/EditText.tsx
+++ b/src/components/atoms/EditText/EditText.tsx
@@ -4,6 +4,8 @@ import { colors } from '../../../theme/colors';
 import { textSizes } from '../../../theme/textSizes';
 import { EditTextProps } from './types';
 
+const LABEL_MARGIN = 8;
+
 export const EditText = ({
     label,
     value = '',
@@ -59,7 +61,11 @@ export const EditText = ({
                     editable={!disabled}
                 />
             </View>
-            {error && <Text style={styles.errorText}>{error}</Text>}
+            {error && (
+                <Text style={[styles.errorText, { marginLeft: labelWidth + LABEL_MARGIN }]}>
+                    {error}
+                </Text>
+            )}
         </View>
     );
 };
@@ -76,7 +82,7 @@ const styles = StyleSheet.create({
     label: {
         color: colors.text,
         fontSize: textSizes.normalText,
-        marginRight: 8,
+        marginRight: LABEL_MARGIN,
     },
     input: {
         flex: 1,
@@ -96,8 +102,7 @@ const styles = StyleSheet.create({
     },
     errorText: {
         color: colors.error,
-        fontSize: 12,
+        fontSize: textSizes.smallText,
         marginTop: 4,
-        marginLeft: 108, // Default labelWidth (100) + marginRight (8)
     },
 });

--- a/src/components/atoms/EditText/EditText.tsx
+++ b/src/components/atoms/EditText/EditText.tsx
@@ -1,0 +1,103 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { colors } from '../../../theme/colors';
+import { textSizes } from '../../../theme/textSizes';
+import { EditTextProps } from './types';
+
+export const EditText = ({
+    label,
+    value = '',
+    labelWidth = 100,
+    placeholder,
+    disabled = false,
+    validate,
+    onValueChange,
+}: EditTextProps) => {
+    const [internalValue, setInternalValue] = useState(value);
+    const [error, setError] = useState<string | null>(null);
+    const refLastValue = useRef(value);
+
+    useEffect(() => {
+        setInternalValue(value);
+        refLastValue.current = value;
+    }, [value]);
+
+    const handleCommit = useCallback(() => {
+        if (internalValue === refLastValue.current) {
+            return;
+        }
+
+        setError(null);
+        if (validate) {
+            const validationError = validate(internalValue);
+            if (validationError) {
+                setError(validationError);
+                return;
+            }
+        }
+
+        refLastValue.current = internalValue;
+        onValueChange?.(internalValue);
+    }, [internalValue, validate, onValueChange]);
+
+    return (
+        <View style={styles.container}>
+            <View style={styles.row}>
+                <Text style={[styles.label, { width: labelWidth }]}>{label}</Text>
+                <TextInput
+                    style={[
+                        styles.input,
+                        disabled && styles.disabledInput,
+                        error !== null && styles.errorBorder,
+                    ]}
+                    value={internalValue}
+                    onChangeText={setInternalValue}
+                    onBlur={handleCommit}
+                    onEndEditing={handleCommit}
+                    placeholder={placeholder}
+                    placeholderTextColor={colors.disabled}
+                    editable={!disabled}
+                />
+            </View>
+            {error && <Text style={styles.errorText}>{error}</Text>}
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        marginVertical: 8,
+        width: '100%',
+    },
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
+    },
+    label: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        marginRight: 8,
+    },
+    input: {
+        flex: 1,
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        borderBottomWidth: 1,
+        borderBottomColor: colors.listSeparator,
+        paddingVertical: 4,
+        paddingHorizontal: 4,
+    },
+    disabledInput: {
+        color: colors.disabled,
+        borderBottomColor: 'transparent',
+    },
+    errorBorder: {
+        borderBottomColor: colors.error,
+    },
+    errorText: {
+        color: colors.error,
+        fontSize: 12,
+        marginTop: 4,
+        marginLeft: 108, // Default labelWidth (100) + marginRight (8)
+    },
+});

--- a/src/components/atoms/EditText/EditText.tsx
+++ b/src/components/atoms/EditText/EditText.tsx
@@ -42,10 +42,13 @@ export const EditText = ({
         onValueChange?.(internalValue);
     }, [internalValue, validate, onValueChange]);
 
+    const labelStyle = { width: labelWidth };
+    const errorStyle = { marginLeft: labelWidth + LABEL_MARGIN };
+
     return (
         <View style={styles.container}>
             <View style={styles.row}>
-                <Text style={[styles.label, { width: labelWidth }]}>{label}</Text>
+                <Text style={[styles.label, labelStyle]}>{label}</Text>
                 <TextInput
                     style={[
                         styles.input,
@@ -62,7 +65,7 @@ export const EditText = ({
                 />
             </View>
             {error && (
-                <Text style={[styles.errorText, { marginLeft: labelWidth + LABEL_MARGIN }]}>
+                <Text style={[styles.errorText, errorStyle]}>
                     {error}
                 </Text>
             )}

--- a/src/components/atoms/EditText/index.ts
+++ b/src/components/atoms/EditText/index.ts
@@ -1,0 +1,2 @@
+export * from './EditText';
+export * from './types';

--- a/src/components/atoms/EditText/types.ts
+++ b/src/components/atoms/EditText/types.ts
@@ -1,0 +1,9 @@
+export type EditTextProps = {
+    label: string;
+    value?: string;
+    labelWidth?: number;
+    placeholder?: string;
+    disabled?: boolean;
+    validate?: (value: string) => string | null;
+    onValueChange?: (value: string) => void;
+};

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -1,0 +1,2 @@
+export * from './EditText';
+export * from './EditNumber';

--- a/src/theme/textSizes.ts
+++ b/src/theme/textSizes.ts
@@ -1,10 +1,8 @@
-
-
 export const textSizes = {
     pageTitle: 28,
     dialogTitle: 24,
     listEntry: 20,
     normalText: 16,
-    noDataText: 24
-
-}
+    noDataText: 24,
+    smallText: 12,
+};


### PR DESCRIPTION
Closes #25

Implemented two reusable atom components for forms:
- `EditText`: A labelled text input with validation support.
- `EditNumber`: A labelled numeric input with min/max validation, unit suffix, and precision control.

Both components use a row-based layout with a configurable label width to ensure alignment in forms. They include internal state for responsive typing and commit values on blur or end editing, with deduplication logic.