### PR TITLE
Implement ChipSelect component and use for Units field

### DIFF
--- a/src/components/ChipSelect/ChipSelect.stories.tsx
+++ b/src/components/ChipSelect/ChipSelect.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { ChipSelect } from './ChipSelect';
+
+const meta: Meta<typeof ChipSelect> = {
+    component: ChipSelect,
+    args: {
+        onValueChange: fn(),
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ChipSelect>;
+
+export const TwoOptions: Story = {
+    args: {
+        label: 'Units',
+        options: ['Metric', 'Imperial'],
+        selected: 'Metric',
+    },
+};
+
+export const ThreeOptions: Story = {
+    args: {
+        label: 'Mode',
+        options: ['Easy', 'Normal', 'Hard'],
+        selected: 'Normal',
+    },
+};
+
+export const FourOptions: Story = {
+    args: {
+        label: 'Size',
+        options: ['XS', 'S', 'M', 'L'],
+        selected: 'M',
+    },
+};
+
+export const NoneSelected: Story = {
+    args: {
+        label: 'Units',
+        options: ['Metric', 'Imperial'],
+    },
+};
+
+export const Disabled: Story = {
+    args: {
+        label: 'Units',
+        options: ['Metric', 'Imperial'],
+        selected: 'Metric',
+        disabled: true,
+    },
+};

--- a/src/components/ChipSelect/ChipSelect.test.tsx
+++ b/src/components/ChipSelect/ChipSelect.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { ChipSelect } from './ChipSelect';
+import { ChipSelectProps } from './types';
+
+const mockLogEvent = jest.fn();
+jest.mock('../../hooks', () => ({
+    useLogging: () => ({
+        logEvent: mockLogEvent,
+    }),
+}));
+
+const MOCK_CHIP_SELECT_PROPS: ChipSelectProps = {
+    label: 'Units',
+    options: ['Metric', 'Imperial'],
+    selected: 'Metric',
+    onValueChange: jest.fn(),
+};
+
+describe('ChipSelect', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders with options and a selected value', () => {
+        const { getByText } = render(<ChipSelect {...MOCK_CHIP_SELECT_PROPS} />);
+        expect(getByText('Units')).toBeTruthy();
+        expect(getByText('Metric')).toBeTruthy();
+        expect(getByText('Imperial')).toBeTruthy();
+    });
+
+    it('renders with no selected value', () => {
+        const props = { ...MOCK_CHIP_SELECT_PROPS, selected: undefined };
+        const { getByText } = render(<ChipSelect {...props} />);
+        expect(getByText('Metric')).toBeTruthy();
+        expect(getByText('Imperial')).toBeTruthy();
+    });
+
+    it('renders disabled', () => {
+        const { getByText } = render(<ChipSelect {...MOCK_CHIP_SELECT_PROPS} disabled={true} />);
+        const chip = getByText('Imperial');
+        fireEvent.press(chip);
+        expect(MOCK_CHIP_SELECT_PROPS.onValueChange).not.toHaveBeenCalled();
+    });
+
+    it('tapping a chip calls onValueChange with the correct value', () => {
+        const { getByText } = render(<ChipSelect {...MOCK_CHIP_SELECT_PROPS} />);
+        const chip = getByText('Imperial');
+        fireEvent.press(chip);
+        expect(MOCK_CHIP_SELECT_PROPS.onValueChange).toHaveBeenCalledWith('Imperial');
+        expect(mockLogEvent).toHaveBeenCalledWith({
+            message: 'option selected',
+            field: 'Units',
+            value: 'Imperial',
+            eventSource: 'user',
+        });
+    });
+
+    it('internal state updates when selected prop changes from outside', () => {
+        const { rerender } = render(<ChipSelect {...MOCK_CHIP_SELECT_PROPS} />);
+        rerender(<ChipSelect {...MOCK_CHIP_SELECT_PROPS} selected="Imperial" />);
+        // The sync effect runs on rerender
+    });
+});

--- a/src/components/ChipSelect/ChipSelect.tsx
+++ b/src/components/ChipSelect/ChipSelect.tsx
@@ -1,0 +1,115 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { colors } from '../../theme/colors';
+import { textSizes } from '../../theme/textSizes';
+import { ChipSelectProps } from './types';
+import { useLogging } from '../../hooks';
+
+const LABEL_MARGIN = 8;
+
+/**
+ * ChipSelect component
+ * 
+ * A reusable labelled row of chips for selecting one option from a small set.
+ */
+export const ChipSelect = ({
+    label,
+    options,
+    selected,
+    labelWidth = 100,
+    disabled = false,
+    onValueChange,
+}: ChipSelectProps) => {
+    const [selectedValue, setSelectedValue] = useState(selected);
+    const { logEvent } = useLogging('ChipSelect');
+
+    useEffect(() => {
+        setSelectedValue(selected);
+    }, [selected]);
+
+    const handleSelect = (option: string) => {
+        if (disabled) return;
+        setSelectedValue(option);
+        logEvent({
+            message: 'option selected',
+            field: label,
+            value: option,
+            eventSource: 'user',
+        });
+        onValueChange?.(option);
+    };
+
+    const labelStyle = { width: labelWidth };
+
+    return (
+        <View style={[styles.container, disabled && styles.disabled]}>
+            <View style={styles.row}>
+                <Text style={[styles.label, labelStyle]}>{label}</Text>
+                <View style={styles.chipsContainer}>
+                    {options.map((option, index) => {
+                        const isSelected = selectedValue === option;
+                        const isLast = index === options.length - 1;
+
+                        return (
+                            <TouchableOpacity
+                                key={option}
+                                style={[
+                                    styles.chip,
+                                    isSelected && styles.chipActive,
+                                    !isLast && styles.marginRight,
+                                ]}
+                                onPress={() => handleSelect(option)}
+                                disabled={disabled}
+                            >
+                                <Text style={styles.chipText}>{option}</Text>
+                            </TouchableOpacity>
+                        );
+                    })}
+                </View>
+            </View>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        marginVertical: 8,
+        width: '100%',
+    },
+    disabled: {
+        opacity: 0.4,
+    },
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
+    },
+    label: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        marginRight: LABEL_MARGIN,
+    },
+    chipsContainer: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        flexWrap: 'nowrap',
+    },
+    chip: {
+        paddingHorizontal: 12,
+        paddingVertical: 6,
+        borderRadius: 16,
+        backgroundColor: 'rgba(255,255,255,0.1)',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    chipActive: {
+        backgroundColor: colors.buttonPrimary,
+    },
+    chipText: {
+        color: colors.text,
+        fontSize: textSizes.smallText,
+        fontWeight: '600',
+    },
+    marginRight: {
+        marginRight: 8,
+    },
+});

--- a/src/components/ChipSelect/index.ts
+++ b/src/components/ChipSelect/index.ts
@@ -1,0 +1,2 @@
+export * from './ChipSelect';
+export * from './types';

--- a/src/components/ChipSelect/types.ts
+++ b/src/components/ChipSelect/types.ts
@@ -1,0 +1,8 @@
+export type ChipSelectProps = {
+    label: string;
+    options: Array<string>;
+    selected?: string;
+    labelWidth?: number;
+    disabled?: boolean;
+    onValueChange?: (value: string) => void;
+};

--- a/src/components/UserSettingsDialog/UserSettingsDialogView.tsx
+++ b/src/components/UserSettingsDialog/UserSettingsDialogView.tsx
@@ -4,7 +4,7 @@ import { UserSettingsDisplayProps } from 'incyclist-services';
 import { Dialog } from '../Dialog';
 import { EditText } from '../EditText';
 import { EditNumber } from '../EditNumber';
-import { SingleSelect } from '../SingleSelect';
+import { ChipSelect } from '../ChipSelect';
 
 export type UserSettingsDialogViewProps = {
     displayProps: UserSettingsDisplayProps | null;
@@ -58,7 +58,7 @@ export const UserSettingsDialogView = ({ displayProps, onClose }: UserSettingsDi
                             digits={1}
                             onValueChange={(v) => { if (v !== undefined) displayProps.onChangeWeight(v); }}
                         />
-                        <SingleSelect
+                        <ChipSelect
                             label="Units"
                             labelWidth={LABEL_WIDTH}
                             options={displayProps.unitsOptions}

--- a/src/components/UserSettingsDialog/UserSettingsDialogView.tsx
+++ b/src/components/UserSettingsDialog/UserSettingsDialogView.tsx
@@ -76,6 +76,7 @@ const styles = StyleSheet.create({
     container: {
         width: '100%',
         paddingTop: 8,
+        paddingHorizontal: 16,
     },
     fields: {
         marginBottom: 16,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -25,3 +25,4 @@ export * from './Dialog';
 export * from './EditText';
 export * from './EditNumber';
 export * from './SingleSelect';
+export * from './ChipSelect';


### PR DESCRIPTION
Closes #39

This PR introduces the `ChipSelect` component, a reusable UI element for selecting from a small set of options (2-4). It replaces the `SingleSelect` dropdown for the Units field in the `UserSettingsDialogView` to provide better UX for choice selection.

Changes:
- Added `ChipSelect` component with logging and theme integration.
- Added unit tests and Storybook stories for `ChipSelect`.
- Updated `UserSettingsDialogView` to use `ChipSelect` for the Units field.
- Exported `ChipSelect` from the components barrel.