### PR TITLE
Implement Settings page shell with section navigation

### DIFF
--- a/rules/storybook.md
+++ b/rules/storybook.md
@@ -35,5 +35,14 @@ const meta: Meta<typeof FooView> = {
 Use PascalCase for all story export names (`Default`, `Compact`, `WithError`).
 Never use camelCase (`defaultArgs`, `withError`).
 
+## Story title
+Always set an explicit `title` in the `meta` object. Never rely on Storybook auto-generation.
+Use the following conventions:
+- Components: `'Components/<ComponentName>'`
+- Pages: `'Pages/<PageName>'`
+
 ## One story file per component
 `ComponentName.stories.tsx` lives in the same folder as the component.
+
+
+

--- a/src/components/ChipSelect/ChipSelect.stories.tsx
+++ b/src/components/ChipSelect/ChipSelect.stories.tsx
@@ -3,6 +3,7 @@ import { fn } from 'storybook/test';
 import { ChipSelect } from './ChipSelect';
 
 const meta: Meta<typeof ChipSelect> = {
+    title: 'Components/DeviceEntry',
     component: ChipSelect,
     args: {
         onValueChange: fn(),

--- a/src/components/RideMenu/RideMenu.tsx
+++ b/src/components/RideMenu/RideMenu.tsx
@@ -165,7 +165,7 @@ export const RideMenu = ({
 
 const styles = StyleSheet.create({
     backdrop: {
-        ...StyleSheet.absoluteFillObject,
+        ...StyleSheet.absoluteFill,
         backgroundColor: 'rgba(0,0,0,0.4)',
     },
     panel: {

--- a/src/pages/NotImplemented/NotImplementedPage.tsx
+++ b/src/pages/NotImplemented/NotImplementedPage.tsx
@@ -43,7 +43,7 @@ const styles = StyleSheet.create({
         flex: 1,
     },
     content: {
-        ...StyleSheet.absoluteFillObject,
+        ...StyleSheet.absoluteFill,
         justifyContent: 'center',
         alignItems: 'center',
         gap: 24,

--- a/src/pages/RidePage/RidePage.tsx
+++ b/src/pages/RidePage/RidePage.tsx
@@ -62,7 +62,7 @@ container: {
     flex: 1,
 },
 content: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     justifyContent: 'center',
     alignItems: 'center',
     gap: 24,

--- a/src/pages/RidePage/Video/VideoRidePage.tsx
+++ b/src/pages/RidePage/Video/VideoRidePage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { View, AppState } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 import { 
     getRidePageService, 
     IObserver, 
@@ -19,6 +20,7 @@ interface VideoRidePageProps {
 
 export const VideoRidePage = ({ simulate = false, onRideTypeChange }: VideoRidePageProps) => {
     const [displayProps, setDisplayProps] = useState<VideoRidePageDisplayProps | null>(null);
+    const navigation = useNavigation();
 
     const refService = useRef<RidePageService | null>(null);
     const refObserver = useRef<IObserver | null>(null);
@@ -85,6 +87,11 @@ export const VideoRidePage = ({ simulate = false, onRideTypeChange }: VideoRideP
     const onRetryStart = useCallback(() => refService.current?.onRetryStart(), []);
     const onIgnoreStart = useCallback(() => refService.current?.onIgnoreStart(), []);
     const onCancelStart = useCallback(() => refService.current?.onCancelStart(), []);
+    
+    const onSettings = useCallback(() => {
+        navigation.navigate('settings' as never);
+    }, [navigation]);
+
     const styleEmpty = { flex: 1, backgroundColor: colors.background };
     if (!displayProps) {
         return (
@@ -106,6 +113,7 @@ export const VideoRidePage = ({ simulate = false, onRideTypeChange }: VideoRideP
             onRetryStart={onRetryStart}
             onIgnoreStart={onIgnoreStart}
             onCancelStart={onCancelStart}
+            onSettings={onSettings}
         />
     );
 };

--- a/src/pages/RidePage/Video/View.tsx
+++ b/src/pages/RidePage/Video/View.tsx
@@ -25,6 +25,7 @@ interface VideoRidePageViewProps {
     onRetryStart: () => void;
     onIgnoreStart: () => void;
     onCancelStart: () => void;
+    onSettings: () => void;
 }
 
 const noop = () => {};
@@ -44,7 +45,8 @@ export const VideoRidePageView = (props: VideoRidePageViewProps) => {
         onEndRide, 
         onRetryStart, 
         onIgnoreStart, 
-        onCancelStart 
+        onCancelStart,
+        onSettings
     } = props;
 
     const { video, videos, route, startOverlayProps, menuProps } = displayProps;
@@ -161,6 +163,7 @@ export const VideoRidePageView = (props: VideoRidePageViewProps) => {
                         onPause={onPause}
                         onResume={onResume}
                         onEndRide={onEndRide}
+                        onSettings={onSettings}
                     />
                 )}
             </View>

--- a/src/pages/RootNavigator/RootNavigator.tsx
+++ b/src/pages/RootNavigator/RootNavigator.tsx
@@ -8,6 +8,8 @@ import { RoutesPage } from '../RoutesPage/RoutesPage';
 import { RidePage } from '../RidePage'; // New import
 import { VideoDemoPage } from '../VideoDemo/RidePage';
 import { NotImplementedPage } from '../NotImplemented/NotImplementedPage';
+import { SettingsPage } from '../SettingsPage';
+import { SettingsPlaceholder } from '../SettingsPlaceholder';
 
 const Stack = createNativeStackNavigator();
 
@@ -24,7 +26,12 @@ export const RootNavigator = () => {
                 }}>
                 <Stack.Screen name="main" component={NotImplementedPage} />
                 <Stack.Screen name="user" component={NotImplementedPage} />
-                <Stack.Screen name="settings" component={NotImplementedPage} />
+                <Stack.Screen
+                    name="settings"
+                    component={SettingsPage}
+                    options={{ presentation: 'modal' }}
+                />
+                <Stack.Screen name="settingsPlaceholder" component={SettingsPlaceholder} />
                 <Stack.Screen name="search" component={RoutesPage} />
                 <Stack.Screen name="routes" component={RoutesPage} />
                 <Stack.Screen name="activities" component={ActivitiesPage} />

--- a/src/pages/SettingsPage/SettingsPage.stories.tsx
+++ b/src/pages/SettingsPage/SettingsPage.stories.tsx
@@ -1,9 +1,22 @@
+import React from 'react';
+import { useWindowDimensions, View } from 'react-native';
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { fn } from 'storybook/test';
 import { SettingsPageView } from './View';
 
 const meta: Meta<typeof SettingsPageView> = {
+    title: 'Pages/SettingsPage',
     component: SettingsPageView,
+    decorators: [
+        (Story) => {
+            const { width, height } = useWindowDimensions();
+            return (
+                <View style={{ width, height }}>
+                    <Story />
+                </View>
+            );
+        },
+    ],
     args: {
         onClose: fn(),
         sections: [

--- a/src/pages/SettingsPage/SettingsPage.stories.tsx
+++ b/src/pages/SettingsPage/SettingsPage.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { SettingsPageView } from './View';
+
+const meta: Meta<typeof SettingsPageView> = {
+    component: SettingsPageView,
+    args: {
+        onClose: fn(),
+        sections: [
+            { label: 'Gear', onPress: fn() },
+            { label: 'Ride', onPress: fn() },
+            { label: 'Apps', onPress: fn() },
+            { label: 'Support', onPress: fn() },
+        ],
+    },
+};
+
+export default meta;
+
+export const Default: StoryObj<typeof SettingsPageView> = {};

--- a/src/pages/SettingsPage/SettingsPage.tsx
+++ b/src/pages/SettingsPage/SettingsPage.tsx
@@ -14,7 +14,7 @@ export const SettingsPage = () => {
     }, [navigation, logEvent]);
 
     const handleSectionPress = useCallback((label: string) => {
-        logEvent({ message: 'button clicked', button: label, eventSource: 'user' });
+        logEvent({ message: 'menu item clicked', item: label, eventSource: 'user' });
         navigation.navigate('settingsPlaceholder' as never);
     }, [navigation, logEvent]);
 

--- a/src/pages/SettingsPage/SettingsPage.tsx
+++ b/src/pages/SettingsPage/SettingsPage.tsx
@@ -1,0 +1,34 @@
+import React, { useCallback, useMemo } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import { useLogging } from '../../hooks';
+import { SettingsPageView } from './View';
+import { SettingsSectionItem } from './types';
+
+export const SettingsPage = () => {
+    const navigation = useNavigation();
+    const { logEvent } = useLogging('SettingsPage');
+
+    const handleClose = useCallback(() => {
+        logEvent({ message: 'button clicked', button: 'close', eventSource: 'user' });
+        navigation.goBack();
+    }, [navigation, logEvent]);
+
+    const handleSectionPress = useCallback((label: string) => {
+        logEvent({ message: 'button clicked', button: label, eventSource: 'user' });
+        navigation.navigate('settingsPlaceholder' as never);
+    }, [navigation, logEvent]);
+
+    const sections: SettingsSectionItem[] = useMemo(() => [
+        { label: 'Gear', onPress: () => handleSectionPress('Gear') },
+        { label: 'Ride', onPress: () => handleSectionPress('Ride') },
+        { label: 'Apps', onPress: () => handleSectionPress('Apps') },
+        { label: 'Support', onPress: () => handleSectionPress('Support') },
+    ], [handleSectionPress]);
+
+    return (
+        <SettingsPageView
+            sections={sections}
+            onClose={handleClose}
+        />
+    );
+};

--- a/src/pages/SettingsPage/View.test.tsx
+++ b/src/pages/SettingsPage/View.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { SettingsPageView } from './View';
+import { SettingsSectionItem, SettingsPageViewProps } from './types';
+
+const MOCK_SECTIONS: SettingsSectionItem[] = [
+    { label: 'Gear', onPress: jest.fn() },
+    { label: 'Ride', onPress: jest.fn() },
+    { label: 'Apps', onPress: jest.fn() },
+    { label: 'Support', onPress: jest.fn() },
+];
+
+const MOCK_PROPS: SettingsPageViewProps = {
+    sections: MOCK_SECTIONS,
+    onClose: jest.fn(),
+};
+
+describe('SettingsPageView', () => {
+    it('renders all four section rows', () => {
+        const { getByText } = render(<SettingsPageView {...MOCK_PROPS} />);
+        expect(getByText('Gear')).toBeTruthy();
+        expect(getByText('Ride')).toBeTruthy();
+        expect(getByText('Apps')).toBeTruthy();
+        expect(getByText('Support')).toBeTruthy();
+    });
+
+    it('renders close button', () => {
+        const { getByText } = render(<SettingsPageView {...MOCK_PROPS} />);
+        expect(getByText('✕')).toBeTruthy();
+    });
+
+    it('tapping a section row calls its onPress', () => {
+        const { getByText } = render(<SettingsPageView {...MOCK_PROPS} />);
+        fireEvent.press(getByText('Gear'));
+        expect(MOCK_SECTIONS[0].onPress).toHaveBeenCalled();
+    });
+
+    it('tapping close calls onClose', () => {
+        const { getByText } = render(<SettingsPageView {...MOCK_PROPS} />);
+        fireEvent.press(getByText('✕'));
+        expect(MOCK_PROPS.onClose).toHaveBeenCalled();
+    });
+});

--- a/src/pages/SettingsPage/View.tsx
+++ b/src/pages/SettingsPage/View.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, FlatList } from 'react-native';
+import { colors, textSizes } from '../../theme';
+import { SettingsPageViewProps, SettingsSectionItem } from './types';
+
+export const SettingsPageView = ({ sections, onClose }: SettingsPageViewProps) => {
+    const renderItem = ({ item }: { item: SettingsSectionItem }) => (
+        <TouchableOpacity style={styles.row} onPress={item.onPress}>
+            <Text style={styles.label}>{item.label}</Text>
+            <Text style={styles.chevron}>›</Text>
+        </TouchableOpacity>
+    );
+
+    return (
+        <View style={styles.container}>
+            <View style={styles.header}>
+                <Text style={styles.title}>Settings</Text>
+                <TouchableOpacity onPress={onClose} style={styles.closeButton}>
+                    <Text style={styles.closeIcon}>✕</Text>
+                </TouchableOpacity>
+            </View>
+            <FlatList
+                data={sections}
+                renderItem={renderItem}
+                keyExtractor={(item) => item.label}
+                contentContainerStyle={styles.listContent}
+            />
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        backgroundColor: colors.background,
+    },
+    header: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        paddingHorizontal: 20,
+        paddingTop: 60,
+        paddingBottom: 20,
+        borderBottomWidth: 1,
+        borderBottomColor: colors.listSeparator,
+    },
+    title: {
+        color: colors.text,
+        fontSize: textSizes.pageTitle,
+        fontWeight: '600',
+    },
+    closeButton: {
+        padding: 5,
+    },
+    closeIcon: {
+        color: colors.text,
+        fontSize: textSizes.pageTitle,
+    },
+    listContent: {
+        paddingTop: 10,
+    },
+    row: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        paddingVertical: 20,
+        paddingHorizontal: 20,
+        borderBottomWidth: 1,
+        borderBottomColor: colors.listSeparator,
+    },
+    label: {
+        color: colors.text,
+        fontSize: textSizes.listEntry,
+    },
+    chevron: {
+        color: colors.text,
+        fontSize: textSizes.listEntry,
+    },
+});

--- a/src/pages/SettingsPage/index.ts
+++ b/src/pages/SettingsPage/index.ts
@@ -1,0 +1,2 @@
+export * from './SettingsPage';
+export * from './types';

--- a/src/pages/SettingsPage/types.ts
+++ b/src/pages/SettingsPage/types.ts
@@ -1,0 +1,9 @@
+export type SettingsSectionItem = {
+    label: string;
+    onPress: () => void;
+};
+
+export interface SettingsPageViewProps {
+    sections: SettingsSectionItem[];
+    onClose: () => void;
+}

--- a/src/pages/SettingsPlaceholder/SettingsPlaceholder.tsx
+++ b/src/pages/SettingsPlaceholder/SettingsPlaceholder.tsx
@@ -42,6 +42,6 @@ const styles = StyleSheet.create({
     },
     message: {
         color: colors.text,
-        fontSize: textSizes.pageTitle,
+        fontSize: textSizes.noDataText,
     },
 });

--- a/src/pages/SettingsPlaceholder/SettingsPlaceholder.tsx
+++ b/src/pages/SettingsPlaceholder/SettingsPlaceholder.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useLogging } from '../../hooks';
+import { colors, textSizes } from '../../theme';
+
+export const SettingsPlaceholder = () => {
+    const navigation = useNavigation();
+    const { logEvent } = useLogging('SettingsPlaceholder');
+
+    const handleBack = () => {
+        logEvent({ message: 'button clicked', button: 'back', eventSource: 'user' });
+        navigation.goBack();
+    };
+
+    return (
+        <View style={styles.container}>
+            <TouchableOpacity onPress={handleBack} style={styles.backButton}>
+                <Text style={styles.backButtonText}>‹</Text>
+            </TouchableOpacity>
+            <Text style={styles.message}>Not yet implemented</Text>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        backgroundColor: colors.background,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    backButton: {
+        position: 'absolute',
+        top: 60,
+        left: 20,
+        padding: 10,
+    },
+    backButtonText: {
+        color: colors.text,
+        fontSize: 40,
+    },
+    message: {
+        color: colors.text,
+        fontSize: textSizes.pageTitle,
+    },
+});

--- a/src/pages/SettingsPlaceholder/index.ts
+++ b/src/pages/SettingsPlaceholder/index.ts
@@ -1,0 +1,1 @@
+export * from './SettingsPlaceholder';

--- a/src/pages/VideoDemo/View.tsx
+++ b/src/pages/VideoDemo/View.tsx
@@ -223,7 +223,7 @@ const styles = StyleSheet.create({
         backgroundColor: colors.background, // Fallback background
     },
     videoBackground: {
-        ...StyleSheet.absoluteFillObject,
+        ...StyleSheet.absoluteFill,
         zIndex: 0, // Ensure video is behind other overlays
     },
     navColumn: {


### PR DESCRIPTION
Closes #42

This PR implements the Settings page shell as a modal and wires it into the app navigation and ride menu.

### Changes:
- Created `SettingsPage` (smart/view split) with sections for Gear, Ride, Apps, and Support.
- Created `SettingsPlaceholder` as a temporary destination for settings sections.
- Registered `SettingsPage` in `RootNavigator` with `presentation: 'modal'`.
- Registered `SettingsPlaceholder` in `RootNavigator`.
- Wired `onSettings` callback in `VideoRidePage` and passed it down to `RideMenu` via `VideoRidePageView`.
- Added comprehensive logging for settings interactions.
- Added Storybook stories and unit tests for the Settings view.