### PR TITLE
Wire SettingsSlideIn into NavigationBar

### DIFF
--- a/src/components/NavigationBar/NavigationBar.stories.tsx
+++ b/src/components/NavigationBar/NavigationBar.stories.tsx
@@ -39,3 +39,13 @@ export const Compact: Story = {
         selected: 'activities',
     }
 };
+
+export const SettingsOpen: Story = {
+    args: {
+        showBackOnly: true,
+        compact: false,
+        iconSize: 40,
+        navWidth: 150,
+        showExit: false,
+    }
+};

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -1,13 +1,17 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import { useWindowDimensions, Platform } from 'react-native';
 import { NavigationBarProps, TNavigationItem } from './types';
 import { NavigationBarView } from './NavigationBarView';
 import { UserSettingsDialog } from '../UserSettingsDialog';
+import { SettingsSlideIn } from '../SettingsSlideIn';
+import { navigate } from '../../services';
+import { SettingsSectionItem } from '../../pages/SettingsPage/types';
 
 export const NavigationBar = (props: NavigationBarProps) => {
     const { selected, onClick, compact } = props;
     const { height } = useWindowDimensions();
     const [showUserSettings, setShowUserSettings] = useState(false);
+    const [showSettings, setShowSettings] = useState(false);
 
     const iconSize = compact ? 32 : Math.min(height / 16, 64);
     const navWidth = compact ? 70 : 150;
@@ -16,10 +20,31 @@ export const NavigationBar = (props: NavigationBarProps) => {
     const handleOnClick = (item: TNavigationItem) => {
         if (item === 'user') {
             setShowUserSettings(true);
+        } else if (item === 'settings') {
+            setShowSettings(true);
         } else {
             onClick(item);
         }
     };
+
+    const handleSectionPress = useCallback((label: string) => {
+        setShowSettings(false);
+        switch (label) {
+            case 'Support':
+                navigate('settingsSupport');
+                break;
+            default:
+                navigate('settingsPlaceholder');
+                break;
+        }
+    }, []);
+
+    const sections: SettingsSectionItem[] = useMemo(() => [
+        { label: 'Gear', onPress: () => handleSectionPress('Gear') },
+        { label: 'Ride', onPress: () => handleSectionPress('Ride') },
+        { label: 'Apps', onPress: () => handleSectionPress('Apps') },
+        { label: 'Support', onPress: () => handleSectionPress('Support') },
+    ], [handleSectionPress]);
 
     return (
         <>
@@ -30,10 +55,18 @@ export const NavigationBar = (props: NavigationBarProps) => {
                 iconSize={iconSize}
                 navWidth={navWidth}
                 showExit={showExit}
+                showBackOnly={showSettings}
+                onBack={() => setShowSettings(false)}
             />
             {showUserSettings && (
                 <UserSettingsDialog onClose={() => setShowUserSettings(false)} />
             )}
+            <SettingsSlideIn
+                visible={showSettings}
+                sections={sections}
+                onClose={() => setShowSettings(false)}
+                onSectionPress={handleSectionPress}
+            />
         </>
     );
 };

--- a/src/components/NavigationBar/NavigationBarView.test.tsx
+++ b/src/components/NavigationBar/NavigationBarView.test.tsx
@@ -27,4 +27,18 @@ describe('NavigationBarView', () => {
         );
         expect(toJSON()).toBeDefined();
     });
+
+    it('renders in back-only mode', () => {
+        const { getByText } = render(
+            <NavigationBarView 
+                onClick={jest.fn()} 
+                iconSize={32} 
+                navWidth={70} 
+                showExit={true}
+                showBackOnly={true}
+                onBack={jest.fn()}
+            />
+        );
+        expect(getByText('‹')).toBeDefined();
+    });
 });

--- a/src/components/NavigationBar/NavigationBarView.tsx
+++ b/src/components/NavigationBar/NavigationBarView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, Text, TouchableOpacity } from 'react-native';
 import { NavigationBarViewProps, TNavigationItem } from './types';
 import { NavigationItem } from './NavigationItem';
 import { navigationItemsMiddle } from './utils';
@@ -17,7 +17,28 @@ import {
 import { colors } from '../../theme';
 
 export const NavigationBarView = (props: NavigationBarViewProps) => {
-    const { selected, onClick, compact, iconSize, navWidth, showExit } = props;
+    const { 
+        selected, 
+        onClick, 
+        compact, 
+        iconSize, 
+        navWidth, 
+        showExit,
+        showBackOnly,
+        onBack 
+    } = props;
+
+    if (showBackOnly) {
+        return (
+            <View style={[styles.container, { width: navWidth }]}>
+                <View style={styles.top}>
+                    <TouchableOpacity onPress={onBack} style={styles.backButton}>
+                        <Text style={styles.backIcon}>‹</Text>
+                    </TouchableOpacity>
+                </View>
+            </View>
+        );
+    }
 
     const renderIcon = (item: TNavigationItem, isSelected: boolean) => {
         const color = isSelected ? colors.iconSelected : colors.icon;
@@ -103,5 +124,16 @@ const styles = StyleSheet.create({
         justifyContent: 'center',
         alignItems: 'center',
         width: '100%',
+    },
+    backButton: {
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+        paddingVertical: 10,
+    },
+    backIcon: {
+        fontSize: 32,
+        lineHeight: 36,
+        color: colors.text,
     },
 });

--- a/src/components/NavigationBar/types.ts
+++ b/src/components/NavigationBar/types.ts
@@ -21,4 +21,6 @@ export interface NavigationBarViewProps {
     iconSize: number;
     navWidth: number;
     showExit: boolean;
+    showBackOnly?: boolean;
+    onBack?: () => void;
 }


### PR DESCRIPTION
Closes #53

This PR integrates the `SettingsSlideIn` component into the `NavigationBar` smart component.

### Key Changes:
- Added `showSettings` state to `NavigationBar` to control the visibility of the settings slide-in.
- Updated `NavigationBarView` to support a `showBackOnly` mode which renders a single back button (`‹`) instead of the full navigation list.
- Tapping 'settings' now triggers the slide-in and toggles the NavBar to back-only mode.
- Implemented navigation logic for settings sections ('Gear', 'Ride', 'Apps', 'Support') using the service layer `navigate` function.
- Added unit tests and a Storybook story for the new back-only mode.