### PR TITLE
Implement GearSettings component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@sinonjs/text-encoding": "^0.7.3",
         "events": "^3.3.0",
         "gd-eventlog": "^0.1.27",
-        "incyclist-services": "^1.7.30",
+        "incyclist-services": "^1.7.31",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
         "react": "^19.2.4",
@@ -11622,9 +11622,9 @@
       }
     },
     "node_modules/incyclist-services": {
-      "version": "1.7.30",
-      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.30.tgz",
-      "integrity": "sha512-JZ7t+fp2puh/erajXUiWuiZVLiCPZRVkWNL5Xw4a6GaA9dvvvoVoaU1V0203zr5HFh5NnbXytmlUPlI2erXHwA==",
+      "version": "1.7.31",
+      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.31.tgz",
+      "integrity": "sha512-rN9q0mI/8sLzkIOzwY7Db90yPn1vnb/wfreA7U6qX1Fzbq/FXl1apxpe8wReFcwJgHCcgcse3jIhXgCFzNP8hw==",
       "dependencies": {
         "axios": "^1.13.6",
         "incyclist-devices": "^3.0.10",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@sinonjs/text-encoding": "^0.7.3",
     "events": "^3.3.0",
     "gd-eventlog": "^0.1.27",
-    "incyclist-services": "^1.7.30",
+    "incyclist-services": "^1.7.31",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "react": "^19.2.4",

--- a/src/components/GearSettings/GearSettings.stories.tsx
+++ b/src/components/GearSettings/GearSettings.stories.tsx
@@ -4,7 +4,7 @@ import { GearSettingsView } from './GearSettingsView';
 import { CyclingModeProperyType } from 'incyclist-services';
 
 const meta: Meta<typeof GearSettingsView> = {
-    title: 'Components/GearSettings',
+    title: 'Components/Settings/Gear',
     component: GearSettingsView,
     args: {
         onClose: fn(),
@@ -16,49 +16,74 @@ const meta: Meta<typeof GearSettingsView> = {
 export default meta;
 type Story = StoryObj<typeof GearSettingsView>;
 
+const ALL_PROPS = [
+    { key: 'i', name: 'Integer', description: '', type: CyclingModeProperyType.Integer, default: 10 },
+    { key: 'f', name: 'Float', description: '', type: CyclingModeProperyType.Float, default: 1.5 },
+    { key: 's', name: 'String', description: '', type: CyclingModeProperyType.String, default: 'text' },
+    { key: 'b', name: 'Boolean', description: '', type: CyclingModeProperyType.Boolean, default: true },
+    { key: 'ss', name: 'Small Select', description: '', type: CyclingModeProperyType.SingleSelect, options: ['A', 'B'], default: 'A' },
+    { key: 'ls', name: 'Large Select', description: '', type: CyclingModeProperyType.SingleSelect, options: ['1', '2', '3', '4', '5'], default: '1' },
+];
+
 const mockModes = [
     {
-        getName: () => 'ERG',
-        getProperties: () => [
-            {
-                key: 'power',
-                name: 'Power',
-                type: CyclingModeProperyType.Integer,
-                min: 0,
-                max: 400,
-                default: 150,
-            },
-        ],
+        getName: () => 'Mode A',
+        getProperties: () => ALL_PROPS,
     },
     {
-        getName: () => 'SIM',
-        getProperties: () => [
-            {
-                key: 'weight',
-                name: 'Weight',
-                type: CyclingModeProperyType.Float,
-                min: 0,
-                max: 200,
-                default: 75,
-            },
-        ],
+        getName: () => 'Mode B',
+        getProperties: () => [],
+    },
+    {
+        getName: () => 'Mode C',
+        getProperties: () => [],
     },
 ];
 
-export const Default: Story = {
+export const AllTypes: Story = {
     args: {
-        mode: 'ERG',
+        mode: 'Mode A',
         options: mockModes as any,
-        settings: { power: 200 },
-        properties: mockModes[0].getProperties() as any,
+        settings: { i: 20, f: 2.5, s: 'hello', b: false, ss: 'B', ls: '3' },
+        properties: ALL_PROPS as any,
     },
 };
 
-export const SimMode: Story = {
+export const SmallSelect: Story = {
     args: {
-        mode: 'SIM',
+        mode: 'Mode A',
+        options: [mockModes[0]] as any,
+        settings: { ss: 'A' },
+        properties: [ALL_PROPS[4]] as any,
+    },
+};
+
+export const LargeSelect: Story = {
+    args: {
+        mode: 'Mode A',
+        options: [mockModes[0]] as any,
+        settings: { ls: '1' },
+        properties: [ALL_PROPS[5]] as any,
+    },
+};
+
+export const ConditionalProperty: Story = {
+    args: {
+        mode: 'Mode A',
+        options: [mockModes[0]] as any,
+        settings: { b: false },
+        properties: [
+            ALL_PROPS[3],
+            { key: 'cond', name: 'Conditional', description: '', type: CyclingModeProperyType.String, condition: (s: any) => s.b === true },
+        ] as any,
+    },
+};
+
+export const MultiMode: Story = {
+    args: {
+        mode: 'Mode A',
         options: mockModes as any,
-        settings: { weight: 80.5 },
-        properties: mockModes[1].getProperties() as any,
+        settings: {},
+        properties: [],
     },
 };

--- a/src/components/GearSettings/GearSettings.stories.tsx
+++ b/src/components/GearSettings/GearSettings.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { GearSettingsView } from './GearSettingsView';
+import { CyclingModeProperyType } from 'incyclist-services';
+
+const meta: Meta<typeof GearSettingsView> = {
+    title: 'Components/GearSettings',
+    component: GearSettingsView,
+    args: {
+        onClose: fn(),
+        onChangeMode: fn(),
+        onChangeSetting: fn(),
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof GearSettingsView>;
+
+const mockModes = [
+    {
+        getName: () => 'ERG',
+        getProperties: () => [
+            {
+                key: 'power',
+                name: 'Power',
+                type: CyclingModeProperyType.Integer,
+                min: 0,
+                max: 400,
+                default: 150,
+            },
+        ],
+    },
+    {
+        getName: () => 'SIM',
+        getProperties: () => [
+            {
+                key: 'weight',
+                name: 'Weight',
+                type: CyclingModeProperyType.Float,
+                min: 0,
+                max: 200,
+                default: 75,
+            },
+        ],
+    },
+];
+
+export const Default: Story = {
+    args: {
+        mode: 'ERG',
+        options: mockModes as any,
+        settings: { power: 200 },
+        properties: mockModes[0].getProperties() as any,
+    },
+};
+
+export const SimMode: Story = {
+    args: {
+        mode: 'SIM',
+        options: mockModes as any,
+        settings: { weight: 80.5 },
+        properties: mockModes[1].getProperties() as any,
+    },
+};

--- a/src/components/GearSettings/GearSettings.tsx
+++ b/src/components/GearSettings/GearSettings.tsx
@@ -2,8 +2,6 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import {
     useDeviceConfiguration,
     DeviceModeInfo,
-    CyclingModeProperty,
-    Settings,
 } from 'incyclist-services';
 import { useLogging, useUnmountEffect } from '../../hooks';
 import { GearSettingsProps } from './types';

--- a/src/components/GearSettings/GearSettings.tsx
+++ b/src/components/GearSettings/GearSettings.tsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import {
-    useDeviceConfiguration,
-    DeviceModeInfo,
-} from 'incyclist-services';
+import { useDeviceConfiguration } from 'incyclist-services';
+import type { DeviceModeInfo } from 'incyclist-services';
 import { useLogging, useUnmountEffect } from '../../hooks';
 import { GearSettingsProps } from './types';
 import { GearSettingsView } from './GearSettingsView';

--- a/src/components/GearSettings/GearSettings.tsx
+++ b/src/components/GearSettings/GearSettings.tsx
@@ -1,0 +1,93 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import {
+    useDeviceConfiguration,
+    DeviceModeInfo,
+    CyclingModeProperty,
+    Settings,
+} from 'incyclist-services';
+import { useLogging, useUnmountEffect } from '../../hooks';
+import { GearSettingsProps } from './types';
+import { GearSettingsView } from './GearSettingsView';
+
+/**
+ * GearSettings smart component
+ * Owns the DeviceConfigurationService subscription and state.
+ */
+export const GearSettings = ({ onClose }: GearSettingsProps) => {
+    const [modeInfo, setModeInfo] = useState<DeviceModeInfo | null>(null);
+    const refInitialized = useRef(false);
+    const { logEvent } = useLogging('GearSettings');
+    const config = useDeviceConfiguration();
+
+    const onModeChanged = useCallback(() => {
+        const updated = config.getModeSettings();
+        if (updated) {
+            setModeInfo(updated);
+        }
+    }, [config]);
+
+    useEffect(() => {
+        if (refInitialized.current) {
+            return;
+        }
+        refInitialized.current = true;
+        const info = config.getModeSettings();
+        if (info) {
+            setModeInfo(info);
+        }
+        config.on('mode-changed', onModeChanged);
+    }, [config, onModeChanged]);
+
+    useUnmountEffect(() => {
+        config.off('mode-changed', onModeChanged);
+        refInitialized.current = false;
+    });
+
+    const onChangeMode = useCallback(
+        (mode: string) => {
+            if (!modeInfo) {
+                return;
+            }
+            logEvent({ message: 'cycling mode selected', mode, eventSource: 'user' });
+            config.setMode(modeInfo.udid, mode);
+        },
+        [config, modeInfo, logEvent]
+    );
+
+    const onChangeSetting = useCallback(
+        (property: string, value: any) => {
+            if (!modeInfo) {
+                return;
+            }
+            logEvent({
+                message: 'cycling mode property changed',
+                mode: modeInfo.mode,
+                property,
+                value,
+                eventSource: 'user',
+            });
+            const updatedSettings = { ...(modeInfo.settings ?? {}), [property]: value };
+            config.setModeSettings(modeInfo.udid, modeInfo.mode, updatedSettings);
+        },
+        [config, modeInfo, logEvent]
+    );
+
+    if (!modeInfo) {
+        return null;
+    }
+
+    const selectedModeObj = modeInfo.options?.find((m) => m.getName() === modeInfo.mode);
+    const properties = selectedModeObj?.getProperties() ?? [];
+
+    return (
+        <GearSettingsView
+            mode={modeInfo.mode}
+            options={modeInfo.options ?? []}
+            settings={modeInfo.settings ?? {}}
+            properties={properties}
+            onClose={onClose}
+            onChangeMode={onChangeMode}
+            onChangeSetting={onChangeSetting}
+        />
+    );
+};

--- a/src/components/GearSettings/GearSettingsView.test.tsx
+++ b/src/components/GearSettings/GearSettingsView.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react-native';
 import { GearSettingsView } from './GearSettingsView';
 import { GearSettingsViewProps } from './types';
 import { CyclingModeProperyType, CyclingModeProperty } from 'incyclist-services';
-import type ICyclingMode from 'incyclist-services';
+import type {ICyclingMode} from 'incyclist-services';
 
 // Mock ICyclingMode helper
 const createMockICyclingMode = (name: string, properties: CyclingModeProperty[]): ICyclingMode =>

--- a/src/components/GearSettings/GearSettingsView.test.tsx
+++ b/src/components/GearSettings/GearSettingsView.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { GearSettingsView } from './GearSettingsView';
+import { GearSettingsViewProps } from './types';
+import { CyclingModeProperyType, CyclingModeProperty } from 'incyclist-services';
+import type ICyclingMode from 'incyclist-services';
+
+// Mock ICyclingMode helper
+const createMockICyclingMode = (name: string, properties: CyclingModeProperty[]): ICyclingMode =>
+    ({
+        getName: () => name,
+        getDescription: () => '',
+        getProperties: () => properties,
+    } as unknown as ICyclingMode);
+
+describe('GearSettingsView', () => {
+    const mockMode = createMockICyclingMode('ERG', [
+        {
+            key: 'power',
+            name: 'Power',
+            type: CyclingModeProperyType.Integer,
+            min: 0,
+            max: 400,
+            default: 150,
+        },
+        {
+            key: 'cadence',
+            name: 'Cadence',
+            type: CyclingModeProperyType.Integer,
+            min: 40,
+            max: 120,
+            default: 90,
+        },
+    ]);
+
+    const MOCK_PROPS: GearSettingsViewProps = {
+        mode: 'ERG',
+        options: [mockMode],
+        settings: { power: 200, cadence: 90 },
+        properties: mockMode.getProperties(),
+        onClose: jest.fn(),
+        onChangeMode: jest.fn(),
+        onChangeSetting: jest.fn(),
+    };
+
+    it('renders with single mode and its properties', () => {
+        const { getByText, getByDisplayValue } = render(<GearSettingsView {...MOCK_PROPS} />);
+        expect(getByText('Bike Preferences')).toBeTruthy();
+        expect(getByText('Power')).toBeTruthy();
+        expect(getByText('Cadence')).toBeTruthy();
+        expect(getByDisplayValue('200')).toBeTruthy();
+    });
+
+    it('renders null-safe when options is empty', () => {
+        const props = { ...MOCK_PROPS, options: [], properties: [] };
+        const { queryByText } = render(<GearSettingsView {...props} />);
+        expect(queryByText('Power')).toBeNull();
+    });
+
+    it('hides conditional property when condition returns false', () => {
+        const conditionalMode = createMockICyclingMode('Conditional', [
+            { key: 'show', name: 'Show it', type: CyclingModeProperyType.Boolean, default: false },
+            {
+                key: 'secret',
+                name: 'Secret',
+                type: CyclingModeProperyType.String,
+                condition: (s: any) => s.show === true,
+            },
+        ]);
+
+        const props: GearSettingsViewProps = {
+            ...MOCK_PROPS,
+            mode: 'Conditional',
+            options: [conditionalMode],
+            settings: { show: false },
+            properties: conditionalMode.getProperties(),
+        };
+
+        const { queryByText } = render(<GearSettingsView {...props} />);
+        expect(queryByText('Secret')).toBeNull();
+    });
+});

--- a/src/components/GearSettings/GearSettingsView.test.tsx
+++ b/src/components/GearSettings/GearSettingsView.test.tsx
@@ -1,9 +1,20 @@
+jest.mock('incyclist-services', () => ({
+    CyclingModeProperyType: {
+        Integer: 'Integer',
+        Float: 'Float',
+        String: 'String',
+        Boolean: 'Boolean',
+        SingleSelect: 'SingleSelect',
+        MultiSelect: 'MultiSelect',
+    },
+}));
+
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import { GearSettingsView } from './GearSettingsView';
 import { GearSettingsViewProps } from './types';
-import { CyclingModeProperyType, CyclingModeProperty } from 'incyclist-services';
-import type { ICyclingMode } from 'incyclist-services';
+import type { CyclingModeProperty, ICyclingMode } from 'incyclist-services';
+import { CyclingModeProperyType } from 'incyclist-services';
 
 // Mock ICyclingMode helper
 const createMockICyclingMode = (name: string, properties: CyclingModeProperty[]): ICyclingMode =>

--- a/src/components/GearSettings/GearSettingsView.test.tsx
+++ b/src/components/GearSettings/GearSettingsView.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react-native';
 import { GearSettingsView } from './GearSettingsView';
 import { GearSettingsViewProps } from './types';
 import { CyclingModeProperyType, CyclingModeProperty } from 'incyclist-services';
-import type {ICyclingMode} from 'incyclist-services';
+import type { ICyclingMode } from 'incyclist-services';
 
 // Mock ICyclingMode helper
 const createMockICyclingMode = (name: string, properties: CyclingModeProperty[]): ICyclingMode =>
@@ -18,6 +18,7 @@ describe('GearSettingsView', () => {
         {
             key: 'power',
             name: 'Power',
+            description: '',
             type: CyclingModeProperyType.Integer,
             min: 0,
             max: 400,
@@ -26,6 +27,7 @@ describe('GearSettingsView', () => {
         {
             key: 'cadence',
             name: 'Cadence',
+            description: '',
             type: CyclingModeProperyType.Integer,
             min: 40,
             max: 120,
@@ -59,10 +61,11 @@ describe('GearSettingsView', () => {
 
     it('hides conditional property when condition returns false', () => {
         const conditionalMode = createMockICyclingMode('Conditional', [
-            { key: 'show', name: 'Show it', type: CyclingModeProperyType.Boolean, default: false },
+            { key: 'show', name: 'Show it', description: '', type: CyclingModeProperyType.Boolean, default: false },
             {
                 key: 'secret',
                 name: 'Secret',
+                description: '',
                 type: CyclingModeProperyType.String,
                 condition: (s: any) => s.show === true,
             },

--- a/src/components/GearSettings/GearSettingsView.tsx
+++ b/src/components/GearSettings/GearSettingsView.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { CyclingModeProperty, CyclingModeProperyType, Settings } from 'incyclist-services';
+import type { CyclingModeProperty, Settings } from 'incyclist-services';
+import { CyclingModeProperyType } from 'incyclist-services';
 import { GearSettingsViewProps } from './types';
 import { Dialog } from '../Dialog';
 import { SingleSelect } from '../SingleSelect';

--- a/src/components/GearSettings/GearSettingsView.tsx
+++ b/src/components/GearSettings/GearSettingsView.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
 import { CyclingModeProperty, CyclingModeProperyType, Settings } from 'incyclist-services';
 import { GearSettingsViewProps } from './types';
 import { Dialog } from '../Dialog';
@@ -21,11 +20,12 @@ export const GearSettingsView = ({
     onChangeSetting,
 }: GearSettingsViewProps) => {
     const modeOptions = options.map((m) => m.getName());
+    const ModeInput = modeOptions.length <= 3 ? ChipSelect : SingleSelect;
     const visibleProperties = properties.filter((p) => !p.condition || p.condition(settings));
 
     return (
         <Dialog title="Bike Preferences" variant="full" visible={true} onOutsideClick={onClose}>
-            <SingleSelect
+            <ModeInput
                 label="Mode"
                 options={modeOptions}
                 selected={mode}
@@ -91,8 +91,9 @@ const renderProperty = (
             const selectOptions = (p.options ?? []).map((o) =>
                 typeof o === 'string' ? o : o.label ?? o.key ?? o.toString()
             );
+            const Input = selectOptions.length <= 3 ? ChipSelect : SingleSelect;
             return (
-                <SingleSelect
+                <Input
                     key={p.key}
                     label={p.name}
                     options={selectOptions}
@@ -105,8 +106,9 @@ const renderProperty = (
             const chipOptions = (p.options ?? []).map((o) =>
                 typeof o === 'string' ? o : o.label ?? o.key ?? o.toString()
             );
+            const Input = chipOptions.length <= 3 ? ChipSelect : SingleSelect;
             return (
-                <ChipSelect
+                <Input
                     key={p.key}
                     label={p.name}
                     options={chipOptions}
@@ -119,5 +121,3 @@ const renderProperty = (
             return null;
     }
 };
-
-const styles = StyleSheet.create({});

--- a/src/components/GearSettings/GearSettingsView.tsx
+++ b/src/components/GearSettings/GearSettingsView.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { CyclingModeProperty, CyclingModeProperyType, Settings } from 'incyclist-services';
+import { GearSettingsViewProps } from './types';
+import { Dialog } from '../Dialog';
+import { SingleSelect } from '../SingleSelect';
+import { EditNumber } from '../EditNumber';
+import { EditText } from '../EditText';
+import { ChipSelect } from '../ChipSelect';
+
+/**
+ * Pure view for GearSettings
+ */
+export const GearSettingsView = ({
+    mode,
+    options,
+    settings,
+    properties,
+    onClose,
+    onChangeMode,
+    onChangeSetting,
+}: GearSettingsViewProps) => {
+    const modeOptions = options.map((m) => m.getName());
+    const visibleProperties = properties.filter((p) => !p.condition || p.condition(settings));
+
+    return (
+        <Dialog title="Bike Preferences" variant="full" visible={true} onOutsideClick={onClose}>
+            <SingleSelect
+                label="Mode"
+                options={modeOptions}
+                selected={mode}
+                onValueChange={onChangeMode}
+            />
+            {visibleProperties.map((p) => renderProperty(p, settings, onChangeSetting))}
+        </Dialog>
+    );
+};
+
+const renderProperty = (
+    p: CyclingModeProperty,
+    settings: Settings,
+    onChange: (key: string, value: any) => void
+) => {
+    const value = settings[p.key] ?? p.default;
+
+    switch (p.type) {
+        case CyclingModeProperyType.Integer:
+            return (
+                <EditNumber
+                    key={p.key}
+                    label={p.name}
+                    value={value}
+                    min={p.min}
+                    max={p.max}
+                    digits={0}
+                    onValueChange={(v) => onChange(p.key, v)}
+                />
+            );
+        case CyclingModeProperyType.Float:
+            return (
+                <EditNumber
+                    key={p.key}
+                    label={p.name}
+                    value={value}
+                    min={p.min}
+                    max={p.max}
+                    digits={2}
+                    onValueChange={(v) => onChange(p.key, v)}
+                />
+            );
+        case CyclingModeProperyType.String:
+            return (
+                <EditText
+                    key={p.key}
+                    label={p.name}
+                    value={value}
+                    onValueChange={(v) => onChange(p.key, v)}
+                />
+            );
+        case CyclingModeProperyType.Boolean:
+            return (
+                <ChipSelect
+                    key={p.key}
+                    label={p.name}
+                    options={['Yes', 'No']}
+                    selected={value ? 'Yes' : 'No'}
+                    onValueChange={(v) => onChange(p.key, v === 'Yes')}
+                />
+            );
+        case CyclingModeProperyType.SingleSelect: {
+            const selectOptions = (p.options ?? []).map((o) =>
+                typeof o === 'string' ? o : o.label ?? o.key ?? o.toString()
+            );
+            return (
+                <SingleSelect
+                    key={p.key}
+                    label={p.name}
+                    options={selectOptions}
+                    selected={value}
+                    onValueChange={(v) => onChange(p.key, v)}
+                />
+            );
+        }
+        case CyclingModeProperyType.MultiSelect: {
+            const chipOptions = (p.options ?? []).map((o) =>
+                typeof o === 'string' ? o : o.label ?? o.key ?? o.toString()
+            );
+            return (
+                <ChipSelect
+                    key={p.key}
+                    label={p.name}
+                    options={chipOptions}
+                    selected={value}
+                    onValueChange={(v) => onChange(p.key, v)}
+                />
+            );
+        }
+        default:
+            return null;
+    }
+};
+
+const styles = StyleSheet.create({});

--- a/src/components/GearSettings/index.ts
+++ b/src/components/GearSettings/index.ts
@@ -1,0 +1,2 @@
+export * from './GearSettings';
+export * from './types';

--- a/src/components/GearSettings/types.ts
+++ b/src/components/GearSettings/types.ts
@@ -1,5 +1,4 @@
-import type {ICyclingMode} from 'incyclist-services';
-import { CyclingModeProperty, Settings } from 'incyclist-services';
+import type { ICyclingMode, CyclingModeProperty, Settings } from 'incyclist-services';
 
 export interface GearSettingsProps {
     onClose: () => void;

--- a/src/components/GearSettings/types.ts
+++ b/src/components/GearSettings/types.ts
@@ -1,0 +1,16 @@
+import type ICyclingMode from 'incyclist-services';
+import { CyclingModeProperty, Settings } from 'incyclist-services';
+
+export interface GearSettingsProps {
+    onClose: () => void;
+}
+
+export interface GearSettingsViewProps {
+    mode: string;
+    options: ICyclingMode[];
+    settings: Settings;
+    properties: CyclingModeProperty[];
+    onClose: () => void;
+    onChangeMode: (mode: string) => void;
+    onChangeSetting: (property: string, value: any) => void;
+}

--- a/src/components/GearSettings/types.ts
+++ b/src/components/GearSettings/types.ts
@@ -1,4 +1,4 @@
-import type ICyclingMode from 'incyclist-services';
+import type {ICyclingMode} from 'incyclist-services';
 import { CyclingModeProperty, Settings } from 'incyclist-services';
 
 export interface GearSettingsProps {

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -3,9 +3,10 @@ import { useWindowDimensions, Platform } from 'react-native';
 import { NavigationBarProps, TNavigationItem } from './types';
 import { NavigationBarView } from './NavigationBarView';
 import { UserSettingsDialog } from '../UserSettingsDialog';
-import { SettingsSlideIn,SettingsSectionItem } from '../SettingsSlideIn';
+import { SettingsSlideIn, SettingsSectionItem } from '../SettingsSlideIn';
 import { SupportSettingsPage } from '../SupportSettings';
 import { SettingsPlaceholder } from '../SettingsPlaceholder';
+import { GearSettings } from '../GearSettings';
 
 export const NavigationBar = (props: NavigationBarProps) => {
     const { selected, onClick, compact } = props;
@@ -14,6 +15,7 @@ export const NavigationBar = (props: NavigationBarProps) => {
     const [showSettings, setShowSettings] = useState(false);
     const [showSupport, setShowSupport] = useState(false);
     const [showPlaceholder, setShowPlaceholder] = useState(false);
+    const [showGear, setShowGear] = useState(false);
 
     const iconSize = compact ? 32 : Math.min(height / 16, 64);
     const navWidth = compact ? 70 : 150;
@@ -35,18 +37,24 @@ export const NavigationBar = (props: NavigationBarProps) => {
             case 'Support':
                 setShowSupport(true);
                 break;
+            case 'Gear':
+                setShowGear(true);
+                break;
             default:
                 setShowPlaceholder(true);
                 break;
         }
     }, []);
 
-    const sections: SettingsSectionItem[] = useMemo(() => [
-        { label: 'Gear', onPress: () => handleSectionPress('Gear') },
-        { label: 'Ride', onPress: () => handleSectionPress('Ride') },
-        { label: 'Apps', onPress: () => handleSectionPress('Apps') },
-        { label: 'Support', onPress: () => handleSectionPress('Support') },
-    ], [handleSectionPress]);
+    const sections: SettingsSectionItem[] = useMemo(
+        () => [
+            { label: 'Gear', onPress: () => handleSectionPress('Gear') },
+            { label: 'Ride', onPress: () => handleSectionPress('Ride') },
+            { label: 'Apps', onPress: () => handleSectionPress('Apps') },
+            { label: 'Support', onPress: () => handleSectionPress('Support') },
+        ],
+        [handleSectionPress]
+    );
 
     return (
         <>
@@ -57,23 +65,17 @@ export const NavigationBar = (props: NavigationBarProps) => {
                 iconSize={iconSize}
                 navWidth={navWidth}
                 showExit={showExit}
-                // showBackOnly and onBack props are removed as the feature is no longer supported by NavigationBarView.
             />
-            {showUserSettings && (
-                <UserSettingsDialog onClose={() => setShowUserSettings(false)} />
-            )}
+            {showUserSettings && <UserSettingsDialog onClose={() => setShowUserSettings(false)} />}
             <SettingsSlideIn
                 visible={showSettings}
                 sections={sections}
                 onClose={() => setShowSettings(false)}
                 onSectionPress={handleSectionPress}
             />
-            {showSupport && (
-                <SupportSettingsPage onClose={() => setShowSupport(false)} />
-            )}
-            {showPlaceholder && (
-                <SettingsPlaceholder onClose={() => setShowPlaceholder(false)} />
-            )}
+            {showSupport && <SupportSettingsPage onClose={() => setShowSupport(false)} />}
+            {showPlaceholder && <SettingsPlaceholder onClose={() => setShowPlaceholder(false)} />}
+            {showGear && <GearSettings onClose={() => setShowGear(false)} />}
         </>
     );
 };


### PR DESCRIPTION
Closes #69

This PR implements the `GearSettings` component, providing a full-screen dialog for managing bike preferences and cycling modes. 

Key features:
- Smart/View component split for `GearSettings` and `GearSettingsView`.
- Integration with `DeviceConfigurationService` for fetching and updating cycling modes and settings.
- Dynamic form rendering based on `CyclingModeProperty` definitions.
- Support for multiple input types: `EditNumber`, `EditText`, `SingleSelect`, and `ChipSelect`.
- Conditional rendering of properties based on current settings.
- Subscription to mode changes via service observer pattern.
- Integration into the `NavigationBar` settings slide-in.
- Comprehensive unit tests and Storybook stories.