### PR TITLE
fix(105): Defer BleManager.start() until app is fully mounted

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,6 +107,7 @@ export const App = () => {
 
                 const uiVersion = bindings.appInfo?.getUIVersion() ?? app.bundleVersion;
                 await service.onAppLaunch('mobile', uiVersion, features);
+                getBleBinding().start();   // ← ADDED HERE
                 logEvent({ message: 'Initializing App done' });
                 setInitialized(true);
             } catch (err: any) {

--- a/src/bindings/ble/binding.ts
+++ b/src/bindings/ble/binding.ts
@@ -7,8 +7,7 @@ import {
     StatScanningCallback,
 } from './types'
 
-import { BlePeripheralRN }
- from './peripheral'
+import { BlePeripheralRN } from './peripheral'
 import { EventLogger } from 'gd-eventlog'
 import { PermissionService } from '../../services'
 

--- a/src/bindings/ble/binding.ts
+++ b/src/bindings/ble/binding.ts
@@ -7,7 +7,8 @@ import {
     StatScanningCallback,
 } from './types'
 
-import { BlePeripheralRN } from './peripheral'
+import { BlePeripheralRN }
+ from './peripheral'
 import { EventLogger } from 'gd-eventlog'
 import { PermissionService } from '../../services'
 
@@ -52,7 +53,6 @@ export class BleBindingRN extends EventEmitter implements BleBinding {
             this.setAuthorized(false)
         }
         this.initializeAuthorization()
-        this.start()
        
     }
 


### PR DESCRIPTION
Closes #105

This change addresses an iOS-specific issue where the Bluetooth permission prompt was not displayed on first launch. Previously, BleManager.start() was called too early in the application lifecycle during the instantiation of BleBindingRN. By deferring this call until after the app is fully mounted and `service.onAppLaunch()` completes, we ensure the CoreBluetooth framework can correctly present the permission prompt.

Key changes:
- `src/bindings/ble/binding.ts`: Removed `this.start()` from the `BleBindingRN` constructor. The constructor still handles event listener registrations and authorization initialization.
- `src/App.tsx`: Explicitly calls `getBleBinding().start()` within the app's initialization `useEffect`, immediately following `service.onAppLaunch()`.

## Manual Steps
No manual steps are required outside this PR.