### PR TITLE
Refactor SupportSettingsPage to use Dialog variant 'full'

### DIFF
--- a/src/pages/SupportSettingsPage/SupportSettingsPage.stories.tsx
+++ b/src/pages/SupportSettingsPage/SupportSettingsPage.stories.tsx
@@ -33,7 +33,7 @@ const meta: Meta<typeof SupportSettingsView> = {
         },
     ],
     args: {
-        onBack: fn(),
+        onClose: fn(),
         onShareUuid: fn(),
         onOpenUrl: fn(),
     },

--- a/src/pages/SupportSettingsPage/SupportSettingsPage.tsx
+++ b/src/pages/SupportSettingsPage/SupportSettingsPage.tsx
@@ -23,7 +23,7 @@ export const SupportSettingsPage = () => {
         service.close();
     });
 
-    const onBack = useCallback(() => {
+    const onClose = useCallback(() => {
         logEvent({ message: 'button clicked', button: 'back', eventSource: 'user' });
         navigation.goBack();
     }, [navigation, logEvent]);
@@ -33,8 +33,8 @@ export const SupportSettingsPage = () => {
         logEvent({ message: 'button clicked', button: 'share uuid', eventSource: 'user' });
         try {
             await Share.share({ message: displayProps.uuid });
-        } catch (err:any) {
-            logEvent({message:'sharing cancelled or failed', reason:err.message})
+        } catch (err: any) {
+            logEvent({ message: 'sharing cancelled or failed', reason: err.message });
         }
     }, [displayProps, logEvent]);
 
@@ -46,7 +46,7 @@ export const SupportSettingsPage = () => {
     return (
         <SupportSettingsView
             displayProps={displayProps}
-            onBack={onBack}
+            onClose={onClose}
             onShareUuid={onShareUuid}
             onOpenUrl={onOpenUrl}
         />

--- a/src/pages/SupportSettingsPage/View.test.tsx
+++ b/src/pages/SupportSettingsPage/View.test.tsx
@@ -18,7 +18,7 @@ const MOCK_DISPLAY_PROPS: SupportSettingsDisplayProps = {
 describe('SupportSettingsView', () => {
     const defaultProps = {
         displayProps: MOCK_DISPLAY_PROPS,
-        onBack: jest.fn(),
+        onClose: jest.fn(),
         onShareUuid: jest.fn(),
         onOpenUrl: jest.fn(),
     };
@@ -36,10 +36,10 @@ describe('SupportSettingsView', () => {
         expect(getByText('Support')).toBeTruthy();
     });
 
-    it('tapping back calls onBack', () => {
+    it('tapping back calls onClose', () => {
         const { getByText } = render(<SupportSettingsView {...defaultProps} />);
         fireEvent.press(getByText('‹'));
-        expect(defaultProps.onBack).toHaveBeenCalled();
+        expect(defaultProps.onClose).toHaveBeenCalled();
     });
 
     it('tapping Share UUID calls onShareUuid', () => {

--- a/src/pages/SupportSettingsPage/View.tsx
+++ b/src/pages/SupportSettingsPage/View.tsx
@@ -1,122 +1,86 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, ScrollView } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { colors, textSizes } from '../../theme';
 import { SupportSettingsViewProps } from './types';
+import { Dialog } from '../../components/Dialog';
 
 export const SupportSettingsView = ({
     displayProps,
-    onBack,
+    onClose,
     onShareUuid,
     onOpenUrl,
 }: SupportSettingsViewProps) => {
-    if (!displayProps) {
-        return (
-            <View style={styles.container}>
-                <View style={styles.header}>
-                    <TouchableOpacity onPress={onBack} style={styles.backButton}>
-                        <Text style={styles.backButtonText}>‹</Text>
-                    </TouchableOpacity>
-                    <Text style={styles.headerTitle}>Support</Text>
-                </View>
-            </View>
-        );
-    }
-
     return (
-        <ScrollView style={styles.container} bounces={false}>
-            <View style={styles.header}>
-                <TouchableOpacity onPress={onBack} style={styles.backButton}>
-                    <Text style={styles.backButtonText}>‹</Text>
-                </TouchableOpacity>
-                <Text style={styles.headerTitle}>Support</Text>
-            </View>
+        <Dialog
+            title="Support"
+            variant="full"
+            visible={true}
+            onOutsideClick={onClose}
+        >
+            {displayProps && (
+                <>
+                    <Text style={styles.sectionHeader}>App Info</Text>
+                    <View style={styles.infoRow}>
+                        <Text style={styles.infoLabel}>App Version</Text>
+                        <Text style={styles.infoValue}>{displayProps.appVersion}</Text>
+                    </View>
+                    <View style={styles.infoRow}>
+                        <Text style={styles.infoLabel}>UI Version</Text>
+                        <Text style={styles.infoValue}>{displayProps.uiVersion}</Text>
+                    </View>
+                    <View style={styles.infoRow}>
+                        <Text style={styles.infoLabel}>UUID</Text>
+                        <View style={styles.uuidValueContainer}>
+                            <Text style={styles.infoValue} selectable={true}>
+                                {displayProps.uuid}
+                            </Text>
+                            <TouchableOpacity onPress={onShareUuid} style={styles.shareButton}>
+                                <Text style={styles.linkText}>Share</Text>
+                            </TouchableOpacity>
+                        </View>
+                    </View>
+                    <View style={styles.infoRow}>
+                        <Text style={styles.infoLabel}>Privacy</Text>
+                        <TouchableOpacity onPress={() => onOpenUrl(displayProps.privacyUrl)}>
+                            <Text style={styles.linkText}>Privacy Policy</Text>
+                        </TouchableOpacity>
+                    </View>
 
-            <Text style={styles.sectionHeader}>App Info</Text>
-            <View style={styles.infoRow}>
-                <Text style={styles.infoLabel}>App Version</Text>
-                <Text style={styles.infoValue}>{displayProps.appVersion}</Text>
-            </View>
-            <View style={styles.infoRow}>
-                <Text style={styles.infoLabel}>UI Version</Text>
-                <Text style={styles.infoValue}>{displayProps.uiVersion}</Text>
-            </View>
-            <View style={styles.infoRow}>
-                <Text style={styles.infoLabel}>UUID</Text>
-                <View style={styles.uuidValueContainer}>
-                    <Text style={styles.infoValue} selectable={true}>
-                        {displayProps.uuid}
+                    <Text style={styles.sectionHeader}>Where can I get support?</Text>
+                    {displayProps.supportUrls.map((item, index) => (
+                        <View key={`${item.label}-${index}`} style={styles.infoRow}>
+                            <Text style={styles.infoLabel}>{item.label}</Text>
+                            <TouchableOpacity onPress={() => onOpenUrl(item.url)}>
+                                <Text style={styles.linkText}>{item.text}</Text>
+                            </TouchableOpacity>
+                        </View>
+                    ))}
+
+                    <Text style={styles.sectionHeader}>How can I support?</Text>
+                    <View style={styles.infoRow}>
+                        <Text style={styles.infoLabel}>Coding</Text>
+                        <TouchableOpacity onPress={() => onOpenUrl(displayProps.gitHubUrl)}>
+                            <Text style={styles.linkText}>GitHub</Text>
+                        </TouchableOpacity>
+                    </View>
+                    <View style={styles.infoRow}>
+                        <Text style={styles.infoLabel}>Donation</Text>
+                        <TouchableOpacity onPress={() => onOpenUrl(displayProps.donationUrl)}>
+                            <Text style={styles.linkText}>Incyclist Paypal</Text>
+                        </TouchableOpacity>
+                    </View>
+                    <Text style={styles.disclaimer}>
+                        Donation is 100% voluntarily. Incyclist remains a 100% free app regardless of donation.
+                        No freemium model is planned.
                     </Text>
-                    <TouchableOpacity onPress={onShareUuid} style={styles.shareButton}>
-                        <Text style={styles.linkText}>Share</Text>
-                    </TouchableOpacity>
-                </View>
-            </View>
-            <View style={styles.infoRow}>
-                <Text style={styles.infoLabel}>Privacy</Text>
-                <TouchableOpacity onPress={() => onOpenUrl(displayProps.privacyUrl)}>
-                    <Text style={styles.linkText}>Privacy Policy</Text>
-                </TouchableOpacity>
-            </View>
-
-            <Text style={styles.sectionHeader}>Where can I get support?</Text>
-            {displayProps.supportUrls.map((item, index) => (
-                <View key={`${item.label}-${index}`} style={styles.infoRow}>
-                    <Text style={styles.infoLabel}>{item.label}</Text>
-                    <TouchableOpacity onPress={() => onOpenUrl(item.url)}>
-                        <Text style={styles.linkText}>{item.text}</Text>
-                    </TouchableOpacity>
-                </View>
-            ))}
-
-            <Text style={styles.sectionHeader}>How can I support?</Text>
-            <View style={styles.infoRow}>
-                <Text style={styles.infoLabel}>Coding</Text>
-                <TouchableOpacity onPress={() => onOpenUrl(displayProps.gitHubUrl)}>
-                    <Text style={styles.linkText}>GitHub</Text>
-                </TouchableOpacity>
-            </View>
-            <View style={styles.infoRow}>
-                <Text style={styles.infoLabel}>Donation</Text>
-                <TouchableOpacity onPress={() => onOpenUrl(displayProps.donationUrl)}>
-                    <Text style={styles.linkText}>Incyclist Paypal</Text>
-                </TouchableOpacity>
-            </View>
-            <Text style={styles.disclaimer}>
-                Donation is 100% voluntarily. Incyclist remains a 100% free app regardless of donation.
-                No freemium model is planned.
-            </Text>
-            <View style={styles.footerSpacer} />
-        </ScrollView>
+                    <View style={styles.footerSpacer} />
+                </>
+            )}
+        </Dialog>
     );
 };
 
 const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        backgroundColor: colors.background,
-    },
-    header: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        paddingHorizontal: 20,
-        paddingVertical: 16,
-        borderBottomWidth: 1,
-        borderBottomColor: colors.listSeparator,
-    },
-    backButton: {
-        marginRight: 16,
-        padding: 4,
-    },
-    backButtonText: {
-        color: colors.text,
-        fontSize: 32,
-        lineHeight: 36,
-    },
-    headerTitle: {
-        color: colors.text,
-        fontSize: textSizes.pageTitle,
-        fontWeight: '600',
-    },
     sectionHeader: {
         color: colors.text,
         fontSize: textSizes.normalText,

--- a/src/pages/SupportSettingsPage/types.ts
+++ b/src/pages/SupportSettingsPage/types.ts
@@ -2,7 +2,7 @@ import { SupportSettingsDisplayProps } from 'incyclist-services';
 
 export interface SupportSettingsViewProps {
     displayProps: SupportSettingsDisplayProps | null;
-    onBack: () => void;
+    onClose: () => void;
     onShareUuid: () => void;
     onOpenUrl: (url: string) => void;
 }


### PR DESCRIPTION
Closes #55

This PR refactors the `SupportSettingsPage` to use the standardized `Dialog` component with `variant='full'`. This ensures visual consistency with other full-screen settings sub-pages.

### Changes
- Replaced the custom header and `ScrollView` in `SupportSettingsView` with the `Dialog` component.
- Renamed the `onBack` prop to `onClose` in `SupportSettingsViewProps` to align with the `Dialog`'s `onOutsideClick` event.
- Updated `SupportSettingsPage` (smart component) to wire the `onClose` callback to `navigation.goBack()` and log the back button click.
- Cleaned up redundant styles in `View.tsx` (container, header, backButton, etc.) that are now managed by the `Dialog` foundation.
- Updated Storybook stories to use the new prop names.