### PR TITLE
Split NavigationBar into smart/view and integrate UserSettingsDialog

### DIFF
--- a/__mocks__/svgMock.tsx
+++ b/__mocks__/svgMock.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { View } from 'react-native';
+
+const SvgMock = (props: any) => <View {...props} />;
+
+export default SvgMock;

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,6 @@ module.exports = {
   preset: 'react-native',
   moduleNameMapper: {
     '^react-native-linear-gradient$': '<rootDir>/__mocks__/react-native-linear-gradient.tsx',
+    '\\.svg$': '<rootDir>/__mocks__/svgMock.tsx',
   },
 };

--- a/src/components/NavigationBar/NavigationBar.stories.tsx
+++ b/src/components/NavigationBar/NavigationBar.stories.tsx
@@ -1,11 +1,11 @@
-import { NavigationBar } from './NavigationBar';
+import { NavigationBarView } from './NavigationBarView';
 import { fn } from 'storybook/test';
 import { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { View, DimensionValue } from 'react-native';
 
 const meta = {
     title: 'Components/NavigationBar',
-    component: NavigationBar,
+    component: NavigationBarView,
     decorators: [
         (Story) => (
             <View style={{ height: '100vh' as DimensionValue, width: '100vw' as DimensionValue, justifyContent:'center', alignItems:'center' }}>
@@ -14,25 +14,28 @@ const meta = {
         )
     ],  
     args:{
-        onClick:fn()
+        onClick: fn(),
+        iconSize: 40,
+        navWidth: 150,
+        showExit: true,
     }
-} satisfies Meta<typeof NavigationBar>
+} satisfies Meta<typeof NavigationBarView>;
 
-export default meta
+export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Left: Story = {
+export const Default: Story = {
     args: {
-        position: 'left',
-        selected: 'exit',
+        selected: 'routes',
     }
-    
 };
 
-export const Top: Story = {
+export const Compact: Story = {
     args: {
-        position: 'top',
-        selected: 'exit',
-    }    
+        compact: true,
+        iconSize: 32,
+        navWidth: 70,
+        selected: 'activities',
+    }
 };

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -1,113 +1,39 @@
-import React from 'react';
-import { View, StyleSheet, useWindowDimensions, Platform } from 'react-native';
+import React, { useState } from 'react';
+import { useWindowDimensions, Platform } from 'react-native';
 import { NavigationBarProps, TNavigationItem } from './types';
-import { NavigationItem } from './NavigationItem';
-import { navigationItemsMiddle } from './utils';
-
-import {
-    UserIcon,
-    SettingsIcon,
-    BikeIcon,
-    RouteIcon,
-    WorkoutIcon,
-    ActivityIcon,
-    ExitIcon,
-    SearchIcon
-} from '../../assets/icons';
-import { colors } from '../../theme';
+import { NavigationBarView } from './NavigationBarView';
+import { UserSettingsDialog } from '../UserSettingsDialog';
 
 export const NavigationBar = (props: NavigationBarProps) => {
-    const { position, selected, onClick, compact } = props;
+    const { selected, onClick, compact } = props;
     const { height } = useWindowDimensions();
+    const [showUserSettings, setShowUserSettings] = useState(false);
 
-    const isVertical = position === 'left';
     const iconSize = compact ? 32 : Math.min(height / 16, 64);
     const navWidth = compact ? 70 : 150;
+    const showExit = Platform.OS === 'android';
 
-    const renderIcon = (item: TNavigationItem, isSelected: boolean) => {
-        const color = isSelected ? colors.iconSelected : colors.icon;
-        const iconProps = { fill: color, width: iconSize, height: iconSize };
-
-        switch (item) {
-            case 'user': return <UserIcon {...iconProps} />;
-            case 'settings': return <SettingsIcon {...iconProps} />;
-            case 'devices': return <BikeIcon {...iconProps} />;
-            case 'search': return <SearchIcon {...iconProps} />;
-            case 'routes': return <RouteIcon {...iconProps} />;
-            case 'workouts': return <WorkoutIcon {...iconProps} />;
-            case 'activities': return <ActivityIcon {...iconProps} />;
-            case 'exit': return <ExitIcon {...iconProps} />;
-            default: return null;
+    const handleOnClick = (item: TNavigationItem) => {
+        if (item === 'user') {
+            setShowUserSettings(true);
+        } else {
+            onClick(item);
         }
     };
 
     return (
-        <View style={[styles.container, { width: navWidth }]}>
-            <View style={styles.top}>
-                <NavigationItem
-                    item="user"
-                    selected={selected === 'user'}
-                    onPress={onClick}
-                    compact={compact}
-                >
-                    {renderIcon('user', selected === 'user')}
-                </NavigationItem>
-            </View>
-
-            <View style={[styles.middle, isVertical && styles.middleVertical]}>
-                {navigationItemsMiddle.map((item) => (
-                    <NavigationItem
-                        key={item}
-                        item={item}
-                        selected={selected === item}
-                        onPress={onClick}
-                        compact={compact}
-                    >
-                        {renderIcon(item, selected === item)}
-                    </NavigationItem>
-                ))}
-            </View>
-
-            {Platform.OS === 'android' && (
-                <View style={styles.bottom}>
-                    <NavigationItem
-                        item="exit"
-                        selected={selected === 'exit'}
-                        onPress={onClick}
-                        compact={compact}
-                    >
-                        {renderIcon('exit', selected === 'exit')}
-                    </NavigationItem>
-                </View>
+        <>
+            <NavigationBarView
+                selected={selected}
+                onClick={handleOnClick}
+                compact={compact}
+                iconSize={iconSize}
+                navWidth={navWidth}
+                showExit={showExit}
+            />
+            {showUserSettings && (
+                <UserSettingsDialog onClose={() => setShowUserSettings(false)} />
             )}
-        </View>
+        </>
     );
 };
-
-const styles = StyleSheet.create({
-    container: {
-        backgroundColor: 'rgba(0,0,0,0.2)',
-        padding: 8,
-        left: 0,
-        flex:1,
-        justifyContent: 'space-between',
-        alignItems: 'center',
-    },
-    top: {
-        justifyContent: 'center',
-        alignItems: 'center',
-        width: '100%',
-    },
-    bottom: {
-        justifyContent: 'center',
-        alignItems: 'center',
-        width: '100%',
-    },
-    middle: {
-        flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center',
-        width: '100%',
-    },
-    middleVertical: {},
-});

--- a/src/components/NavigationBar/NavigationBarView.test.tsx
+++ b/src/components/NavigationBar/NavigationBarView.test.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import { NavigationBarView } from './NavigationBarView';
-import { fn } from 'storybook/test';
 
 describe('NavigationBarView', () => {
     it('renders correctly', () => {
         const { toJSON } = render(
             <NavigationBarView 
-                onClick={fn()} 
+                onClick={jest.fn()} 
                 iconSize={32} 
                 navWidth={70} 
                 showExit={true} 
@@ -20,7 +19,7 @@ describe('NavigationBarView', () => {
         const { toJSON } = render(
             <NavigationBarView 
                 selected="routes"
-                onClick={fn()} 
+                onClick={jest.fn()} 
                 iconSize={32} 
                 navWidth={70} 
                 showExit={true} 

--- a/src/components/NavigationBar/NavigationBarView.test.tsx
+++ b/src/components/NavigationBar/NavigationBarView.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { NavigationBarView } from './NavigationBarView';
+import { fn } from 'storybook/test';
+
+describe('NavigationBarView', () => {
+    it('renders correctly', () => {
+        const { toJSON } = render(
+            <NavigationBarView 
+                onClick={fn()} 
+                iconSize={32} 
+                navWidth={70} 
+                showExit={true} 
+            />
+        );
+        expect(toJSON()).toBeDefined();
+    });
+
+    it('renders with selected item', () => {
+        const { toJSON } = render(
+            <NavigationBarView 
+                selected="routes"
+                onClick={fn()} 
+                iconSize={32} 
+                navWidth={70} 
+                showExit={true} 
+            />
+        );
+        expect(toJSON()).toBeDefined();
+    });
+});

--- a/src/components/NavigationBar/NavigationBarView.tsx
+++ b/src/components/NavigationBar/NavigationBarView.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { NavigationBarViewProps, TNavigationItem } from './types';
+import { NavigationItem } from './NavigationItem';
+import { navigationItemsMiddle } from './utils';
+
+import {
+    UserIcon,
+    SettingsIcon,
+    BikeIcon,
+    RouteIcon,
+    WorkoutIcon,
+    ActivityIcon,
+    ExitIcon,
+    SearchIcon
+} from '../../assets/icons';
+import { colors } from '../../theme';
+
+export const NavigationBarView = (props: NavigationBarViewProps) => {
+    const { selected, onClick, compact, iconSize, navWidth, showExit } = props;
+
+    const renderIcon = (item: TNavigationItem, isSelected: boolean) => {
+        const color = isSelected ? colors.iconSelected : colors.icon;
+        const iconProps = { fill: color, width: iconSize, height: iconSize };
+
+        switch (item) {
+            case 'user': return <UserIcon {...iconProps} />;
+            case 'settings': return <SettingsIcon {...iconProps} />;
+            case 'devices': return <BikeIcon {...iconProps} />;
+            case 'search': return <SearchIcon {...iconProps} />;
+            case 'routes': return <RouteIcon {...iconProps} />;
+            case 'workouts': return <WorkoutIcon {...iconProps} />;
+            case 'activities': return <ActivityIcon {...iconProps} />;
+            case 'exit': return <ExitIcon {...iconProps} />;
+            default: return null;
+        }
+    };
+
+    return (
+        <View style={[styles.container, { width: navWidth }]}>
+            <View style={styles.top}>
+                <NavigationItem
+                    item="user"
+                    selected={selected === 'user'}
+                    onPress={onClick}
+                    compact={compact}
+                >
+                    {renderIcon('user', selected === 'user')}
+                </NavigationItem>
+            </View>
+
+            <View style={styles.middle}>
+                {navigationItemsMiddle.map((item) => (
+                    <NavigationItem
+                        key={item}
+                        item={item}
+                        selected={selected === item}
+                        onPress={onClick}
+                        compact={compact}
+                    >
+                        {renderIcon(item, selected === item)}
+                    </NavigationItem>
+                ))}
+            </View>
+
+            {showExit && (
+                <View style={styles.bottom}>
+                    <NavigationItem
+                        item="exit"
+                        selected={selected === 'exit'}
+                        onPress={onClick}
+                        compact={compact}
+                    >
+                        {renderIcon('exit', selected === 'exit')}
+                    </NavigationItem>
+                </View>
+            )}
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        backgroundColor: 'rgba(0,0,0,0.2)',
+        padding: 8,
+        left: 0,
+        flex: 1,
+        justifyContent: 'space-between',
+        alignItems: 'center',
+    },
+    top: {
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+    },
+    bottom: {
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+    },
+    middle: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+    },
+});

--- a/src/components/NavigationBar/types.ts
+++ b/src/components/NavigationBar/types.ts
@@ -8,11 +8,17 @@ export type TNavigationItem =
     | 'activities'
     | 'exit';
 
-export type TPosition = 'left' | 'top'
-
 export interface NavigationBarProps {
-    position: TPosition;
     selected?: TNavigationItem;
     onClick: (item: TNavigationItem) => void;
     compact?: boolean;
+}
+
+export interface NavigationBarViewProps {
+    selected?: TNavigationItem;
+    onClick: (item: TNavigationItem) => void;
+    compact?: boolean;
+    iconSize: number;
+    navWidth: number;
+    showExit: boolean;
 }

--- a/src/pages/MainPage/View.tsx
+++ b/src/pages/MainPage/View.tsx
@@ -80,7 +80,7 @@ export const MainPageView = ({ onClick }: MainPageViewProps) => {
         <MainBackground>
             <View style={styles.layout}>
                 <View style={styles.navColumn}>
-                    <NavigationBar position="left" onClick={onClick} />
+                    <NavigationBar onClick={onClick} />
                 </View>
 
                 <ScrollView style={styles.contentColumn} contentContainerStyle={styles.scrollContent}>

--- a/src/pages/NotImplemented/NotImplementedPage.tsx
+++ b/src/pages/NotImplemented/NotImplementedPage.tsx
@@ -16,7 +16,7 @@ export const NotImplementedView = ( {onClick,selected}:NotImplementedViewProps) 
         <MainBackground>
             <View style={styles.layout}>
                 <View style={styles.navColumn}>
-                    <NavigationBar position="left" selected={selected} onClick={onClick} />
+                    <NavigationBar selected={selected} onClick={onClick} />
                 </View>
                 
                 <View style={styles.content}>

--- a/src/pages/RoutesPage/View.tsx
+++ b/src/pages/RoutesPage/View.tsx
@@ -52,7 +52,6 @@ export const RoutesPageView = (props: RoutesPageViewProps) => {
                 <View style={[styles.navColumn, { width: compact ? 70 : 150 }]}>
                     <NavigationBar
                         compact={compact}
-                        position="left"
                         selected="routes"
                         onClick={onNavigate}
                     />

--- a/src/pages/VideoDemo/View.tsx
+++ b/src/pages/VideoDemo/View.tsx
@@ -176,7 +176,7 @@ export const VideoDemoView = ({ onClick }: RidePageViewProps) => {
             )}
 
             <View style={styles.navColumn}>
-                <NavigationBar position='left' onClick={onClick} />
+                <NavigationBar onClick={onClick} />
             </View>
 
             <View style={styles.controlPanel}>


### PR DESCRIPTION
Closes #28

This PR refactors the `NavigationBar` component into a smart component and a pure view component. 

Key changes:
- Moved layout calculations (`iconSize`, `navWidth`) and platform-specific logic (`showExit`) to the smart `NavigationBar` component.
- Removed the unused `position` prop and `isVertical` logic.
- Integrated `UserSettingsDialog` within the smart `NavigationBar` to open when the 'user' icon is tapped.
- Updated all page callers to remove the `position` prop.
- Updated Storybook to target `NavigationBarView`.
- Added basic render tests for `NavigationBarView`.