### PR TITLE
ActivityGraphPreview: add Storybook story

### DIFF
--- a/src/components/ActivityGraphPreview/ActivityGraphPreview.stories.tsx
+++ b/src/components/ActivityGraphPreview/ActivityGraphPreview.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
-import { fn } from 'storybook/test';
 import { ActivityGraphPreview } from './ActivityGraphPreview';
 import { colors } from '../../theme/colors';
 import ActivityLargeJson from '../../../__tests__/testdata/ActivityLarge.json';
@@ -19,9 +18,6 @@ const meta: Meta<typeof ActivityGraphPreview> = {
             </View>
         ),
     ],
-    args: {
-        // No callback props on this component, but fn() import is required by rules
-    },
 };
 
 export default meta;

--- a/src/components/ActivityGraphPreview/ActivityGraphPreview.stories.tsx
+++ b/src/components/ActivityGraphPreview/ActivityGraphPreview.stories.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { ActivityGraphPreview } from './ActivityGraphPreview';
+import { colors } from '../../theme/colors';
+import ActivityLargeJson from '../../../__tests__/testdata/ActivityLarge.json';
+import { ActivityDetailsUI } from 'incyclist-services';
+
+const ActivityLarge = ActivityLargeJson as unknown as ActivityDetailsUI;
+
+const meta: Meta<typeof ActivityGraphPreview> = {
+    title: 'Components/ActivityGraphPreview',
+    component: ActivityGraphPreview,
+    decorators: [
+        (Story) => (
+            <View style={styles.decorator}>
+                <Story />
+            </View>
+        ),
+    ],
+    args: {
+        // No callback props on this component, but fn() import is required by rules
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ActivityGraphPreview>;
+
+export const Default: Story = {
+    args: {
+        activity: ActivityLarge,
+        ftp: 230,
+        width: 350,
+        height: 80,
+    },
+};
+
+export const NoFTP: Story = {
+    args: {
+        activity: {
+            ...ActivityLarge,
+            user: ActivityLarge.user
+                ? { ...ActivityLarge.user, ftp: undefined }
+                : undefined,
+        } as ActivityDetailsUI,
+        width: 350,
+        height: 80,
+    },
+};
+
+export const NoData: Story = {
+    args: {
+        activity: undefined,
+        width: 350,
+        height: 80,
+    },
+};
+
+const styles = StyleSheet.create({
+    decorator: {
+        width: 400,
+        height: 150,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: colors.background,
+    },
+});


### PR DESCRIPTION
Closes #89

Adds a Storybook story file for `ActivityGraphPreview` with three variations:
- `Default`: Displays the graph using real activity data.
- `NoFTP`: Displays the graph with real data but no FTP, resulting in gray fallback colors.
- `NoData`: Verifies that the component handles undefined activity correctly.