### PR TITLE
feat: show empty state in GearSettings when no device is paired

### DIFF
--- a/src/components/GearSettings/GearSettings.test.tsx
+++ b/src/components/GearSettings/GearSettings.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { GearSettings } from './GearSettings';
+
+jest.mock('incyclist-services', () => ({
+    useDeviceConfiguration: () => ({
+        getModeSettings: () => undefined,
+        on: jest.fn(),
+        off: jest.fn(),
+    }),
+    CyclingModeProperyType: {
+        Integer: 'Integer',
+        Float: 'Float',
+        String: 'String',
+        Boolean: 'Boolean',
+        SingleSelect: 'SingleSelect',
+        MultiSelect: 'MultiSelect',
+    },
+}));
+
+// Mocking dependencies used by Dialog and other components
+jest.mock('react-native-linear-gradient', () => 'LinearGradient');
+jest.mock('../../hooks', () => ({
+    useLogging: () => ({ logEvent: jest.fn(), logError: jest.fn() }),
+    useUnmountEffect: jest.fn(),
+    useScreenLayout: () => 'wide',
+}));
+
+describe('GearSettings', () => {
+    it('renders empty state dialog when no device is paired', () => {
+        const { getByText } = render(<GearSettings onClose={jest.fn()} />);
+        expect(getByText('No device paired. Go to Devices to set up your bike.')).toBeTruthy();
+    });
+});

--- a/src/components/GearSettings/GearSettings.tsx
+++ b/src/components/GearSettings/GearSettings.tsx
@@ -1,9 +1,12 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
 import { useDeviceConfiguration } from 'incyclist-services';
 import type { DeviceModeInfo } from 'incyclist-services';
 import { useLogging, useUnmountEffect } from '../../hooks';
 import { GearSettingsProps } from './types';
 import { GearSettingsView } from './GearSettingsView';
+import { colors, textSizes } from '../../theme';
+import { Dialog } from '../Dialog';
 
 /**
  * GearSettings smart component
@@ -69,7 +72,18 @@ export const GearSettings = ({ onClose }: GearSettingsProps) => {
     );
 
     if (!modeInfo) {
-        return null;
+        return (
+            <Dialog
+                title="Bike Preferences"
+                variant="full"
+                visible={true}
+                onOutsideClick={onClose}
+            >
+                <Text style={styles.emptyMessage}>
+                    No device paired. Go to Devices to set up your bike.
+                </Text>
+            </Dialog>
+        );
     }
 
     const selectedModeObj = modeInfo.options?.find((m) => m.getName() === modeInfo.mode);
@@ -87,3 +101,13 @@ export const GearSettings = ({ onClose }: GearSettingsProps) => {
         />
     );
 };
+
+const styles = StyleSheet.create({
+    emptyMessage: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        textAlign: 'center',
+        marginTop: 40,
+        paddingHorizontal: 20,
+    },
+});

--- a/src/components/GearSettings/GearSettings.tsx
+++ b/src/components/GearSettings/GearSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { Text, StyleSheet } from 'react-native';
 import { useDeviceConfiguration } from 'incyclist-services';
 import type { DeviceModeInfo } from 'incyclist-services';
 import { useLogging, useUnmountEffect } from '../../hooks';


### PR DESCRIPTION
Closes #72

Replaces the silent `null` return in `GearSettings` when no device is paired with a `Dialog` showing an explanatory message. This improves UX by providing feedback instead of silently failing to open the settings.

### Changes
- **GearSettings.tsx**: Replaced the `null` guard with a `Dialog` of variant `full` containing the empty state message. Added styling for the message.
- **GearSettings.test.tsx**: Added a smart component test to verify that the empty state dialog is rendered when the service returns no mode settings.

## Manual Steps
- Open Gear Settings when no bike is paired and verify the explanatory message is shown.