### PR TITLE
Move SupportSettingsPage and SettingsPlaceholder out of navigation stack

### DIFF
--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -4,14 +4,17 @@ import { NavigationBarProps, TNavigationItem } from './types';
 import { NavigationBarView } from './NavigationBarView';
 import { UserSettingsDialog } from '../UserSettingsDialog';
 import { SettingsSlideIn } from '../SettingsSlideIn';
-import { navigate } from '../../services';
 import { SettingsSectionItem } from '../../pages/SettingsPage/types';
+import { SupportSettingsPage } from '../../pages/SupportSettingsPage';
+import { SettingsPlaceholder } from '../../pages/SettingsPlaceholder';
 
 export const NavigationBar = (props: NavigationBarProps) => {
     const { selected, onClick, compact } = props;
     const { height } = useWindowDimensions();
     const [showUserSettings, setShowUserSettings] = useState(false);
     const [showSettings, setShowSettings] = useState(false);
+    const [showSupport, setShowSupport] = useState(false);
+    const [showPlaceholder, setShowPlaceholder] = useState(false);
 
     const iconSize = compact ? 32 : Math.min(height / 16, 64);
     const navWidth = compact ? 70 : 150;
@@ -31,10 +34,10 @@ export const NavigationBar = (props: NavigationBarProps) => {
         setShowSettings(false);
         switch (label) {
             case 'Support':
-                navigate('settingsSupport');
+                setShowSupport(true);
                 break;
             default:
-                navigate('settingsPlaceholder');
+                setShowPlaceholder(true);
                 break;
         }
     }, []);
@@ -66,6 +69,12 @@ export const NavigationBar = (props: NavigationBarProps) => {
                 onClose={() => setShowSettings(false)}
                 onSectionPress={handleSectionPress}
             />
+            {showSupport && (
+                <SupportSettingsPage onClose={() => setShowSupport(false)} />
+            )}
+            {showPlaceholder && (
+                <SettingsPlaceholder onClose={() => setShowPlaceholder(false)} />
+            )}
         </>
     );
 };

--- a/src/pages/RootNavigator/RootNavigator.tsx
+++ b/src/pages/RootNavigator/RootNavigator.tsx
@@ -8,8 +8,6 @@ import { RoutesPage } from '../RoutesPage/RoutesPage';
 import { RidePage } from '../RidePage'; // New import
 import { VideoDemoPage } from '../VideoDemo/RidePage';
 import { NotImplementedPage } from '../NotImplemented/NotImplementedPage';
-import { SettingsPlaceholder } from '../SettingsPlaceholder';
-import { SupportSettingsPage } from '../SupportSettingsPage';
 
 const Stack = createNativeStackNavigator();
 
@@ -26,8 +24,6 @@ export const RootNavigator = () => {
                 }}>
                 <Stack.Screen name="main" component={NotImplementedPage} />
                 <Stack.Screen name="user" component={NotImplementedPage} />
-                <Stack.Screen name="settingsPlaceholder" component={SettingsPlaceholder} />
-                <Stack.Screen name="settingsSupport" component={SupportSettingsPage} />
                 <Stack.Screen name="search" component={RoutesPage} />
                 <Stack.Screen name="routes" component={RoutesPage} />
                 <Stack.Screen name="activities" component={ActivitiesPage} />

--- a/src/pages/SettingsPlaceholder/SettingsPlaceholder.tsx
+++ b/src/pages/SettingsPlaceholder/SettingsPlaceholder.tsx
@@ -1,47 +1,38 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { Text, StyleSheet } from 'react-native';
 import { useLogging } from '../../hooks';
 import { colors, textSizes } from '../../theme';
+import { Dialog } from '../../components/Dialog';
 
-export const SettingsPlaceholder = () => {
-    const navigation = useNavigation();
+interface SettingsPlaceholderProps {
+    onClose: () => void;
+}
+
+export const SettingsPlaceholder = ({ onClose }: SettingsPlaceholderProps) => {
     const { logEvent } = useLogging('SettingsPlaceholder');
 
-    const handleBack = () => {
+    const handleClose = () => {
         logEvent({ message: 'button clicked', button: 'back', eventSource: 'user' });
-        navigation.goBack();
+        onClose();
     };
 
     return (
-        <View style={styles.container}>
-            <TouchableOpacity onPress={handleBack} style={styles.backButton}>
-                <Text style={styles.backButtonText}>‹</Text>
-            </TouchableOpacity>
+        <Dialog
+            title="Settings"
+            variant="full"
+            visible={true}
+            onOutsideClick={handleClose}
+        >
             <Text style={styles.message}>Not yet implemented</Text>
-        </View>
+        </Dialog>
     );
 };
 
 const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        backgroundColor: colors.background,
-        justifyContent: 'center',
-        alignItems: 'center',
-    },
-    backButton: {
-        position: 'absolute',
-        top: 60,
-        left: 20,
-        padding: 10,
-    },
-    backButtonText: {
-        color: colors.text,
-        fontSize: 40,
-    },
     message: {
         color: colors.text,
         fontSize: textSizes.noDataText,
+        textAlign: 'center',
+        marginTop: 40,
     },
 });

--- a/src/pages/SupportSettingsPage/SupportSettingsPage.tsx
+++ b/src/pages/SupportSettingsPage/SupportSettingsPage.tsx
@@ -1,15 +1,17 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Share, Linking } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
 import { SupportSettingsDisplayProps, useSupportSettingsDisplay } from 'incyclist-services';
 import { useLogging, useUnmountEffect } from '../../hooks';
 import { SupportSettingsView } from './View';
 
-export const SupportSettingsPage = () => {
+interface SupportSettingsPageProps {
+    onClose: () => void;
+}
+
+export const SupportSettingsPage = ({ onClose }: SupportSettingsPageProps) => {
     const [displayProps, setDisplayProps] = useState<SupportSettingsDisplayProps | null>(null);
     const refInitialized = useRef(false);
     const service = useSupportSettingsDisplay();
-    const navigation = useNavigation();
     const { logEvent } = useLogging('SupportSettingsPage');
 
     useEffect(() => {
@@ -23,10 +25,10 @@ export const SupportSettingsPage = () => {
         service.close();
     });
 
-    const onClose = useCallback(() => {
+    const handleClose = useCallback(() => {
         logEvent({ message: 'button clicked', button: 'back', eventSource: 'user' });
-        navigation.goBack();
-    }, [navigation, logEvent]);
+        onClose();
+    }, [onClose, logEvent]);
 
     const onShareUuid = useCallback(async () => {
         if (!displayProps) return;
@@ -46,7 +48,7 @@ export const SupportSettingsPage = () => {
     return (
         <SupportSettingsView
             displayProps={displayProps}
-            onClose={onClose}
+            onClose={handleClose}
             onShareUuid={onShareUuid}
             onOpenUrl={onOpenUrl}
         />


### PR DESCRIPTION
Closes #65

- Removed `settingsPlaceholder` and `settingsSupport` routes from `RootNavigator`.
- Moved instantiation of `SupportSettingsPage` and `SettingsPlaceholder` into `NavigationBar` using local state.
- Updated `SettingsPlaceholder` to use `Dialog variant='full'` for visual consistency.
- Removed `useNavigation` and `navigate` dependencies from affected components.