### PR TITLE
Fix #33: Correct UserSettingsDialog variant and button placement

### DIFF
--- a/src/components/UserSettingsDialog/UserSettingsDialogView.tsx
+++ b/src/components/UserSettingsDialog/UserSettingsDialogView.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { UserSettingsDisplayProps } from 'incyclist-services';
 import { Dialog } from '../Dialog/Dialog';
-import { ButtonBar } from '../ButtonBar/ButtonBar';
 import { EditText, EditNumber, SingleSelect } from '../atoms';
 
 export type UserSettingsDialogViewProps = {
@@ -22,9 +21,10 @@ export const UserSettingsDialogView = ({ displayProps, onClose }: UserSettingsDi
     return (
         <Dialog
             title="User Settings"
-            variant="info"
+            variant="details"
             visible={true}
             onOutsideClick={onClose}
+            buttons={[{ label: 'OK', primary: true, onClick: onClose }]}
         >
             <View style={styles.container}>
                 {displayProps && (
@@ -60,13 +60,6 @@ export const UserSettingsDialogView = ({ displayProps, onClose }: UserSettingsDi
                         />
                     </View>
                 )}
-                <View style={styles.footer}>
-                    <ButtonBar
-                        buttons={[
-                            { label: 'OK', primary: true, onClick: onClose },
-                        ]}
-                    />
-                </View>
             </View>
         </Dialog>
     );
@@ -79,9 +72,5 @@ const styles = StyleSheet.create({
     },
     fields: {
         marginBottom: 16,
-    },
-    footer: {
-        marginTop: 8,
-        alignItems: 'flex-end',
     },
 });


### PR DESCRIPTION
Closes #33

This PR addresses two issues in `UserSettingsDialogView`:

1.  **Dialog Variant**: Changed the `Dialog` variant from `'info'` to `'details'`. The `'info'` variant is compact and not suitable for forms with multiple input fields, while `'details'` provides the necessary larger, scrollable layout.
2.  **Button Placement**: Moved the 'OK' button from being rendered inside the `Dialog`'s children (where it would scroll with the form content) to the `buttons` prop of the `Dialog` component. This ensures the button is pinned to the bottom footer of the dialog, consistent with UI foundations rules.

Changes include:
-   Updating `variant="info"` to `variant="details"` on the `Dialog` component.
-   Removing the `ButtonBar` import.
-   Removing the internal `<View style={styles.footer}>` containing the `ButtonBar`.
-   Passing the 'OK' button directly to the `Dialog`'s `buttons` prop.
-   Deleting the `styles.footer` entry from `StyleSheet.create()`.