### PR TITLE
Implement Support settings sub-screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@sinonjs/text-encoding": "^0.7.3",
         "events": "^3.3.0",
         "gd-eventlog": "^0.1.27",
-        "incyclist-services": "^1.7.29",
+        "incyclist-services": "^1.7.30",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
         "react": "^19.2.4",
@@ -11622,9 +11622,9 @@
       }
     },
     "node_modules/incyclist-services": {
-      "version": "1.7.29",
-      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.29.tgz",
-      "integrity": "sha512-gMhe4poaIQMmLE6kHS+43rfhUcf1SxVzdZemSYawYcQ4SKCgY7cIPu0gZ3qhY3ppdfzpaAz4ApRSvOQES5OrmQ==",
+      "version": "1.7.30",
+      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.30.tgz",
+      "integrity": "sha512-JZ7t+fp2puh/erajXUiWuiZVLiCPZRVkWNL5Xw4a6GaA9dvvvoVoaU1V0203zr5HFh5NnbXytmlUPlI2erXHwA==",
       "dependencies": {
         "axios": "^1.13.6",
         "incyclist-devices": "^3.0.10",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@sinonjs/text-encoding": "^0.7.3",
     "events": "^3.3.0",
     "gd-eventlog": "^0.1.27",
-    "incyclist-services": "^1.7.29",
+    "incyclist-services": "^1.7.30",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "react": "^19.2.4",

--- a/src/pages/RootNavigator/RootNavigator.tsx
+++ b/src/pages/RootNavigator/RootNavigator.tsx
@@ -10,6 +10,7 @@ import { VideoDemoPage } from '../VideoDemo/RidePage';
 import { NotImplementedPage } from '../NotImplemented/NotImplementedPage';
 import { SettingsPage } from '../SettingsPage';
 import { SettingsPlaceholder } from '../SettingsPlaceholder';
+import { SupportSettingsPage } from '../SupportSettingsPage';
 
 const Stack = createNativeStackNavigator();
 
@@ -32,6 +33,7 @@ export const RootNavigator = () => {
                     options={{ presentation: 'modal' }}
                 />
                 <Stack.Screen name="settingsPlaceholder" component={SettingsPlaceholder} />
+                <Stack.Screen name="settingsSupport" component={SupportSettingsPage} />
                 <Stack.Screen name="search" component={RoutesPage} />
                 <Stack.Screen name="routes" component={RoutesPage} />
                 <Stack.Screen name="activities" component={ActivitiesPage} />

--- a/src/pages/SettingsPage/SettingsPage.tsx
+++ b/src/pages/SettingsPage/SettingsPage.tsx
@@ -15,7 +15,11 @@ export const SettingsPage = () => {
 
     const handleSectionPress = useCallback((label: string) => {
         logEvent({ message: 'menu item clicked', item: label, eventSource: 'user' });
-        navigation.navigate('settingsPlaceholder' as never);
+        if (label === 'Support') {
+            navigation.navigate('settingsSupport' as any);
+        } else {
+            navigation.navigate('settingsPlaceholder' as any);
+        }
     }, [navigation, logEvent]);
 
     const sections: SettingsSectionItem[] = useMemo(() => [

--- a/src/pages/SettingsPage/SettingsPage.tsx
+++ b/src/pages/SettingsPage/SettingsPage.tsx
@@ -16,9 +16,9 @@ export const SettingsPage = () => {
     const handleSectionPress = useCallback((label: string) => {
         logEvent({ message: 'menu item clicked', item: label, eventSource: 'user' });
         if (label === 'Support') {
-            navigation.navigate('settingsSupport' as any);
+            navigation.navigate('settingsSupport' as any as never);
         } else {
-            navigation.navigate('settingsPlaceholder' as any);
+            navigation.navigate('settingsPlaceholder' as any as never);
         }
     }, [navigation, logEvent]);
 

--- a/src/pages/SupportSettingsPage/SupportSettingsPage.stories.tsx
+++ b/src/pages/SupportSettingsPage/SupportSettingsPage.stories.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { View, useWindowDimensions } from 'react-native';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { SupportSettingsView } from './View';
+import { SupportSettingsDisplayProps } from 'incyclist-services';
+
+const MOCK_DISPLAY_PROPS: SupportSettingsDisplayProps = {
+    uuid: '1b4ff3d2-f602-4cc5-9d7b-a9f9444e5797',
+    appVersion: '0.9.14',
+    uiVersion: '26.3.6',
+    privacyUrl: 'https://incyclist.com/privacy',
+    supportUrls: [
+        { label: 'Slack', text: 'Incyclist Slack Workspace', url: 'https://slack.incyclist.com' },
+        { label: 'Strava', text: 'Incyclist Strava Club', url: 'https://strava.com/clubs/1029407' },
+        { label: 'Email', text: 'support@incyclist.com', url: 'mailto:support@incyclist.com' },
+    ],
+    gitHubUrl: 'https://github.com/incyclist',
+    donationUrl: 'https://www.paypal.com/paypalme/incyclist',
+};
+
+const meta: Meta<typeof SupportSettingsView> = {
+    title: 'Pages/SupportSettingsPage',
+    component: SupportSettingsView,
+    decorators: [
+        (Story) => {
+            const { width, height } = useWindowDimensions();
+            return (
+                <View style={{ width, height }}>
+                    <Story />
+                </View>
+            );
+        },
+    ],
+    args: {
+        onBack: fn(),
+        onShareUuid: fn(),
+        onOpenUrl: fn(),
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SupportSettingsView>;
+
+export const Default: Story = {
+    args: {
+        displayProps: MOCK_DISPLAY_PROPS,
+    },
+};
+
+export const Loading: Story = {
+    args: {
+        displayProps: null,
+    },
+};

--- a/src/pages/SupportSettingsPage/SupportSettingsPage.tsx
+++ b/src/pages/SupportSettingsPage/SupportSettingsPage.tsx
@@ -33,8 +33,8 @@ export const SupportSettingsPage = () => {
         logEvent({ message: 'button clicked', button: 'share uuid', eventSource: 'user' });
         try {
             await Share.share({ message: displayProps.uuid });
-        } catch (e) {
-            // share cancelled or failed - ignore
+        } catch (err:any) {
+            logEvent({message:'sharing cancelled or failed', reason:err.message})
         }
     }, [displayProps, logEvent]);
 

--- a/src/pages/SupportSettingsPage/SupportSettingsPage.tsx
+++ b/src/pages/SupportSettingsPage/SupportSettingsPage.tsx
@@ -1,0 +1,54 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { Share, Linking } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { SupportSettingsDisplayProps, useSupportSettingsDisplay } from 'incyclist-services';
+import { useLogging, useUnmountEffect } from '../../hooks';
+import { SupportSettingsView } from './View';
+
+export const SupportSettingsPage = () => {
+    const [displayProps, setDisplayProps] = useState<SupportSettingsDisplayProps | null>(null);
+    const refInitialized = useRef(false);
+    const service = useSupportSettingsDisplay();
+    const navigation = useNavigation();
+    const { logEvent } = useLogging('SupportSettingsPage');
+
+    useEffect(() => {
+        if (refInitialized.current) return;
+        service.open();
+        setDisplayProps(service.getDisplayProps());
+        refInitialized.current = true;
+    }, [service]);
+
+    useUnmountEffect(() => {
+        service.close();
+    });
+
+    const onBack = useCallback(() => {
+        logEvent({ message: 'button clicked', button: 'back', eventSource: 'user' });
+        navigation.goBack();
+    }, [navigation, logEvent]);
+
+    const onShareUuid = useCallback(async () => {
+        if (!displayProps) return;
+        logEvent({ message: 'button clicked', button: 'share uuid', eventSource: 'user' });
+        try {
+            await Share.share({ message: displayProps.uuid });
+        } catch (e) {
+            // share cancelled or failed - ignore
+        }
+    }, [displayProps, logEvent]);
+
+    const onOpenUrl = useCallback((url: string) => {
+        logEvent({ message: 'link clicked', url, eventSource: 'user' });
+        Linking.openURL(url);
+    }, [logEvent]);
+
+    return (
+        <SupportSettingsView
+            displayProps={displayProps}
+            onBack={onBack}
+            onShareUuid={onShareUuid}
+            onOpenUrl={onOpenUrl}
+        />
+    );
+};

--- a/src/pages/SupportSettingsPage/View.test.tsx
+++ b/src/pages/SupportSettingsPage/View.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { SupportSettingsView } from './View';
+import { SupportSettingsDisplayProps } from 'incyclist-services';
+
+const MOCK_DISPLAY_PROPS: SupportSettingsDisplayProps = {
+    uuid: '1b4ff3d2-f602-4cc5-9d7b-a9f9444e5797',
+    appVersion: '0.9.14',
+    uiVersion: '26.3.6',
+    privacyUrl: 'https://incyclist.com/privacy',
+    supportUrls: [
+        { label: 'Slack', text: 'Incyclist Slack Workspace', url: 'https://slack.incyclist.com' },
+    ],
+    gitHubUrl: 'https://github.com/incyclist',
+    donationUrl: 'https://www.paypal.com/paypalme/incyclist',
+};
+
+describe('SupportSettingsView', () => {
+    const defaultProps = {
+        displayProps: MOCK_DISPLAY_PROPS,
+        onBack: jest.fn(),
+        onShareUuid: jest.fn(),
+        onOpenUrl: jest.fn(),
+    };
+
+    it('renders with full display props', () => {
+        const { getByText } = render(<SupportSettingsView {...defaultProps} />);
+        expect(getByText('Support')).toBeTruthy();
+        expect(getByText('0.9.14')).toBeTruthy();
+        expect(getByText('1b4ff3d2-f602-4cc5-9d7b-a9f9444e5797')).toBeTruthy();
+        expect(getByText('Incyclist Slack Workspace')).toBeTruthy();
+    });
+
+    it('renders with displayProps={null} without crashing', () => {
+        const { getByText } = render(<SupportSettingsView {...defaultProps} displayProps={null} />);
+        expect(getByText('Support')).toBeTruthy();
+    });
+
+    it('tapping back calls onBack', () => {
+        const { getByText } = render(<SupportSettingsView {...defaultProps} />);
+        fireEvent.press(getByText('‹'));
+        expect(defaultProps.onBack).toHaveBeenCalled();
+    });
+
+    it('tapping Share UUID calls onShareUuid', () => {
+        const { getByText } = render(<SupportSettingsView {...defaultProps} />);
+        fireEvent.press(getByText('Share'));
+        expect(defaultProps.onShareUuid).toHaveBeenCalled();
+    });
+
+    it('tapping a support URL calls onOpenUrl with the correct URL', () => {
+        const { getByText } = render(<SupportSettingsView {...defaultProps} />);
+        fireEvent.press(getByText('Incyclist Slack Workspace'));
+        expect(defaultProps.onOpenUrl).toHaveBeenCalledWith('https://slack.incyclist.com');
+    });
+
+    it('tapping privacy calls onOpenUrl with privacyUrl', () => {
+        const { getByText } = render(<SupportSettingsView {...defaultProps} />);
+        fireEvent.press(getByText('Privacy Policy'));
+        expect(defaultProps.onOpenUrl).toHaveBeenCalledWith(MOCK_DISPLAY_PROPS.privacyUrl);
+    });
+});

--- a/src/pages/SupportSettingsPage/View.tsx
+++ b/src/pages/SupportSettingsPage/View.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, ScrollView } from 'react-native';
+import { colors, textSizes } from '../../theme';
+import { SupportSettingsViewProps } from './types';
+
+export const SupportSettingsView = ({
+    displayProps,
+    onBack,
+    onShareUuid,
+    onOpenUrl,
+}: SupportSettingsViewProps) => {
+    if (!displayProps) {
+        return (
+            <View style={styles.container}>
+                <View style={styles.header}>
+                    <TouchableOpacity onPress={onBack} style={styles.backButton}>
+                        <Text style={styles.backButtonText}>‹</Text>
+                    </TouchableOpacity>
+                    <Text style={styles.headerTitle}>Support</Text>
+                </View>
+            </View>
+        );
+    }
+
+    return (
+        <ScrollView style={styles.container} bounces={false}>
+            <View style={styles.header}>
+                <TouchableOpacity onPress={onBack} style={styles.backButton}>
+                    <Text style={styles.backButtonText}>‹</Text>
+                </TouchableOpacity>
+                <Text style={styles.headerTitle}>Support</Text>
+            </View>
+
+            <Text style={styles.sectionHeader}>App Info</Text>
+            <View style={styles.infoRow}>
+                <Text style={styles.infoLabel}>App Version</Text>
+                <Text style={styles.infoValue}>{displayProps.appVersion}</Text>
+            </View>
+            <View style={styles.infoRow}>
+                <Text style={styles.infoLabel}>UI Version</Text>
+                <Text style={styles.infoValue}>{displayProps.uiVersion}</Text>
+            </View>
+            <View style={styles.infoRow}>
+                <Text style={styles.infoLabel}>UUID</Text>
+                <View style={styles.uuidValueContainer}>
+                    <Text style={styles.infoValue} selectable={true}>
+                        {displayProps.uuid}
+                    </Text>
+                    <TouchableOpacity onPress={onShareUuid} style={styles.shareButton}>
+                        <Text style={styles.linkText}>Share</Text>
+                    </TouchableOpacity>
+                </View>
+            </View>
+            <View style={styles.infoRow}>
+                <Text style={styles.infoLabel}>Privacy</Text>
+                <TouchableOpacity onPress={() => onOpenUrl(displayProps.privacyUrl)}>
+                    <Text style={styles.linkText}>Privacy Policy</Text>
+                </TouchableOpacity>
+            </View>
+
+            <Text style={styles.sectionHeader}>Where can I get support?</Text>
+            {displayProps.supportUrls.map((item, index) => (
+                <View key={`${item.label}-${index}`} style={styles.infoRow}>
+                    <Text style={styles.infoLabel}>{item.label}</Text>
+                    <TouchableOpacity onPress={() => onOpenUrl(item.url)}>
+                        <Text style={styles.linkText}>{item.text}</Text>
+                    </TouchableOpacity>
+                </View>
+            ))}
+
+            <Text style={styles.sectionHeader}>How can I support?</Text>
+            <View style={styles.infoRow}>
+                <Text style={styles.infoLabel}>Coding</Text>
+                <TouchableOpacity onPress={() => onOpenUrl(displayProps.gitHubUrl)}>
+                    <Text style={styles.linkText}>GitHub</Text>
+                </TouchableOpacity>
+            </View>
+            <View style={styles.infoRow}>
+                <Text style={styles.infoLabel}>Donation</Text>
+                <TouchableOpacity onPress={() => onOpenUrl(displayProps.donationUrl)}>
+                    <Text style={styles.linkText}>Incyclist Paypal</Text>
+                </TouchableOpacity>
+            </View>
+            <Text style={styles.disclaimer}>
+                Donation is 100% voluntarily. Incyclist remains a 100% free app regardless of donation.
+                No freemium model is planned.
+            </Text>
+            <View style={styles.footerSpacer} />
+        </ScrollView>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        backgroundColor: colors.background,
+    },
+    header: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingHorizontal: 20,
+        paddingVertical: 16,
+        borderBottomWidth: 1,
+        borderBottomColor: colors.listSeparator,
+    },
+    backButton: {
+        marginRight: 16,
+        padding: 4,
+    },
+    backButtonText: {
+        color: colors.text,
+        fontSize: 32,
+        lineHeight: 36,
+    },
+    headerTitle: {
+        color: colors.text,
+        fontSize: textSizes.pageTitle,
+        fontWeight: '600',
+    },
+    sectionHeader: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        fontWeight: '700',
+        paddingHorizontal: 20,
+        paddingTop: 24,
+        paddingBottom: 8,
+    },
+    infoRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'flex-start',
+        paddingHorizontal: 20,
+        paddingVertical: 12,
+        borderBottomWidth: 1,
+        borderBottomColor: 'rgba(238, 238, 238, 0.1)',
+    },
+    infoLabel: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        flex: 1,
+    },
+    infoValue: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        textAlign: 'right',
+        flex: 2,
+    },
+    uuidValueContainer: {
+        flex: 3,
+        alignItems: 'flex-end',
+    },
+    shareButton: {
+        marginTop: 4,
+    },
+    linkText: {
+        color: colors.selected,
+        fontSize: textSizes.normalText,
+        textDecorationLine: 'underline',
+    },
+    disclaimer: {
+        color: colors.disabled,
+        fontSize: textSizes.smallText,
+        paddingHorizontal: 20,
+        paddingTop: 12,
+        lineHeight: 20,
+    },
+    footerSpacer: {
+        height: 40,
+    },
+});

--- a/src/pages/SupportSettingsPage/index.ts
+++ b/src/pages/SupportSettingsPage/index.ts
@@ -1,0 +1,1 @@
+export * from './SupportSettingsPage';

--- a/src/pages/SupportSettingsPage/types.ts
+++ b/src/pages/SupportSettingsPage/types.ts
@@ -1,0 +1,8 @@
+import { SupportSettingsDisplayProps } from 'incyclist-services';
+
+export interface SupportSettingsViewProps {
+    displayProps: SupportSettingsDisplayProps | null;
+    onBack: () => void;
+    onShareUuid: () => void;
+    onOpenUrl: (url: string) => void;
+}


### PR DESCRIPTION
Closes #44

Implemented the Support sub-screen in the Settings area following the smart/view split pattern. The screen provides app version info, support links, and contribution information with native sharing support for the UUID.

Key changes:
- Created `SupportSettingsPage` smart component.
- Created `SupportSettingsPageView` pure view component.
- Added Storybook stories and Jest tests for the view.
- Registered `'settingsSupport'` route in `RootNavigator`.
- Updated `SettingsPage` to navigate to the new support screen.
- Implemented logging for all interactions.