### PR TITLE
feat: Implement UserSettingsDialog component

### DIFF
--- a/__mocks__/react-native-linear-gradient.tsx
+++ b/__mocks__/react-native-linear-gradient.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { View } from 'react-native';
+
+const LinearGradient = ({ children, ...props }: any) => (
+    <View {...props}>{children}</View>
+);
+
+export default LinearGradient;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   preset: 'react-native',
+  moduleNameMapper: {
+    '^react-native-linear-gradient$': '<rootDir>/__mocks__/react-native-linear-gradient.tsx',
+  },
 };

--- a/src/components/UserSettingsDialog/UserSettingsDialog.stories.tsx
+++ b/src/components/UserSettingsDialog/UserSettingsDialog.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
-import { fn } from '@storybook/test';
+import { fn } from 'storybook/test';
 import { UserSettingsDialogView } from './UserSettingsDialogView';
 
 const meta: Meta<typeof UserSettingsDialogView> = {
@@ -38,7 +38,7 @@ export const Imperial: Story = {
         displayProps: {
             username: 'Guido Doumen',
             ftp: 224,
-            weight: { value: 165.0, unit: 'lb' },
+            weight: { value: 165.0, unit: 'lbs' },
             units: 'Imperial',
             unitsOptions: ['Metric', 'Imperial'],
             onChangeWeight: fn(),

--- a/src/components/UserSettingsDialog/UserSettingsDialog.stories.tsx
+++ b/src/components/UserSettingsDialog/UserSettingsDialog.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from '@storybook/test';
+import { UserSettingsDialogView } from './UserSettingsDialogView';
+
+const meta: Meta<typeof UserSettingsDialogView> = {
+    title: 'Components/UserSettingsDialog',
+    component: UserSettingsDialogView,
+    parameters: {
+        layout: 'centered',
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof UserSettingsDialogView>;
+
+const MOCK_ON_CLOSE = fn();
+
+export const Metric: Story = {
+    args: {
+        onClose: MOCK_ON_CLOSE,
+        displayProps: {
+            username: 'Guido Doumen',
+            ftp: 224,
+            weight: { value: 75.0, unit: 'kg' },
+            units: 'Metric',
+            unitsOptions: ['Metric', 'Imperial'],
+            onChangeWeight: fn(),
+            onChangeFtp: fn(),
+            onChangeName: fn(),
+            onChangeUnits: fn(),
+        },
+    },
+};
+
+export const Imperial: Story = {
+    args: {
+        onClose: MOCK_ON_CLOSE,
+        displayProps: {
+            username: 'Guido Doumen',
+            ftp: 224,
+            weight: { value: 165.0, unit: 'lb' },
+            units: 'Imperial',
+            unitsOptions: ['Metric', 'Imperial'],
+            onChangeWeight: fn(),
+            onChangeFtp: fn(),
+            onChangeName: fn(),
+            onChangeUnits: fn(),
+        },
+    },
+};
+
+export const Loading: Story = {
+    args: {
+        onClose: MOCK_ON_CLOSE,
+        displayProps: null,
+    },
+};

--- a/src/components/UserSettingsDialog/UserSettingsDialog.tsx
+++ b/src/components/UserSettingsDialog/UserSettingsDialog.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { UserSettingsDisplayProps, useUserSettingsDisplay } from 'incyclist-services';
-import { useUnmountEffect } from '../../hooks/useUnmountEffect';
+import { useUnmountEffect } from '../../hooks';
 import { UserSettingsDialogView } from './UserSettingsDialogView';
 
 /**

--- a/src/components/UserSettingsDialog/UserSettingsDialog.tsx
+++ b/src/components/UserSettingsDialog/UserSettingsDialog.tsx
@@ -1,0 +1,53 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { UserSettingsDisplayProps, useUserSettingsDisplay } from 'incyclist-services';
+import { useUnmountEffect } from '../../hooks/useUnmountEffect';
+import { UserSettingsDialogView } from './UserSettingsDialogView';
+
+/**
+ * UserSettingsDialog (Smart Component)
+ * 
+ * Subscribes to UserSettingsDisplay service and manages the lifecycle 
+ * of the user settings interaction.
+ */
+export interface UserSettingsDialogProps {
+    onClose: () => void;
+}
+
+export const UserSettingsDialog = ({ onClose }: UserSettingsDialogProps) => {
+    const [displayProps, setDisplayProps] = useState<UserSettingsDisplayProps | null>(null);
+    const service = useUserSettingsDisplay();
+    const refObserver = useRef<any>(null);
+
+    const onUpdate = useCallback((updated: UserSettingsDisplayProps) => {
+        setDisplayProps(updated);
+    }, []);
+
+    useEffect(() => {
+        if (!service || refObserver.current) {
+            return;
+        }
+
+        // Subscribe once using ref gate
+        const observer = service.open();
+        refObserver.current = observer;
+        
+        observer.on('units-changed', onUpdate);
+        
+        // Initial data fetch
+        setDisplayProps(service.getDisplayProps());
+    }, [service, onUpdate]);
+
+    useUnmountEffect(() => {
+        if (service) {
+            service.close();
+        }
+        refObserver.current = null;
+    });
+
+    return (
+        <UserSettingsDialogView
+            displayProps={displayProps}
+            onClose={onClose}
+        />
+    );
+};

--- a/src/components/UserSettingsDialog/UserSettingsDialogView.test.tsx
+++ b/src/components/UserSettingsDialog/UserSettingsDialogView.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { UserSettingsDialogView } from './UserSettingsDialogView';
+import { UserSettingsDisplayProps } from 'incyclist-services';
+
+const MOCK_ON_CLOSE = jest.fn();
+
+const MOCK_DISPLAY_PROPS: UserSettingsDisplayProps = {
+    username: 'Guido Doumen',
+    ftp: 224,
+    weight: { value: 75.0, unit: 'kg' },
+    units: 'Metric',
+    unitsOptions: ['Metric', 'Imperial'],
+    onChangeWeight: jest.fn(),
+    onChangeFtp: jest.fn(),
+    onChangeName: jest.fn(),
+    onChangeUnits: jest.fn(),
+};
+
+describe('UserSettingsDialogView', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders with full display props (normal state)', () => {
+        const { getByText, getByDisplayValue } = render(
+            <UserSettingsDialogView
+                displayProps={MOCK_DISPLAY_PROPS}
+                onClose={MOCK_ON_CLOSE}
+            />
+        );
+
+        expect(getByText('User Settings')).toBeTruthy();
+        expect(getByDisplayValue('Guido Doumen')).toBeTruthy();
+        expect(getByDisplayValue('224')).toBeTruthy();
+        expect(getByDisplayValue('75.0')).toBeTruthy();
+        expect(getByText('Metric')).toBeTruthy();
+        expect(getByText('OK')).toBeTruthy();
+    });
+
+    it('renders with displayProps set to null (loading state) without crashing', () => {
+        const { getByText, queryByDisplayValue } = render(
+            <UserSettingsDialogView
+                displayProps={null}
+                onClose={MOCK_ON_CLOSE}
+            />
+        );
+
+        expect(getByText('User Settings')).toBeTruthy();
+        expect(queryByDisplayValue('Guido Doumen')).toBeNull();
+        expect(getByText('OK')).toBeTruthy();
+    });
+
+    it('calls onClose when OK button is tapped', () => {
+        const { getByText } = render(
+            <UserSettingsDialogView
+                displayProps={MOCK_DISPLAY_PROPS}
+                onClose={MOCK_ON_CLOSE}
+            />
+        );
+
+        fireEvent.press(getByText('OK'));
+        expect(MOCK_ON_CLOSE).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/components/UserSettingsDialog/UserSettingsDialogView.tsx
+++ b/src/components/UserSettingsDialog/UserSettingsDialogView.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { UserSettingsDisplayProps } from 'incyclist-services';
+import { Dialog } from '../Dialog/Dialog';
+import { ButtonBar } from '../ButtonBar/ButtonBar';
+import { EditText, EditNumber, SingleSelect } from '../atoms';
+
+export type UserSettingsDialogViewProps = {
+    displayProps: UserSettingsDisplayProps | null;
+    onClose: () => void;
+};
+
+const LABEL_WIDTH = 80;
+
+/**
+ * UserSettingsDialogView (Pure Component)
+ * 
+ * Renders the user profile editing form within a Dialog.
+ * Uses atom components for input fields.
+ */
+export const UserSettingsDialogView = ({ displayProps, onClose }: UserSettingsDialogViewProps) => {
+    return (
+        <Dialog
+            title="User Settings"
+            variant="info"
+            visible={true}
+            onOutsideClick={onClose}
+        >
+            <View style={styles.container}>
+                {displayProps && (
+                    <View style={styles.fields}>
+                        <EditText
+                            label="Name"
+                            labelWidth={LABEL_WIDTH}
+                            value={displayProps.username}
+                            onValueChange={displayProps.onChangeName}
+                        />
+                        <EditNumber
+                            label="FTP"
+                            labelWidth={LABEL_WIDTH}
+                            value={displayProps.ftp}
+                            unit="W"
+                            digits={0}
+                            onValueChange={displayProps.onChangeFtp}
+                        />
+                        <EditNumber
+                            label="Weight"
+                            labelWidth={LABEL_WIDTH}
+                            value={displayProps.weight?.value}
+                            unit={displayProps.weight?.unit}
+                            digits={1}
+                            onValueChange={displayProps.onChangeWeight}
+                        />
+                        <SingleSelect
+                            label="Units"
+                            labelWidth={LABEL_WIDTH}
+                            options={displayProps.unitsOptions}
+                            selected={displayProps.units}
+                            onValueChange={displayProps.onChangeUnits}
+                        />
+                    </View>
+                )}
+                <View style={styles.footer}>
+                    <ButtonBar
+                        buttons={[
+                            { label: 'OK', primary: true, onClick: onClose },
+                        ]}
+                    />
+                </View>
+            </View>
+        </Dialog>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        width: '100%',
+        paddingTop: 8,
+    },
+    fields: {
+        marginBottom: 16,
+    },
+    footer: {
+        marginTop: 8,
+        alignItems: 'flex-end',
+    },
+});

--- a/src/components/UserSettingsDialog/UserSettingsDialogView.tsx
+++ b/src/components/UserSettingsDialog/UserSettingsDialogView.tsx
@@ -41,7 +41,7 @@ export const UserSettingsDialogView = ({ displayProps, onClose }: UserSettingsDi
                             value={displayProps.ftp}
                             unit="W"
                             digits={0}
-                            onValueChange={displayProps.onChangeFtp}
+                            onValueChange={(v) => { if (v !== undefined) displayProps.onChangeFtp(v); }}
                         />
                         <EditNumber
                             label="Weight"
@@ -49,7 +49,7 @@ export const UserSettingsDialogView = ({ displayProps, onClose }: UserSettingsDi
                             value={displayProps.weight?.value}
                             unit={displayProps.weight?.unit}
                             digits={1}
-                            onValueChange={displayProps.onChangeWeight}
+                            onValueChange={(v) => { if (v !== undefined) displayProps.onChangeWeight(v); }}
                         />
                         <SingleSelect
                             label="Units"

--- a/src/components/UserSettingsDialog/index.ts
+++ b/src/components/UserSettingsDialog/index.ts
@@ -1,0 +1,2 @@
+export * from './UserSettingsDialog';
+export * from './UserSettingsDialogView';


### PR DESCRIPTION
Closes #27

Implemented the `UserSettingsDialog` component following the smart/view split pattern. 

Key features:
- Smart component `UserSettingsDialog` manages service connection, observer subscription for `'units-changed'`, and cleanup.
- View component `UserSettingsDialogView` handles layout and rendering of profile fields (Name, FTP, Weight, Units) using atom components.
- Integrates `EditText`, `EditNumber`, and `SingleSelect` atoms.
- Supports loading state (null props) by rendering the dialog shell.
- Full Storybook coverage for Metric, Imperial, and Loading states.
- Unit tests for rendering and interaction logic.