### PR TITLE
Update RouteDetailsDialog and UserSettingsDialog to variant 'full'

### DIFF
--- a/src/components/RouteDetailsDialog/RouteDetailsView.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.tsx
@@ -269,7 +269,7 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
         const showCompactPanel = (hasGpx && !!points?.length) || !!previewUrl;
 
         return (
-            <Dialog title={title} buttons={dialogButtons} onOutsideClick={onCancel}>
+            <Dialog title={title} variant="full" buttons={dialogButtons} onOutsideClick={onCancel}>
                 <View style={styles.compactRoot}>
                     <View style={styles.compactLeft}>
                         {renderForm()}
@@ -291,7 +291,7 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
     }
 
     return (
-        <Dialog title={title} buttons={dialogButtons} onOutsideClick={onCancel}>
+        <Dialog title={title} variant="full" buttons={dialogButtons} onOutsideClick={onCancel}>
             <View style={styles.mediaRow}>
                 <View style={styles.mediaContainer}>{renderMedia()}</View>
                 <View style={styles.mediaContainer}>{renderPreview()}</View>

--- a/src/components/UserSettingsDialog/UserSettingsDialogView.tsx
+++ b/src/components/UserSettingsDialog/UserSettingsDialogView.tsx
@@ -23,7 +23,7 @@ export const UserSettingsDialogView = ({ displayProps, onClose }: UserSettingsDi
     return (
         <Dialog
             title="User Settings"
-            variant="details"
+            variant="full"
             visible={true}
             onOutsideClick={onClose}
             buttons={[{ label: 'OK', primary: true, onClick: onClose }]}


### PR DESCRIPTION
Closes #54

Updates `UserSettingsDialogView` and `RouteDetailsView` to use `variant='full'` for the `Dialog` component. This provides a better layout for these content-heavy dialogs, utilizing the full-screen layout with the background visible behind the navigation bar.