### PR TITLE
feat: ChipSelect: add optional multi-select mode

### DIFF
--- a/src/components/ChipSelect/ChipSelect.stories.tsx
+++ b/src/components/ChipSelect/ChipSelect.stories.tsx
@@ -3,7 +3,7 @@ import { fn } from 'storybook/test';
 import { ChipSelect } from './ChipSelect';
 
 const meta: Meta<typeof ChipSelect> = {
-    title: 'Components/DeviceEntry',
+    title: 'Components/ChipSelect',
     component: ChipSelect,
     args: {
         onValueChange: fn(),
@@ -51,5 +51,14 @@ export const Disabled: Story = {
         options: ['Metric', 'Imperial'],
         selected: 'Metric',
         disabled: true,
+    },
+};
+
+export const MultiSelect: Story = {
+    args: {
+        label: 'Sensors',
+        options: ['Power', 'HR', 'Speed', 'Cadence'],
+        selectedValues: ['Power', 'HR'],
+        multi: true,
     },
 };

--- a/src/components/ChipSelect/ChipSelect.test.tsx
+++ b/src/components/ChipSelect/ChipSelect.test.tsx
@@ -17,6 +17,8 @@ const MOCK_CHIP_SELECT_PROPS: ChipSelectProps = {
     onValueChange: jest.fn(),
 };
 
+const MULTI_OPTIONS = ['Power', 'HR', 'Speed', 'Cadence'];
+
 describe('ChipSelect', () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -60,5 +62,61 @@ describe('ChipSelect', () => {
         const { rerender } = render(<ChipSelect {...MOCK_CHIP_SELECT_PROPS} />);
         rerender(<ChipSelect {...MOCK_CHIP_SELECT_PROPS} selected="Imperial" />);
         // The sync effect runs on rerender
+    });
+
+    it('renders in multi mode with no initial selection', () => {
+        const onValueChange = jest.fn();
+        const { getByText } = render(
+            <ChipSelect label="Sensors" options={MULTI_OPTIONS} multi={true} onValueChange={onValueChange} />
+        );
+        expect(getByText('Power')).toBeTruthy();
+        expect(getByText('HR')).toBeTruthy();
+    });
+
+    it('renders in multi mode with initial selectedValues', () => {
+        const { getByText } = render(
+            <ChipSelect label="Sensors" options={MULTI_OPTIONS} multi={true} selectedValues={['Power', 'HR']} />
+        );
+        expect(getByText('Power')).toBeTruthy();
+        expect(getByText('HR')).toBeTruthy();
+    });
+
+    it('selecting a chip adds it to selection and calls onValueChange with updated array', () => {
+        const onValueChange = jest.fn();
+        const { getByText } = render(
+            <ChipSelect label="Sensors" options={MULTI_OPTIONS} multi={true} onValueChange={onValueChange} />
+        );
+        fireEvent.press(getByText('Power'));
+        expect(onValueChange).toHaveBeenCalledWith(['Power']);
+    });
+
+    it('selecting an already-selected chip removes it and calls onValueChange with updated array', () => {
+        const onValueChange = jest.fn();
+        const { getByText } = render(
+            <ChipSelect
+                label="Sensors"
+                options={MULTI_OPTIONS}
+                multi={true}
+                selectedValues={['Power', 'HR']}
+                onValueChange={onValueChange}
+            />
+        );
+        fireEvent.press(getByText('Power'));
+        expect(onValueChange).toHaveBeenCalledWith(['HR']);
+    });
+
+    it('disabled multi mode does not respond to press', () => {
+        const onValueChange = jest.fn();
+        const { getByText } = render(
+            <ChipSelect
+                label="Sensors"
+                options={MULTI_OPTIONS}
+                multi={true}
+                disabled={true}
+                onValueChange={onValueChange}
+            />
+        );
+        fireEvent.press(getByText('Power'));
+        expect(onValueChange).not.toHaveBeenCalled();
     });
 });

--- a/src/components/ChipSelect/ChipSelect.tsx
+++ b/src/components/ChipSelect/ChipSelect.tsx
@@ -23,17 +23,20 @@ export const ChipSelect = (props: ChipSelectProps) => {
         props.multi ? (props.selectedValues ?? []) : []
     );
 
+    const singleSelected = !props.multi ? props.selected : undefined;
+    const multiSelectedValues = props.multi ? props.selectedValues : undefined;
+
     useEffect(() => {
         if (!props.multi) {
-            setSelectedValue(props.selected);
+            setSelectedValue(singleSelected);
         }
-    }, [props.multi, !props.multi ? props.selected : undefined]);
+    }, [props.multi, singleSelected]);
 
     useEffect(() => {
         if (props.multi) {
-            setSelectedValues(props.selectedValues ?? []);
+            setSelectedValues(multiSelectedValues ?? []);
         }
-    }, [props.multi, props.multi ? props.selectedValues : undefined]);
+    }, [props.multi, multiSelectedValues]);
 
     const handleSelect = (option: string) => {
         if (disabled) return;

--- a/src/components/ChipSelect/ChipSelect.tsx
+++ b/src/components/ChipSelect/ChipSelect.tsx
@@ -9,34 +9,58 @@ const LABEL_MARGIN = 8;
 
 /**
  * ChipSelect component
- * 
- * A reusable labelled row of chips for selecting one option from a small set.
+ *
+ * A reusable labelled row of chips for selecting one or more options from a small set.
  */
-export const ChipSelect = ({
-    label,
-    options,
-    selected,
-    labelWidth = 100,
-    disabled = false,
-    onValueChange,
-}: ChipSelectProps) => {
-    const [selectedValue, setSelectedValue] = useState(selected);
+export const ChipSelect = (props: ChipSelectProps) => {
+    const { label, options, labelWidth = 100, disabled = false } = props;
     const { logEvent } = useLogging('ChipSelect');
 
+    const [selectedValue, setSelectedValue] = useState<string | undefined>(
+        props.multi ? undefined : props.selected
+    );
+    const [selectedValues, setSelectedValues] = useState<string[]>(
+        props.multi ? (props.selectedValues ?? []) : []
+    );
+
     useEffect(() => {
-        setSelectedValue(selected);
-    }, [selected]);
+        if (!props.multi) {
+            setSelectedValue(props.selected);
+        }
+    }, [props.multi, !props.multi ? props.selected : undefined]);
+
+    useEffect(() => {
+        if (props.multi) {
+            setSelectedValues(props.selectedValues ?? []);
+        }
+    }, [props.multi, props.multi ? props.selectedValues : undefined]);
 
     const handleSelect = (option: string) => {
         if (disabled) return;
-        setSelectedValue(option);
-        logEvent({
-            message: 'option selected',
-            field: label,
-            value: option,
-            eventSource: 'user',
-        });
-        onValueChange?.(option);
+
+        if (props.multi) {
+            const updated = selectedValues.includes(option)
+                ? selectedValues.filter((v) => v !== option)
+                : [...selectedValues, option];
+
+            setSelectedValues(updated);
+            logEvent({
+                message: 'option selected',
+                field: label,
+                value: option,
+                eventSource: 'user',
+            });
+            props.onValueChange?.(updated);
+        } else {
+            setSelectedValue(option);
+            logEvent({
+                message: 'option selected',
+                field: label,
+                value: option,
+                eventSource: 'user',
+            });
+            props.onValueChange?.(option);
+        }
     };
 
     const labelStyle = { width: labelWidth };
@@ -47,7 +71,9 @@ export const ChipSelect = ({
                 <Text style={[styles.label, labelStyle]}>{label}</Text>
                 <View style={styles.chipsContainer}>
                     {options.map((option, index) => {
-                        const isSelected = selectedValue === option;
+                        const isSelected = props.multi
+                            ? selectedValues.includes(option)
+                            : selectedValue === option;
                         const isLast = index === options.length - 1;
 
                         return (

--- a/src/components/ChipSelect/types.ts
+++ b/src/components/ChipSelect/types.ts
@@ -1,8 +1,21 @@
-export type ChipSelectProps = {
+export type ChipSelectSingleProps = {
     label: string;
     options: Array<string>;
     selected?: string;
     labelWidth?: number;
     disabled?: boolean;
+    multi?: false;
     onValueChange?: (value: string) => void;
 };
+
+export type ChipSelectMultiProps = {
+    label: string;
+    options: Array<string>;
+    selectedValues?: string[];
+    labelWidth?: number;
+    disabled?: boolean;
+    multi: true;
+    onValueChange?: (values: string[]) => void;
+};
+
+export type ChipSelectProps = ChipSelectSingleProps | ChipSelectMultiProps;


### PR DESCRIPTION
Closes #87

Extended `ChipSelect` to support an optional multi-select mode using a discriminated union for props. This ensures type safety for both single and multi-select modes while maintaining backward compatibility.

### Changes:
- Modified `ChipSelectProps` to be a discriminated union of `ChipSelectSingleProps` and `ChipSelectMultiProps`.
- Updated `ChipSelect` implementation to handle state and callback logic for both modes.
- Added comprehensive unit tests for multi-select functionality.
- Added a `MultiSelect` story to Storybook and corrected the story title to match component naming conventions.