### PR TITLE
feat: Implement SettingsSlideIn component

### DIFF
--- a/src/components/SettingsSlideIn/SettingsSlideIn.stories.tsx
+++ b/src/components/SettingsSlideIn/SettingsSlideIn.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, useWindowDimensions } from 'react-native';
+import { View, useWindowDimensions, StyleSheet } from 'react-native';
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { fn } from 'storybook/test';
 import { SettingsSlideIn } from './SettingsSlideIn';
@@ -10,8 +10,9 @@ const meta: Meta<typeof SettingsSlideIn> = {
     decorators: [
         (Story) => {
             const { width, height } = useWindowDimensions();
+            const containerStyle = { width, height };
             return (
-                <View style={{ width, height, position: 'relative', backgroundColor: '#333' }}>
+                <View style={[styles.storyContainer, containerStyle]}>
                     <Story />
                 </View>
             );
@@ -47,3 +48,10 @@ export const Closed: Story = {
         sections: MOCK_SECTIONS,
     },
 };
+
+const styles = StyleSheet.create({
+    storyContainer: {
+        position: 'relative',
+        backgroundColor: '#333',
+    },
+});

--- a/src/components/SettingsSlideIn/SettingsSlideIn.stories.tsx
+++ b/src/components/SettingsSlideIn/SettingsSlideIn.stories.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { View, useWindowDimensions } from 'react-native';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { SettingsSlideIn } from './SettingsSlideIn';
+
+const meta: Meta<typeof SettingsSlideIn> = {
+    title: 'Components/SettingsSlideIn',
+    component: SettingsSlideIn,
+    decorators: [
+        (Story) => {
+            const { width, height } = useWindowDimensions();
+            return (
+                <View style={{ width, height, position: 'relative', backgroundColor: '#333' }}>
+                    <Story />
+                </View>
+            );
+        },
+    ],
+    args: {
+        onClose: fn(),
+        onSectionPress: fn(),
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SettingsSlideIn>;
+
+const MOCK_SECTIONS = [
+    { label: 'Gear', onPress: () => {} },
+    { label: 'Ride', onPress: () => {} },
+    { label: 'Apps', onPress: () => {} },
+    { label: 'Support', onPress: () => {} },
+];
+
+export const Open: Story = {
+    args: {
+        visible: true,
+        sections: MOCK_SECTIONS,
+    },
+};
+
+export const Closed: Story = {
+    args: {
+        visible: false,
+        sections: MOCK_SECTIONS,
+    },
+};

--- a/src/components/SettingsSlideIn/SettingsSlideIn.test.tsx
+++ b/src/components/SettingsSlideIn/SettingsSlideIn.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { SettingsSlideIn } from './SettingsSlideIn';
+import { SettingsSectionItem } from '../../pages/SettingsPage/types';
+
+const MOCK_SECTIONS: SettingsSectionItem[] = [
+    { label: 'Gear',    onPress: jest.fn() },
+    { label: 'Ride',    onPress: jest.fn() },
+    { label: 'Apps',    onPress: jest.fn() },
+    { label: 'Support', onPress: jest.fn() },
+];
+
+describe('SettingsSlideIn', () => {
+    it('renders null when visible=false and animation complete', () => {
+        const { queryByTestID } = render(
+            <SettingsSlideIn 
+                visible={false} 
+                sections={MOCK_SECTIONS} 
+                onClose={jest.fn()} 
+                onSectionPress={jest.fn()} 
+            />
+        );
+        expect(queryByTestID('settings-slide-in')).toBeNull();
+    });
+
+    it('renders section rows when visible=true', () => {
+        const { getByText } = render(
+            <SettingsSlideIn 
+                visible={true} 
+                sections={MOCK_SECTIONS} 
+                onClose={jest.fn()} 
+                onSectionPress={jest.fn()} 
+            />
+        );
+        
+        expect(getByText('Gear')).toBeTruthy();
+        expect(getByText('Ride')).toBeTruthy();
+        expect(getByText('Apps')).toBeTruthy();
+        expect(getByText('Support')).toBeTruthy();
+    });
+
+    it('tapping a section row calls onSectionPress with the correct label', () => {
+        const onSectionPress = jest.fn();
+        const { getByTestID } = render(
+            <SettingsSlideIn 
+                visible={true} 
+                sections={MOCK_SECTIONS} 
+                onClose={jest.fn()} 
+                onSectionPress={onSectionPress} 
+            />
+        );
+
+        fireEvent.press(getByTestID('section-Gear'));
+        expect(onSectionPress).toHaveBeenCalledWith('Gear');
+    });
+
+    it('tapping the backdrop calls onClose', () => {
+        const onClose = jest.fn();
+        const { getByTestID } = render(
+            <SettingsSlideIn 
+                visible={true} 
+                sections={MOCK_SECTIONS} 
+                onClose={onClose} 
+                onSectionPress={jest.fn()} 
+            />
+        );
+
+        fireEvent.press(getByTestID('settings-backdrop'));
+        expect(onClose).toHaveBeenCalled();
+    });
+});

--- a/src/components/SettingsSlideIn/SettingsSlideIn.test.tsx
+++ b/src/components/SettingsSlideIn/SettingsSlideIn.test.tsx
@@ -12,7 +12,7 @@ const MOCK_SECTIONS: SettingsSectionItem[] = [
 
 describe('SettingsSlideIn', () => {
     it('renders null when visible=false and animation complete', () => {
-        const { queryByTestID } = render(
+        const { queryByTestId } = render(
             <SettingsSlideIn 
                 visible={false} 
                 sections={MOCK_SECTIONS} 
@@ -20,7 +20,7 @@ describe('SettingsSlideIn', () => {
                 onSectionPress={jest.fn()} 
             />
         );
-        expect(queryByTestID('settings-slide-in')).toBeNull();
+        expect(queryByTestId('settings-slide-in')).toBeNull();
     });
 
     it('renders section rows when visible=true', () => {
@@ -41,7 +41,7 @@ describe('SettingsSlideIn', () => {
 
     it('tapping a section row calls onSectionPress with the correct label', () => {
         const onSectionPress = jest.fn();
-        const { getByTestID } = render(
+        const { getByTestId } = render(
             <SettingsSlideIn 
                 visible={true} 
                 sections={MOCK_SECTIONS} 
@@ -50,13 +50,13 @@ describe('SettingsSlideIn', () => {
             />
         );
 
-        fireEvent.press(getByTestID('section-Gear'));
+        fireEvent.press(getByTestId('section-Gear'));
         expect(onSectionPress).toHaveBeenCalledWith('Gear');
     });
 
     it('tapping the backdrop calls onClose', () => {
         const onClose = jest.fn();
-        const { getByTestID } = render(
+        const { getByTestId } = render(
             <SettingsSlideIn 
                 visible={true} 
                 sections={MOCK_SECTIONS} 
@@ -65,7 +65,7 @@ describe('SettingsSlideIn', () => {
             />
         );
 
-        fireEvent.press(getByTestID('settings-backdrop'));
+        fireEvent.press(getByTestId('settings-backdrop'));
         expect(onClose).toHaveBeenCalled();
     });
 });

--- a/src/components/SettingsSlideIn/SettingsSlideIn.tsx
+++ b/src/components/SettingsSlideIn/SettingsSlideIn.tsx
@@ -14,8 +14,8 @@ import { SettingsSlideInProps } from './types';
 import { colors, textSizes } from '../../theme';
 import { useLogging } from '../../hooks';
 
-const gradientColors = colors.dialogBackground as string[];
-const BackgroundContainer = Platform.OS === 'web' ? View : LinearGradient;
+const gradientColors = colors.dialogBackground;
+const BackgroundContainer = Platform.OS === 'web' ? View : (LinearGradient as any);
 const panelBackgroundStyle = Platform.OS === 'web'
     ? { backgroundColor: gradientColors[gradientColors.length - 1] }
     : { flex: 1 };
@@ -37,16 +37,22 @@ export const SettingsSlideIn = ({
     // Track animation state to handle backdrop visibility and pointer events
     const [isAnimating, setIsAnimating] = useState(false);
     const [isFullyClosed, setIsFullyClosed] = useState(!visible);
+    const hasMountedRef = useRef(false);
 
     useEffect(() => {
+        if (!hasMountedRef.current) {
+            hasMountedRef.current = true;
+            if (!visible) {
+                return;
+            }
+        }
+
         const targetValue = visible ? 0 : -panelWidth;
         
         if (visible) {
             setIsFullyClosed(false);
-            setIsAnimating(true);
-        } else {
-            setIsAnimating(true);
         }
+        setIsAnimating(true);
 
         Animated.timing(animTranslateX, {
             toValue: targetValue,
@@ -99,7 +105,7 @@ export const SettingsSlideIn = ({
                 ]}
             >
                 <BackgroundContainer
-                    {...(Platform.OS !== 'web' ? { colors: gradientColors } : {})}
+                    colors={gradientColors}
                     style={panelBackgroundStyle}
                 >
                     <View style={styles.content}>

--- a/src/components/SettingsSlideIn/SettingsSlideIn.tsx
+++ b/src/components/SettingsSlideIn/SettingsSlideIn.tsx
@@ -7,11 +7,18 @@ import {
     TouchableOpacity,
     TouchableWithoutFeedback,
     useWindowDimensions,
-    LayoutChangeEvent
+    Platform
 } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
 import { SettingsSlideInProps } from './types';
 import { colors, textSizes } from '../../theme';
 import { useLogging } from '../../hooks';
+
+const gradientColors = colors.dialogBackground as string[];
+const BackgroundContainer = Platform.OS === 'web' ? View : LinearGradient;
+const panelBackgroundStyle = Platform.OS === 'web'
+    ? { backgroundColor: gradientColors[gradientColors.length - 1] }
+    : { flex: 1 };
 
 export const SettingsSlideIn = ({
     visible,
@@ -91,19 +98,24 @@ export const SettingsSlideIn = ({
                     },
                 ]}
             >
-                <View style={styles.content}>
-                    {sections.map((section) => (
-                        <TouchableOpacity 
-                            key={section.label}
-                            style={styles.row} 
-                            onPress={() => handleSectionPress(section.label)}
-                            testID={`section-${section.label}`}
-                        >
-                            <Text style={styles.label}>{section.label}</Text>
-                            <Text style={styles.chevron}>›</Text>
-                        </TouchableOpacity>
-                    ))}
-                </View>
+                <BackgroundContainer
+                    {...(Platform.OS !== 'web' ? { colors: gradientColors } : {})}
+                    style={panelBackgroundStyle}
+                >
+                    <View style={styles.content}>
+                        {sections.map((section) => (
+                            <TouchableOpacity 
+                                key={section.label}
+                                style={styles.row} 
+                                onPress={() => handleSectionPress(section.label)}
+                                testID={`section-${section.label}`}
+                            >
+                                <Text style={styles.label}>{section.label}</Text>
+                                <Text style={styles.chevron}>›</Text>
+                            </TouchableOpacity>
+                        ))}
+                    </View>
+                </BackgroundContainer>
             </Animated.View>
         </View>
     );
@@ -119,7 +131,6 @@ const styles = StyleSheet.create({
         left: 0,
         top: 0,
         bottom: 0,
-        backgroundColor: 'rgba(0, 0, 0, 0.88)',
         zIndex: 1000,
     },
     content: {

--- a/src/components/SettingsSlideIn/SettingsSlideIn.tsx
+++ b/src/components/SettingsSlideIn/SettingsSlideIn.tsx
@@ -1,0 +1,146 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+    View,
+    Text,
+    StyleSheet,
+    Animated,
+    TouchableOpacity,
+    TouchableWithoutFeedback,
+    useWindowDimensions,
+    LayoutChangeEvent
+} from 'react-native';
+import { SettingsSlideInProps } from './types';
+import { colors, textSizes } from '../../theme';
+import { useLogging } from '../../hooks';
+
+export const SettingsSlideIn = ({
+    visible,
+    sections,
+    onClose,
+    onSectionPress
+}: SettingsSlideInProps) => {
+    const { width: screenWidth } = useWindowDimensions();
+    const { logEvent } = useLogging('SettingsSlideIn');
+
+    const panelWidth = screenWidth * 0.35;
+    
+    // Start off-screen (left)
+    const animTranslateX = useRef(new Animated.Value(-panelWidth)).current;
+    
+    // Track animation state to handle backdrop visibility and pointer events
+    const [isAnimating, setIsAnimating] = useState(false);
+    const [isFullyClosed, setIsFullyClosed] = useState(!visible);
+
+    useEffect(() => {
+        const targetValue = visible ? 0 : -panelWidth;
+        
+        if (visible) {
+            setIsFullyClosed(false);
+            setIsAnimating(true);
+        } else {
+            setIsAnimating(true);
+        }
+
+        Animated.timing(animTranslateX, {
+            toValue: targetValue,
+            duration: 220,
+            useNativeDriver: true,
+        }).start(() => {
+            setIsAnimating(false);
+            if (!visible) {
+                setIsFullyClosed(true);
+            }
+        });
+    }, [visible, animTranslateX, panelWidth]);
+
+    const handleSectionPress = (label: string) => {
+        logEvent({ message: 'menu item clicked', item: label, eventSource: 'user' });
+        onSectionPress(label);
+    };
+
+    // If fully closed and not animating, don't show the backdrop/content
+    if (isFullyClosed && !isAnimating) {
+        return null;
+    }
+
+    const backdropPointerEvents = visible ? 'auto' : 'none';
+    const backdropOpacity = visible ? 1 : 0;
+
+    return (
+        <View 
+            style={StyleSheet.absoluteFill} 
+            pointerEvents={visible || isAnimating ? 'box-none' : 'none'}
+            testID="settings-slide-in"
+        >
+            {/* Backdrop */}
+            <TouchableWithoutFeedback onPress={onClose}>
+                <View 
+                    style={[styles.backdrop, { opacity: backdropOpacity }]} 
+                    pointerEvents={backdropPointerEvents} 
+                    testID="settings-backdrop"
+                />
+            </TouchableWithoutFeedback>
+
+            {/* Side Panel */}
+            <Animated.View
+                style={[
+                    styles.panel,
+                    { 
+                        width: panelWidth, 
+                        transform: [{ translateX: animTranslateX }] 
+                    },
+                ]}
+            >
+                <View style={styles.content}>
+                    {sections.map((section) => (
+                        <TouchableOpacity 
+                            key={section.label}
+                            style={styles.row} 
+                            onPress={() => handleSectionPress(section.label)}
+                            testID={`section-${section.label}`}
+                        >
+                            <Text style={styles.label}>{section.label}</Text>
+                            <Text style={styles.chevron}>›</Text>
+                        </TouchableOpacity>
+                    ))}
+                </View>
+            </Animated.View>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    backdrop: {
+        ...StyleSheet.absoluteFill,
+        backgroundColor: 'rgba(0,0,0,0.4)',
+    },
+    panel: {
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        bottom: 0,
+        backgroundColor: 'rgba(0, 0, 0, 0.88)',
+        zIndex: 1000,
+    },
+    content: {
+        flex: 1,
+        paddingTop: 20,
+    },
+    row: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        paddingVertical: 20,
+        paddingHorizontal: 20,
+        borderBottomWidth: 1,
+        borderBottomColor: 'rgba(255,255,255,0.15)',
+    },
+    label: {
+        color: colors.text,
+        fontSize: textSizes.listEntry,
+    },
+    chevron: {
+        color: colors.text,
+        fontSize: textSizes.listEntry,
+    },
+});

--- a/src/components/SettingsSlideIn/index.ts
+++ b/src/components/SettingsSlideIn/index.ts
@@ -1,0 +1,2 @@
+export * from './SettingsSlideIn';
+export * from './types';

--- a/src/components/SettingsSlideIn/types.ts
+++ b/src/components/SettingsSlideIn/types.ts
@@ -1,0 +1,8 @@
+import { SettingsSectionItem } from '../../pages/SettingsPage/types';
+
+export interface SettingsSlideInProps {
+    visible: boolean;
+    sections: SettingsSectionItem[];
+    onClose: () => void;
+    onSectionPress: (label: string) => void;
+}


### PR DESCRIPTION
Closes #51

Implemented the `SettingsSlideIn` component with the following features:
- Animated slide-in from the left using `translateX` (220ms).
- Semi-transparent backdrop with `onClose` callback.
- List of settings sections with styling matching the Settings page.
- Logging for section item clicks.
- Full Storybook coverage and Jest tests.