### PR TITLE
feat(forms): Introduce 'length' prop for input width control

### DIFF
--- a/src/components/UserSettingsDialog/UserSettingsDialogView.tsx
+++ b/src/components/UserSettingsDialog/UserSettingsDialogView.tsx
@@ -32,7 +32,7 @@ export const UserSettingsDialogView = ({ displayProps, onClose }: UserSettingsDi
                         <EditText
                             label="Name"
                             labelWidth={LABEL_WIDTH}
-                            length={20} // Explicit length for user name
+                            length={20}
                             value={displayProps.username}
                             onValueChange={displayProps.onChangeName}
                         />
@@ -40,7 +40,8 @@ export const UserSettingsDialogView = ({ displayProps, onClose }: UserSettingsDi
                             label="FTP"
                             labelWidth={LABEL_WIDTH}
                             min={0}
-                            max={999} // min/max help derive length automatically
+                            max={999}
+                            value={displayProps.ftp}
                             unit="W"
                             digits={0}
                             onValueChange={(v) => { if (v !== undefined) displayProps.onChangeFtp(v); }}
@@ -49,7 +50,8 @@ export const UserSettingsDialogView = ({ displayProps, onClose }: UserSettingsDi
                             label="Weight"
                             labelWidth={LABEL_WIDTH}
                             min={0}
-                            max={999} // min/max help derive length automatically
+                            max={999}
+                            value={displayProps.weight?.value}
                             unit={displayProps.weight?.unit}
                             digits={1}
                             onValueChange={(v) => { if (v !== undefined) displayProps.onChangeWeight(v); }}
@@ -57,7 +59,7 @@ export const UserSettingsDialogView = ({ displayProps, onClose }: UserSettingsDi
                         <SingleSelect
                             label="Units"
                             labelWidth={LABEL_WIDTH}
-                            options={displayProps.unitsOptions} // options help derive length automatically
+                            options={displayProps.unitsOptions}
                             selected={displayProps.units}
                             onValueChange={displayProps.onChangeUnits}
                         />

--- a/src/components/UserSettingsDialog/UserSettingsDialogView.tsx
+++ b/src/components/UserSettingsDialog/UserSettingsDialogView.tsx
@@ -32,13 +32,15 @@ export const UserSettingsDialogView = ({ displayProps, onClose }: UserSettingsDi
                         <EditText
                             label="Name"
                             labelWidth={LABEL_WIDTH}
+                            length={20} // Explicit length for user name
                             value={displayProps.username}
                             onValueChange={displayProps.onChangeName}
                         />
                         <EditNumber
                             label="FTP"
                             labelWidth={LABEL_WIDTH}
-                            value={displayProps.ftp}
+                            min={0}
+                            max={999} // min/max help derive length automatically
                             unit="W"
                             digits={0}
                             onValueChange={(v) => { if (v !== undefined) displayProps.onChangeFtp(v); }}
@@ -46,7 +48,8 @@ export const UserSettingsDialogView = ({ displayProps, onClose }: UserSettingsDi
                         <EditNumber
                             label="Weight"
                             labelWidth={LABEL_WIDTH}
-                            value={displayProps.weight?.value}
+                            min={0}
+                            max={999} // min/max help derive length automatically
                             unit={displayProps.weight?.unit}
                             digits={1}
                             onValueChange={(v) => { if (v !== undefined) displayProps.onChangeWeight(v); }}
@@ -54,7 +57,7 @@ export const UserSettingsDialogView = ({ displayProps, onClose }: UserSettingsDi
                         <SingleSelect
                             label="Units"
                             labelWidth={LABEL_WIDTH}
-                            options={displayProps.unitsOptions}
+                            options={displayProps.unitsOptions} // options help derive length automatically
                             selected={displayProps.units}
                             onValueChange={displayProps.onChangeUnits}
                         />

--- a/src/components/atoms/EditNumber/EditNumber.stories.tsx
+++ b/src/components/atoms/EditNumber/EditNumber.stories.tsx
@@ -56,3 +56,29 @@ export const Disabled: Story = {
         disabled: true,
     },
 };
+
+export const WithLength: Story = {
+    args: {
+        label: 'FTP',
+        value: 224,
+        unit: 'W',
+        digits: 0,
+        length: 5, // Explicitly set length
+    },
+};
+
+export const WithMinMaxDerivedLength: Story = {
+    args: {
+        label: 'Weight Range',
+        value: 123.45,
+        min: -999.99,
+        max: 9999.99,
+        digits: 2,
+        unit: 'kg',
+        // length is not specified, will be derived from min/max
+        // minStr: '-999.99' (length 7) -> this doesn't happen, it's min.toString() -> '-999' (4 chars)
+        // maxStr: '9999.99' (length 7) -> this doesn't happen, it's max.toString() -> '9999' (4 chars)
+        // longestLen = 4. Derived: 4 + 3 = 7.
+        // It will accommodate `999.99` (6 chars) or `-99.99` (6 chars).
+    },
+};

--- a/src/components/atoms/EditNumber/EditNumber.tsx
+++ b/src/components/atoms/EditNumber/EditNumber.tsx
@@ -3,6 +3,7 @@ import { View, Text, TextInput, StyleSheet } from 'react-native';
 import { colors } from '../../../theme/colors';
 import { textSizes } from '../../../theme/textSizes';
 import { EditNumberProps } from './types';
+import { CHAR_WIDTH_MULTIPLIER } from '../../../utils/ui'; // Import shared constant
 
 const LABEL_MARGIN = 8;
 
@@ -17,6 +18,7 @@ export const EditNumber = ({
     unit,
     disabled = false,
     onValueChange,
+    length, // Added length prop
 }: EditNumberProps) => {
     const formatValue = useCallback(
         (val?: number) => {
@@ -75,8 +77,25 @@ export const EditNumber = ({
         setInternalValue(formatValue(numericValue));
     }, [internalValue, allowEmpty, min, max, onValueChange, formatValue]);
 
+    const deriveLength = useCallback((): number | undefined => {
+        if (length !== undefined) return length; // Explicit length takes precedence
+        if (min === undefined && max === undefined) return undefined; // No min/max to derive from
+
+        const minStr = min !== undefined ? min.toString() : '';
+        const maxStr = max !== undefined ? max.toString() : '';
+        const longestLen = Math.max(minStr.length, maxStr.length);
+
+        // Add 3 characters as buffer for potential negative sign, decimal point, and extra digits
+        return longestLen + 3;
+    }, [length, min, max]);
+
     const labelStyle = { width: labelWidth };
     const errorStyle = { marginLeft: labelWidth + LABEL_MARGIN };
+
+    const inputCalculatedLength = deriveLength();
+    const inputWidthStyle = inputCalculatedLength !== undefined
+        ? { width: inputCalculatedLength * CHAR_WIDTH_MULTIPLIER }
+        : styles.inputFull; // Use flex: 1 if no length derived
 
     return (
         <View style={styles.container}>
@@ -85,6 +104,7 @@ export const EditNumber = ({
                 <TextInput
                     style={[
                         styles.input,
+                        inputWidthStyle, // Apply dynamic width here
                         disabled && styles.disabledInput,
                         error !== null && styles.errorBorder,
                     ]}
@@ -121,13 +141,15 @@ const styles = StyleSheet.create({
         marginRight: LABEL_MARGIN,
     },
     input: {
-        flex: 1,
         color: colors.text,
         fontSize: textSizes.normalText,
         borderBottomWidth: 1,
         borderBottomColor: colors.listSeparator,
         paddingVertical: 4,
         paddingHorizontal: 4,
+    },
+    inputFull: { // Style for full width when length is not specified
+        flex: 1,
     },
     disabledInput: {
         color: colors.disabled,

--- a/src/components/atoms/EditNumber/types.ts
+++ b/src/components/atoms/EditNumber/types.ts
@@ -9,4 +9,5 @@ export type EditNumberProps = {
     unit?: string;
     disabled?: boolean;
     onValueChange?: (value: number | undefined) => void;
+    length?: number; // Added for input width control
 };

--- a/src/components/atoms/EditText/EditText.stories.tsx
+++ b/src/components/atoms/EditText/EditText.stories.tsx
@@ -41,3 +41,11 @@ export const WithValidation: Story = {
         validate: (v) => (v.trim() === '' ? 'Name is required' : null),
     },
 };
+
+export const WithLength: Story = {
+    args: {
+        label: 'Name',
+        value: 'Guido Doumen',
+        length: 20, // Explicitly set length
+    },
+};

--- a/src/components/atoms/EditText/EditText.tsx
+++ b/src/components/atoms/EditText/EditText.tsx
@@ -48,13 +48,9 @@ export const EditText = ({
     const errorStyle = { marginLeft: labelWidth + LABEL_MARGIN };
 
     // Determine input width based on length prop or flex: 1
-    const inputWidth = length !== undefined
-        ? length * CHAR_WIDTH_MULTIPLIER
-        : undefined;
-
-    const inputContainerStyle = inputWidth !== undefined
-        ? [styles.input, { width: inputWidth }]
-        : [styles.input, styles.inputFull];
+    const inputWidthStyle = length !== undefined
+        ? { width: length * CHAR_WIDTH_MULTIPLIER }
+        : styles.inputFull; // Use flex: 1 if no length specified
 
     return (
         <View style={styles.container}>
@@ -62,7 +58,8 @@ export const EditText = ({
                 <Text style={[styles.label, labelStyle]}>{label}</Text>
                 <TextInput
                     style={[
-                        inputContainerStyle, // Apply dynamic width here
+                        styles.input,
+                        inputWidthStyle, // Apply dynamic width here
                         disabled && styles.disabledInput,
                         error !== null && styles.errorBorder,
                     ]}

--- a/src/components/atoms/EditText/EditText.tsx
+++ b/src/components/atoms/EditText/EditText.tsx
@@ -3,6 +3,7 @@ import { View, Text, TextInput, StyleSheet } from 'react-native';
 import { colors } from '../../../theme/colors';
 import { textSizes } from '../../../theme/textSizes';
 import { EditTextProps } from './types';
+import { CHAR_WIDTH_MULTIPLIER } from '../../../utils/ui'; // Import shared constant
 
 const LABEL_MARGIN = 8;
 
@@ -14,6 +15,7 @@ export const EditText = ({
     disabled = false,
     validate,
     onValueChange,
+    length, // Added length prop
 }: EditTextProps) => {
     const [internalValue, setInternalValue] = useState(value);
     const [error, setError] = useState<string | null>(null);
@@ -45,13 +47,22 @@ export const EditText = ({
     const labelStyle = { width: labelWidth };
     const errorStyle = { marginLeft: labelWidth + LABEL_MARGIN };
 
+    // Determine input width based on length prop or flex: 1
+    const inputWidth = length !== undefined
+        ? length * CHAR_WIDTH_MULTIPLIER
+        : undefined;
+
+    const inputContainerStyle = inputWidth !== undefined
+        ? [styles.input, { width: inputWidth }]
+        : [styles.input, styles.inputFull];
+
     return (
         <View style={styles.container}>
             <View style={styles.row}>
                 <Text style={[styles.label, labelStyle]}>{label}</Text>
                 <TextInput
                     style={[
-                        styles.input,
+                        inputContainerStyle, // Apply dynamic width here
                         disabled && styles.disabledInput,
                         error !== null && styles.errorBorder,
                     ]}
@@ -88,13 +99,15 @@ const styles = StyleSheet.create({
         marginRight: LABEL_MARGIN,
     },
     input: {
-        flex: 1,
         color: colors.text,
         fontSize: textSizes.normalText,
         borderBottomWidth: 1,
         borderBottomColor: colors.listSeparator,
         paddingVertical: 4,
         paddingHorizontal: 4,
+    },
+    inputFull: { // Style for full width when length is not specified
+        flex: 1,
     },
     disabledInput: {
         color: colors.disabled,

--- a/src/components/atoms/EditText/types.ts
+++ b/src/components/atoms/EditText/types.ts
@@ -6,4 +6,5 @@ export type EditTextProps = {
     disabled?: boolean;
     validate?: (value: string) => string | null;
     onValueChange?: (value: string) => void;
+    length?: number; // Added for input width control
 };

--- a/src/components/atoms/SingleSelect/SingleSelect.stories.tsx
+++ b/src/components/atoms/SingleSelect/SingleSelect.stories.tsx
@@ -44,3 +44,22 @@ export const Disabled: Story = {
         disabled: true,
     },
 };
+
+export const WithLength: Story = {
+    args: {
+        label: 'Units',
+        options: ['Metric', 'Imperial'],
+        selected: 'Metric',
+        length: 12, // Explicitly set length
+    },
+};
+
+export const WithAutoDerivedLength: Story = {
+    args: {
+        label: 'Lengthy Options',
+        options: ['Short', 'Medium Length', 'Very Very Long Option'],
+        selected: 'Medium Length',
+        // length is not specified, will be derived from longest option
+        // 'Very Very Long Option' is 22 chars. Derived: 22 + 4 = 26.
+    },
+};

--- a/src/components/atoms/SingleSelect/SingleSelect.tsx
+++ b/src/components/atoms/SingleSelect/SingleSelect.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-nati
 import { colors } from '../../../theme/colors';
 import { textSizes } from '../../../theme/textSizes';
 import { SingleSelectProps } from './types';
+import { CHAR_WIDTH_MULTIPLIER, SINGLE_SELECT_ARROW_BUFFER } from '../../../utils/ui'; // Import shared constants
 
 const LABEL_MARGIN = 8;
 
@@ -21,6 +22,7 @@ export const SingleSelect = ({
     labelWidth = 100,
     disabled = false,
     onValueChange,
+    length, // Added length prop
 }: SingleSelectProps) => {
     const [selectedValue, setSelectedValue] = useState(selected);
     const [isOpen, setIsOpen] = useState(false);
@@ -42,13 +44,25 @@ export const SingleSelect = ({
         onValueChange?.(itemValue);
     }, [onValueChange]);
 
+    const deriveLength = useCallback((): number | undefined => {
+        if (length !== undefined) return length; // Explicit length takes precedence
+        if (!options || options.length === 0) return undefined; // No options to derive from
+
+        const longestOptionLength = Math.max(...options.map(o => o.length));
+        return longestOptionLength + SINGLE_SELECT_ARROW_BUFFER; // Add buffer for arrow and padding
+    }, [length, options]);
+
     const labelStyle = { width: labelWidth };
+    const triggerCalculatedLength = deriveLength();
+    const triggerWidthStyle = triggerCalculatedLength !== undefined
+        ? { width: triggerCalculatedLength * CHAR_WIDTH_MULTIPLIER }
+        : styles.triggerFull; // Use flex: 1 if no length derived
 
     return (
         <View style={[styles.container, isOpen && styles.activeZIndex]}>
             <View style={styles.row}>
                 <Text style={[styles.label, labelStyle]}>{label}</Text>
-                <View style={styles.dropdownContainer}>
+                <View style={[styles.dropdownContainer, triggerWidthStyle]}> {/* Apply dynamic width here */}
                     <TouchableOpacity
                         style={[
                             styles.trigger,
@@ -105,7 +119,6 @@ const styles = StyleSheet.create({
         marginRight: LABEL_MARGIN,
     },
     dropdownContainer: {
-        flex: 1,
         position: 'relative',
     },
     trigger: {
@@ -116,6 +129,9 @@ const styles = StyleSheet.create({
         borderBottomColor: colors.listSeparator,
         paddingVertical: 4,
         paddingHorizontal: 4,
+    },
+    triggerFull: { // Style for full width when length is not specified
+        flex: 1,
     },
     disabledTrigger: {
         borderBottomColor: 'transparent',

--- a/src/components/atoms/SingleSelect/types.ts
+++ b/src/components/atoms/SingleSelect/types.ts
@@ -5,4 +5,5 @@ export type SingleSelectProps = {
     labelWidth?: number;
     disabled?: boolean;
     onValueChange?: (value: string) => void;
+    length?: number; // Added for input width control
 };

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -1,0 +1,2 @@
+export const CHAR_WIDTH_MULTIPLIER = 10; // Visually tuned for normalText (16px)
+export const SINGLE_SELECT_ARROW_BUFFER = 4; // Buffer for dropdown arrow and padding (e.g., '▲' / '▼' and some padding)


### PR DESCRIPTION
Closes #36

This PR introduces an optional `length` prop to `EditText`, `EditNumber`, and `SingleSelect` components, allowing explicit control over input field width based on character count.

Key changes include:
- Added `length?: number` to the types of all three components.
- Implemented width calculation logic:
    - `EditText`: Uses `length` if provided, otherwise `flex: 1`.
    - `EditNumber`: Derives length automatically from `min`/`max` props (accounting for sign, decimal, and digits) if `length` is not provided. Falls back to `flex: 1` if neither `length`, `min`, nor `max` are set.
    - `SingleSelect`: Derives length automatically from the longest string in `options` (plus a buffer for the dropdown arrow) if `length` is not provided. Falls back to `flex: 1` if `length` is not set and `options` is empty.
- Introduced a shared `CHAR_WIDTH_MULTIPLIER` constant in `src/utils/ui.ts` to convert character count to pixel width, ensuring consistency and easy tuning. Also added `SINGLE_SELECT_ARROW_BUFFER` for `SingleSelect`'s auto-derivation.
- Updated `UserSettingsDialogView.tsx` to utilize the new `length` prop and auto-derivation for a more visually balanced form.
- Added new Storybook stories (`WithLength`) for each component to demonstrate the `length` prop functionality.

The width is applied directly to the `TextInput` or `TouchableOpacity` trigger, ensuring the label column width remains unaffected.

## Manual Steps
No manual steps required outside this PR.