### PR TITLE
feat(63): Add NavBar strip with back button to SettingsSlideIn

### DIFF
--- a/src/components/NavigationBar/NavigationBar.stories.tsx
+++ b/src/components/NavigationBar/NavigationBar.stories.tsx
@@ -39,13 +39,3 @@ export const Compact: Story = {
         selected: 'activities',
     }
 };
-
-export const SettingsOpen: Story = {
-    args: {
-        showBackOnly: true,
-        compact: false,
-        iconSize: 40,
-        navWidth: 150,
-        showExit: false,
-    }
-};

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -55,8 +55,7 @@ export const NavigationBar = (props: NavigationBarProps) => {
                 iconSize={iconSize}
                 navWidth={navWidth}
                 showExit={showExit}
-                showBackOnly={showSettings}
-                onBack={() => setShowSettings(false)}
+                // showBackOnly and onBack props are removed as the feature is no longer supported by NavigationBarView.
             />
             {showUserSettings && (
                 <UserSettingsDialog onClose={() => setShowUserSettings(false)} />

--- a/src/components/NavigationBar/NavigationBarView.test.tsx
+++ b/src/components/NavigationBar/NavigationBarView.test.tsx
@@ -28,17 +28,5 @@ describe('NavigationBarView', () => {
         expect(toJSON()).toBeDefined();
     });
 
-    it('renders in back-only mode', () => {
-        const { getByText } = render(
-            <NavigationBarView 
-                onClick={jest.fn()} 
-                iconSize={32} 
-                navWidth={70} 
-                showExit={true}
-                showBackOnly={true}
-                onBack={jest.fn()}
-            />
-        );
-        expect(getByText('‹')).toBeDefined();
-    });
+    // The 'renders in back-only mode' test has been removed as the feature is no longer supported.
 });

--- a/src/components/NavigationBar/NavigationBarView.tsx
+++ b/src/components/NavigationBar/NavigationBarView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, StyleSheet, Text, TouchableOpacity } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { NavigationBarViewProps, TNavigationItem } from './types';
 import { NavigationItem } from './NavigationItem';
 import { navigationItemsMiddle } from './utils';

--- a/src/components/NavigationBar/NavigationBarView.tsx
+++ b/src/components/NavigationBar/NavigationBarView.tsx
@@ -23,22 +23,10 @@ export const NavigationBarView = (props: NavigationBarViewProps) => {
         compact, 
         iconSize, 
         navWidth, 
-        showExit,
-        showBackOnly,
-        onBack 
+        showExit
     } = props;
 
-    if (showBackOnly) {
-        return (
-            <View style={[styles.container, { width: navWidth }]}>
-                <View style={styles.top}>
-                    <TouchableOpacity onPress={onBack} style={styles.backButton}>
-                        <Text style={styles.backIcon}>‹</Text>
-                    </TouchableOpacity>
-                </View>
-            </View>
-        );
-    }
+    // The showBackOnly mode and associated rendering logic have been removed.
 
     const renderIcon = (item: TNavigationItem, isSelected: boolean) => {
         const color = isSelected ? colors.iconSelected : colors.icon;
@@ -125,15 +113,5 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         width: '100%',
     },
-    backButton: {
-        justifyContent: 'center',
-        alignItems: 'center',
-        width: '100%',
-        paddingVertical: 10,
-    },
-    backIcon: {
-        fontSize: 32,
-        lineHeight: 36,
-        color: colors.text,
-    },
+    // The backButton and backIcon styles have been removed as showBackOnly mode is no longer supported.
 });

--- a/src/components/NavigationBar/types.ts
+++ b/src/components/NavigationBar/types.ts
@@ -21,6 +21,5 @@ export interface NavigationBarViewProps {
     iconSize: number;
     navWidth: number;
     showExit: boolean;
-    showBackOnly?: boolean;
-    onBack?: () => void;
+    // showBackOnly and onBack props are removed as the feature is no longer supported.
 }

--- a/src/components/SettingsSlideIn/SettingsSlideIn.tsx
+++ b/src/components/SettingsSlideIn/SettingsSlideIn.tsx
@@ -12,7 +12,7 @@ import {
 import LinearGradient from 'react-native-linear-gradient';
 import { SettingsSlideInProps } from './types';
 import { colors, textSizes } from '../../theme';
-import { useLogging } from '../../hooks';
+import { useLogging, useScreenLayout } from '../../hooks'; // Add useScreenLayout
 
 const gradientColors = colors.dialogBackground;
 const BackgroundContainer = Platform.OS === 'web' ? View : (LinearGradient as any);
@@ -28,11 +28,16 @@ export const SettingsSlideIn = ({
 }: SettingsSlideInProps) => {
     const { width: screenWidth } = useWindowDimensions();
     const { logEvent } = useLogging('SettingsSlideIn');
+    const layout = useScreenLayout(); // Get screen layout
+    const isCompact = layout === 'compact'; // Determine if compact
 
-    const panelWidth = screenWidth * 0.35;
+    // Calculate widths as per instructions
+    const stripWidth = isCompact ? 70 : 150;
+    const panelWidth = screenWidth * 0.35; // Unchanged fixed panel width
+    const totalWidth = stripWidth + panelWidth; // Total width of the sliding unit
     
     // Start off-screen (left)
-    const animTranslateX = useRef(new Animated.Value(-panelWidth)).current;
+    const animTranslateX = useRef(new Animated.Value(-totalWidth)).current; // Use totalWidth for initial position
     
     // Track animation state to handle backdrop visibility and pointer events
     const [isAnimating, setIsAnimating] = useState(false);
@@ -47,7 +52,7 @@ export const SettingsSlideIn = ({
             }
         }
 
-        const targetValue = visible ? 0 : -panelWidth;
+        const targetValue = visible ? 0 : -totalWidth; // Use totalWidth for target
         
         if (visible) {
             setIsFullyClosed(false);
@@ -64,7 +69,7 @@ export const SettingsSlideIn = ({
                 setIsFullyClosed(true);
             }
         });
-    }, [visible, animTranslateX, panelWidth]);
+    }, [visible, animTranslateX, totalWidth]); // Add totalWidth to deps
 
     const handleSectionPress = (label: string) => {
         logEvent({ message: 'menu item clicked', item: label, eventSource: 'user' });
@@ -94,19 +99,25 @@ export const SettingsSlideIn = ({
                 />
             </TouchableWithoutFeedback>
 
-            {/* Side Panel */}
+            {/* Sliding Unit (Strip + Panel) */}
             <Animated.View
                 style={[
-                    styles.panel,
-                    { 
-                        width: panelWidth, 
-                        transform: [{ translateX: animTranslateX }] 
-                    },
+                    styles.panelContainer, // Container for both strip and panel
+                    { width: totalWidth }, // Apply total width to the animated unit
+                    { transform: [{ translateX: animTranslateX }] }
                 ]}
             >
+                {/* Strip Column */}
+                <View style={[styles.strip, { width: stripWidth }]}> {/* Explicit strip width */}
+                    <TouchableOpacity onPress={onClose} style={styles.backButton}>
+                        <Text style={styles.backIcon}>‹</Text>
+                    </TouchableOpacity>
+                </View>
+
+                {/* Sections Panel */}
                 <BackgroundContainer
                     colors={gradientColors}
-                    style={panelBackgroundStyle}
+                    style={[panelBackgroundStyle, { width: panelWidth }]} // Explicit panel width
                 >
                     <View style={styles.content}>
                         {sections.map((section) => (
@@ -132,15 +143,32 @@ const styles = StyleSheet.create({
         ...StyleSheet.absoluteFill,
         backgroundColor: 'rgba(0,0,0,0.4)',
     },
-    panel: {
+    panelContainer: { // New style for the sliding unit wrapper
         position: 'absolute',
         left: 0,
         top: 0,
         bottom: 0,
         zIndex: 1000,
+        flexDirection: 'row', // Arrange strip and panel side-by-side
+    },
+    strip: {
+        backgroundColor: 'rgba(200,200,200,0.15)',
+        alignSelf: 'stretch', // Ensures it takes full height of panelContainer
+        paddingTop: Platform.OS === 'ios' ? 40 : 10, // Adjust for iOS status bar, similar to Dialog
+    },
+    backButton: {
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+        paddingVertical: 10,
+    },
+    backIcon: {
+        fontSize: 32,
+        lineHeight: 36,
+        color: colors.text,
     },
     content: {
-        flex: 1,
+        flex: 1, // Content needs to flex within its parent BackgroundContainer
         paddingTop: 20,
     },
     row: {


### PR DESCRIPTION
Closes #63

This PR refactors the `SettingsSlideIn` component to incorporate a dedicated navigation strip on the left, consistent with the `full` Dialog variant layout. The strip includes a `‹` back button that triggers the `onClose` handler.

Key changes include:
- `SettingsSlideIn.tsx`: Now renders two side-by-side columns (strip and sections panel) within a single animated unit. Widths are calculated dynamically based on screen layout (`compact` or `normal`) and screen dimensions. New styles for the strip and back button are introduced.
- `NavigationBarView.tsx`: The `showBackOnly` rendering path and associated styles are completely removed.
- `NavigationBar.tsx`: The `showBackOnly` and `onBack` props are removed from the `NavigationBarView` JSX.
- `NavigationBarView.test.tsx`: The test case for `showBackOnly` mode is removed.
- `types.ts`: `showBackOnly` and `onBack` are removed from `NavigationBarViewProps`.

The `Open` story for `SettingsSlideIn` has been verified to render correctly with the new layout.