### PR TITLE
Add full variant to Dialog component

### DIFF
--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -114,3 +114,23 @@ export const NoButtons: Story = {
     },
 };
 
+export const FullVariant: Story = {
+    args: {
+        variant: 'full',
+        visible: true,
+        title: 'Settings',
+        buttons: [
+            { 
+                label: 'OK', 
+                onClick: fn(), 
+                primary: true
+            },
+        ],
+        children: (
+            <View style={{ padding: 10 }}>
+                <Text style={styles.text}>This is a full screen dialog variant.</Text>
+                <Text style={styles.text}>It features a side strip and a content area.</Text>
+            </View>
+        ),
+    },
+};

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { fn } from 'storybook/test';
-import {Dialog} from './Dialog';
+import { Dialog } from './Dialog';
 
 const styles = StyleSheet.create({
-    text: { color:'white',fontSize:16},
-    longText: { color:'white',fontSize:16, marginBottom: 15 },
-    container: { flex: 1, padding: 20, justifyContent: 'center', alignItems: 'center' }
-})
-
+    text: { color: 'white', fontSize: 16 },
+    longText: { color: 'white', fontSize: 16, marginBottom: 15 },
+    container: { flex: 1, padding: 20, justifyContent: 'center', alignItems: 'center' },
+    fullVariantContent: { padding: 10 },
+});
 
 const meta = {
     title: 'Components/Dialog',
@@ -31,15 +31,13 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-
-
 export const Basic: Story = {
     args: {
         visible: true,
         title: 'Basic Dialog',
         children: (
             <View>
-                <Text  style={styles.text}>This is a standard dialog with simple content.</Text>
+                <Text style={styles.text}>This is a standard dialog with simple content.</Text>
             </View>
         ),
     },
@@ -52,13 +50,11 @@ export const TitleStyle: Story = {
         titleStyle: { color: 'red' },
         children: (
             <View>
-                <Text  style={styles.text}>This is a standard dialog with simple content.</Text>
+                <Text style={styles.text}>This is a standard dialog with simple content.</Text>
             </View>
         ),
     },
 };
-
- 
 
 export const WithButtons: Story = {
     args: {
@@ -77,7 +73,7 @@ export const WithButtons: Story = {
         ],
         children: (
             <View>
-                <Text  style={styles.text}>Do you want to save the changes you made to your profile?</Text>
+                <Text style={styles.text}>Do you want to save the changes you made to your profile?</Text>
             </View>
         ),
     },
@@ -87,7 +83,7 @@ export const LongContent: Story = {
     args: {
         visible: true,
         title: 'Terms of Service',
-        buttons: [{ label: 'I Agree', onClick: fn(), primary:true }],
+        buttons: [{ label: 'I Agree', onClick: fn(), primary: true }],
         children: (
             <View>
                 {Array.from({ length: 5 }).map((_, i) => (
@@ -108,7 +104,7 @@ export const NoButtons: Story = {
         title: 'Information Only',
         children: (
             <View>
-                <Text  style={styles.text}>The button bar is automatically hidden because the buttons prop is undefined.</Text>
+                <Text style={styles.text}>The button bar is automatically hidden because the buttons prop is undefined.</Text>
             </View>
         ),
     },
@@ -127,7 +123,7 @@ export const FullVariant: Story = {
             },
         ],
         children: (
-            <View style={{ padding: 10 }}>
+            <View style={styles.fullVariantContent}>
                 <Text style={styles.text}>This is a full screen dialog variant.</Text>
                 <Text style={styles.text}>It features a side strip and a content area.</Text>
             </View>

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useEffect, useRef, useCallback } from 'react';
+import React, { PropsWithChildren, useEffect, useRef } from 'react';
 import { DialogProps, DialogVariant } from './types';
 import LinearGradient from 'react-native-linear-gradient';
 import { 

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useEffect, useRef } from 'react';
+import React, { PropsWithChildren, useEffect, useRef, useCallback } from 'react';
 import { DialogProps, DialogVariant } from './types';
 import LinearGradient from 'react-native-linear-gradient';
 import { 
@@ -9,12 +9,14 @@ import {
     TouchableWithoutFeedback, 
     Platform,
     ScrollView,
-    DimensionValue
+    DimensionValue,
+    TouchableOpacity
 } from 'react-native';
 import { ButtonBar } from '../ButtonBar';
 import { colors, textSizes } from '../../theme';
-import { useLogging, useUnmountEffect } from '../../hooks';
+import { useLogging, useUnmountEffect, useScreenLayout } from '../../hooks';
 import { EventLogger } from 'gd-eventlog';
+import { MainBackground } from '../MainBackground';
 
 export const Dialog = ({ 
     title, 
@@ -29,6 +31,7 @@ export const Dialog = ({
 
     const { logEvent } = useLogging('Incyclist');
     const refInitialized = useRef<boolean>(false);
+    const layout = useScreenLayout();
 
     useEffect(() => {
         if (refInitialized.current) return;
@@ -53,6 +56,57 @@ export const Dialog = ({
     const backgroundStyle = Platform.OS === 'web' 
         ? [styles.container, { backgroundColor: gradientColors[gradientColors.length - 1] }] 
         : styles.container;
+
+    const isCompact = layout === 'compact';
+    const stripWidth = isCompact ? 70 : 150;
+    const stripWidthStyle = { width: stripWidth };
+    const stripColorStyle = { backgroundColor: 'rgba(0,0,0,0.2)' };
+
+    if (variant === 'full') {
+        return (
+            <Modal
+                transparent={false}
+                visible={visible}
+                animationType="slide"
+                onRequestClose={onOutsideClick}
+            >
+                <View style={styles.fullScreenWrapper}>
+                    <View style={StyleSheet.absoluteFill}>
+                        <MainBackground />
+                    </View>
+                    <View style={styles.fullLayout}>
+                        <View style={[styles.strip, stripWidthStyle, stripColorStyle]}>
+                            <TouchableOpacity onPress={onOutsideClick} style={styles.backButton}>
+                                <Text style={styles.backIcon}>{'\u2039'}</Text>
+                            </TouchableOpacity>
+                        </View>
+                        <BackgroundContainer 
+                            colors={gradientColors} 
+                            style={[backgroundStyle, styles.fullContentArea, style]}
+                        >
+                            <View style={styles.header}>
+                                <Text style={[styles.title, titleStyle]}>{title}</Text>
+                            </View>
+                            
+                            <ScrollView 
+                                style={styles.scrollArea}
+                                contentContainerStyle={styles.content}
+                                bounces={false}
+                            >
+                                {children}
+                            </ScrollView>                                
+
+                            {buttons?.length ? (
+                                <View style={styles.footer}>
+                                    <ButtonBar buttons={buttons} />
+                                </View>
+                            ) : <></>}
+                        </BackgroundContainer>
+                    </View>
+                </View>
+            </Modal>
+        );
+    }
 
     return (
         <Modal
@@ -114,8 +168,8 @@ const getStyles = ({ width, height, minWidth, minHeight, variant = 'details' }: 
             minHeight: minHeight ?? (variant === 'details' ? '80%' : undefined),
             width,
             height,
-            maxHeight: '80%',
-            borderRadius: 8,
+            maxHeight: variant === 'full' ? '100%' : '80%',
+            borderRadius: variant === 'full' ? 0 : 8,
             overflow: 'hidden',
             color: colors.text
         },
@@ -133,13 +187,39 @@ const getStyles = ({ width, height, minWidth, minHeight, variant = 'details' }: 
             flexShrink: 1,
         },    
         content: {
-            flexGrow: variant === 'details' ? 1 : 0,
+            flexGrow: variant === 'details' || variant === 'full' ? 1 : 0,
             padding: 2,
             color: colors.text,
         },
         footer: {
             borderTopWidth: 1,
             borderTopColor: colors.dialogBorder ?? '#ccc',
+        },
+        fullScreenWrapper: {
+            flex: 1,
+        },
+        fullLayout: {
+            flex: 1,
+            flexDirection: 'row',
+        },
+        strip: {
+            height: '100%',
+            alignItems: 'center',
+            paddingTop: Platform.OS === 'ios' ? 40 : 10,
+        },
+        backButton: {
+            padding: 15,
+        },
+        backIcon: {
+            color: colors.text,
+            fontSize: 48,
+            fontWeight: '300',
+        },
+        fullContentArea: {
+            flex: 1,
+            height: '100%',
+            borderRadius: 0,
+            maxHeight: '100%',
         },
     });
 };

--- a/src/components/Dialog/types.ts
+++ b/src/components/Dialog/types.ts
@@ -1,7 +1,7 @@
 import { DimensionValue, StyleProp, TextStyle, ViewStyle } from 'react-native';
 import { ButtonProps } from '../ButtonBar/types';
 
-export type DialogVariant = 'info' | 'details'; // default: 'informational'
+export type DialogVariant = 'info' | 'details' | 'full'; // default: 'informational'
 
 export interface DialogProps {
     title: string;


### PR DESCRIPTION
Closes #49

This PR introduces a new `'full'` variant to the `Dialog` component, designed for settings and user profile screens. 

Key changes:
- Added `'full'` to `DialogVariant` type.
- Implemented the full-screen layout featuring a transparent navigation-style strip on the left and a gradient content area on the right.
- Integrated `MainBackground` as the base layer for the full-screen dialog.
- Added a back button (`‹`) in the left strip to handle dialog dismissal.
- Preserved existing behavior and styling for `'info'` and `'details'` variants.
- Added a `FullVariant` story to Storybook for visual verification.

## Manual Steps
- Verify the `'full'` variant in Storybook under `Components/Dialog/FullVariant`.