### PR TITLE
feat: Page layouts for compact NavBar

### DIFF
--- a/__tests__/jest.setup.ts
+++ b/__tests__/jest.setup.ts
@@ -1,0 +1,10 @@
+const originalError = console.error.bind(console);
+console.error = (...args: any[]) => {
+    if (
+        typeof args[0] === 'string' &&
+        args[0].includes('was not wrapped in act')
+    ) {
+        return;
+    }
+    originalError(...args);
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   preset: 'react-native',
+  setupFilesAfterEnv: ['./__tests__/jest.setup.ts'],
+  testPathIgnorePatterns: ['/node_modules/', '__tests__/jest.setup.ts'],
   moduleNameMapper: {
     '^react-native-linear-gradient$': '<rootDir>/__mocks__/react-native-linear-gradient.tsx',
     '\\.svg$': '<rootDir>/__mocks__/svgMock.tsx',

--- a/src/pages/MainPage/View.test.tsx
+++ b/src/pages/MainPage/View.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { MainPageView } from './View';
+import { useScreenLayout } from '../../hooks/render/useScreenLayout';
+
+jest.mock('../../hooks/render/useScreenLayout');
+jest.mock('../../components', () => ({
+    NavigationBar: () => null,
+    MainBackground: ({ children }: any) => children,
+    ElevationGraph: () => null,
+}));
+
+describe('MainPageView', () => {
+    const mockProps = {
+        onClick: jest.fn(),
+    };
+
+    it('renders correctly in normal layout', () => {
+        (useScreenLayout as jest.Mock).mockReturnValue('normal');
+        const { toJSON } = render(<MainPageView {...mockProps} />);
+        expect(toJSON()).toMatchSnapshot();
+    });
+
+    it('renders correctly in compact layout', () => {
+        (useScreenLayout as jest.Mock).mockReturnValue('compact');
+        const { toJSON } = render(<MainPageView {...mockProps} />);
+        expect(toJSON()).toMatchSnapshot();
+    });
+});

--- a/src/pages/MainPage/View.tsx
+++ b/src/pages/MainPage/View.tsx
@@ -4,6 +4,7 @@ import { EventEmitter } from 'events';
 import { NavigationBar, MainBackground, ElevationGraph, RiderMarker } from '../../components';
 import { colors, textSizes } from '../../theme';
 import { useUnmountEffect } from '../../hooks';
+import { useScreenLayout } from '../../hooks/render/useScreenLayout';
 import type { TNavigationItem } from '../../components';
 
 // Import route data
@@ -19,6 +20,9 @@ export const MainPageView = ({ onClick }: MainPageViewProps) => {
     const [speedKmh, setSpeedKmh] = useState(30);
     const [currentPos, setCurrentPos] = useState(0);
     const [lapMode, setLapMode] = useState(true);
+
+    const layout = useScreenLayout();
+    const isCompact = layout === 'compact';
 
     const refObserver = useRef<EventEmitter | null>(null);
     const refInitialized = useRef(false);
@@ -78,9 +82,9 @@ export const MainPageView = ({ onClick }: MainPageViewProps) => {
 
     return (
         <MainBackground>
-            <View style={styles.layout}>
-                <View style={styles.navColumn}>
-                    <NavigationBar onClick={onClick} />
+            <View style={[styles.layout, isCompact && styles.layoutCompact]}>
+                <View style={[styles.navColumn, isCompact && styles.navColumnCompact]}>
+                    <NavigationBar onClick={onClick} compact={isCompact} />
                 </View>
 
                 <ScrollView style={styles.contentColumn} contentContainerStyle={styles.scrollContent}>
@@ -197,8 +201,15 @@ const styles = StyleSheet.create({
         flex: 1,
         flexDirection: 'row',
     },
+    layoutCompact: {
+        flexDirection: 'column',
+    },
     navColumn: {
         width: 150,
+    },
+    navColumnCompact: {
+        width: '100%',
+        height: 56,
     },
     contentColumn: {
         flex: 1,

--- a/src/pages/MainPage/__snapshots__/View.test.tsx.snap
+++ b/src/pages/MainPage/__snapshots__/View.test.tsx.snap
@@ -1,0 +1,1152 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MainPageView renders correctly in compact layout 1`] = `
+<View
+  style={
+    [
+      {
+        "flex": 1,
+        "flexDirection": "row",
+      },
+      {
+        "flexDirection": "column",
+      },
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {
+          "width": 150,
+        },
+        {
+          "height": 56,
+          "width": "100%",
+        },
+      ]
+    }
+  />
+  <RCTScrollView
+    contentContainerStyle={
+      {
+        "paddingBottom": 40,
+      }
+    }
+    style={
+      {
+        "flex": 1,
+        "padding": 20,
+      }
+    }
+  >
+    <View>
+      <Text
+        style={
+          {
+            "color": "#FFFFFF",
+            "fontSize": 28,
+            "fontWeight": "bold",
+            "marginBottom": 20,
+          }
+        }
+      >
+        Elevation Graph Simulation
+      </Text>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "gap": 12,
+            "marginBottom": 10,
+          }
+        }
+      >
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "backgroundColor": "rgba(255,255,255,0.1)",
+              "borderRadius": 4,
+              "minWidth": 80,
+              "opacity": 1,
+              "paddingHorizontal": 16,
+              "paddingVertical": 8,
+            }
+          }
+        >
+          <Text
+            style={
+              {
+                "color": "#FFFFFF",
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Play
+          </Text>
+        </View>
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "backgroundColor": "rgba(255,255,255,0.1)",
+              "borderRadius": 4,
+              "minWidth": 80,
+              "opacity": 1,
+              "paddingHorizontal": 16,
+              "paddingVertical": 8,
+            }
+          }
+        >
+          <Text
+            style={
+              {
+                "color": "#FFFFFF",
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Reset
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "backgroundColor": "rgba(0,0,0,0.3)",
+              "borderRadius": 4,
+              "flexDirection": "row",
+              "gap": 4,
+              "padding": 4,
+            }
+          }
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "borderRadius": 2,
+                "opacity": 1,
+                "paddingHorizontal": 8,
+                "paddingVertical": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#FFFFFF",
+                  "fontSize": 12,
+                }
+              }
+            >
+              10
+            </Text>
+          </View>
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "borderRadius": 2,
+                "opacity": 1,
+                "paddingHorizontal": 8,
+                "paddingVertical": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#FFFFFF",
+                  "fontSize": 12,
+                }
+              }
+            >
+              20
+            </Text>
+          </View>
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "backgroundColor": "rgba(255,255,255,0.2)",
+                "borderRadius": 2,
+                "opacity": 1,
+                "paddingHorizontal": 8,
+                "paddingVertical": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#FFFFFF",
+                  "fontSize": 12,
+                }
+              }
+            >
+              30
+            </Text>
+          </View>
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "borderRadius": 2,
+                "opacity": 1,
+                "paddingHorizontal": 8,
+                "paddingVertical": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#FFFFFF",
+                  "fontSize": 12,
+                }
+              }
+            >
+              40
+            </Text>
+          </View>
+          <Text
+            style={
+              {
+                "color": "#9fa4a8",
+                "fontSize": 10,
+                "marginLeft": 4,
+              }
+            }
+          >
+            km/h
+          </Text>
+        </View>
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "backgroundColor": "#dd9933",
+              "borderRadius": 4,
+              "minWidth": 80,
+              "opacity": 1,
+              "paddingHorizontal": 16,
+              "paddingVertical": 8,
+            }
+          }
+        >
+          <Text
+            style={
+              {
+                "color": "#FFFFFF",
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Lap: 
+            ON
+          </Text>
+        </View>
+      </View>
+      <Text
+        style={
+          {
+            "color": "#dd9933",
+            "fontSize": 14,
+            "fontWeight": "700",
+            "marginBottom": 20,
+          }
+        }
+      >
+        Position: 
+        0.0
+        m
+      </Text>
+      <View
+        style={
+          {
+            "backgroundColor": "rgba(255,255,255,0.05)",
+            "borderRadius": 8,
+            "marginBottom": 30,
+            "padding": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#9fa4a8",
+              "fontSize": 12,
+              "letterSpacing": 1,
+              "marginBottom": 8,
+              "textTransform": "uppercase",
+            }
+          }
+        >
+          List Preview (Teide, no axes/colors)
+        </Text>
+        <View
+          style={
+            {
+              "height": 50,
+            }
+          }
+        />
+      </View>
+      <View
+        style={
+          {
+            "backgroundColor": "rgba(255,255,255,0.05)",
+            "borderRadius": 8,
+            "marginBottom": 30,
+            "padding": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#9fa4a8",
+              "fontSize": 12,
+              "letterSpacing": 1,
+              "marginBottom": 8,
+              "textTransform": "uppercase",
+            }
+          }
+        >
+          Route Detail (Teide, colors/X axis)
+        </Text>
+        <View
+          style={
+            {
+              "height": 160,
+            }
+          }
+        />
+      </View>
+      <View
+        style={
+          {
+            "backgroundColor": "rgba(255,255,255,0.05)",
+            "borderRadius": 8,
+            "marginBottom": 30,
+            "padding": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#9fa4a8",
+              "fontSize": 12,
+              "letterSpacing": 1,
+              "marginBottom": 8,
+              "textTransform": "uppercase",
+            }
+          }
+        >
+          2km Preview (Sydney Loop, both axes)
+        </Text>
+        <View
+          style={
+            {
+              "height": 140,
+            }
+          }
+        />
+      </View>
+      <View
+        style={
+          {
+            "backgroundColor": "rgba(255,255,255,0.05)",
+            "borderRadius": 8,
+            "marginBottom": 30,
+            "padding": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#9fa4a8",
+              "fontSize": 12,
+              "letterSpacing": 1,
+              "marginBottom": 8,
+              "textTransform": "uppercase",
+            }
+          }
+        >
+          Full Route (Sydney, Lap Mode, Group Markers)
+        </Text>
+        <View
+          style={
+            {
+              "height": 100,
+            }
+          }
+        />
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`MainPageView renders correctly in normal layout 1`] = `
+<View
+  style={
+    [
+      {
+        "flex": 1,
+        "flexDirection": "row",
+      },
+      false,
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {
+          "width": 150,
+        },
+        false,
+      ]
+    }
+  />
+  <RCTScrollView
+    contentContainerStyle={
+      {
+        "paddingBottom": 40,
+      }
+    }
+    style={
+      {
+        "flex": 1,
+        "padding": 20,
+      }
+    }
+  >
+    <View>
+      <Text
+        style={
+          {
+            "color": "#FFFFFF",
+            "fontSize": 28,
+            "fontWeight": "bold",
+            "marginBottom": 20,
+          }
+        }
+      >
+        Elevation Graph Simulation
+      </Text>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "gap": 12,
+            "marginBottom": 10,
+          }
+        }
+      >
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "backgroundColor": "rgba(255,255,255,0.1)",
+              "borderRadius": 4,
+              "minWidth": 80,
+              "opacity": 1,
+              "paddingHorizontal": 16,
+              "paddingVertical": 8,
+            }
+          }
+        >
+          <Text
+            style={
+              {
+                "color": "#FFFFFF",
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Play
+          </Text>
+        </View>
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "backgroundColor": "rgba(255,255,255,0.1)",
+              "borderRadius": 4,
+              "minWidth": 80,
+              "opacity": 1,
+              "paddingHorizontal": 16,
+              "paddingVertical": 8,
+            }
+          }
+        >
+          <Text
+            style={
+              {
+                "color": "#FFFFFF",
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Reset
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "backgroundColor": "rgba(0,0,0,0.3)",
+              "borderRadius": 4,
+              "flexDirection": "row",
+              "gap": 4,
+              "padding": 4,
+            }
+          }
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "borderRadius": 2,
+                "opacity": 1,
+                "paddingHorizontal": 8,
+                "paddingVertical": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#FFFFFF",
+                  "fontSize": 12,
+                }
+              }
+            >
+              10
+            </Text>
+          </View>
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "borderRadius": 2,
+                "opacity": 1,
+                "paddingHorizontal": 8,
+                "paddingVertical": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#FFFFFF",
+                  "fontSize": 12,
+                }
+              }
+            >
+              20
+            </Text>
+          </View>
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "backgroundColor": "rgba(255,255,255,0.2)",
+                "borderRadius": 2,
+                "opacity": 1,
+                "paddingHorizontal": 8,
+                "paddingVertical": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#FFFFFF",
+                  "fontSize": 12,
+                }
+              }
+            >
+              30
+            </Text>
+          </View>
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "borderRadius": 2,
+                "opacity": 1,
+                "paddingHorizontal": 8,
+                "paddingVertical": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#FFFFFF",
+                  "fontSize": 12,
+                }
+              }
+            >
+              40
+            </Text>
+          </View>
+          <Text
+            style={
+              {
+                "color": "#9fa4a8",
+                "fontSize": 10,
+                "marginLeft": 4,
+              }
+            }
+          >
+            km/h
+          </Text>
+        </View>
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "backgroundColor": "#dd9933",
+              "borderRadius": 4,
+              "minWidth": 80,
+              "opacity": 1,
+              "paddingHorizontal": 16,
+              "paddingVertical": 8,
+            }
+          }
+        >
+          <Text
+            style={
+              {
+                "color": "#FFFFFF",
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Lap: 
+            ON
+          </Text>
+        </View>
+      </View>
+      <Text
+        style={
+          {
+            "color": "#dd9933",
+            "fontSize": 14,
+            "fontWeight": "700",
+            "marginBottom": 20,
+          }
+        }
+      >
+        Position: 
+        0.0
+        m
+      </Text>
+      <View
+        style={
+          {
+            "backgroundColor": "rgba(255,255,255,0.05)",
+            "borderRadius": 8,
+            "marginBottom": 30,
+            "padding": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#9fa4a8",
+              "fontSize": 12,
+              "letterSpacing": 1,
+              "marginBottom": 8,
+              "textTransform": "uppercase",
+            }
+          }
+        >
+          List Preview (Teide, no axes/colors)
+        </Text>
+        <View
+          style={
+            {
+              "height": 50,
+            }
+          }
+        />
+      </View>
+      <View
+        style={
+          {
+            "backgroundColor": "rgba(255,255,255,0.05)",
+            "borderRadius": 8,
+            "marginBottom": 30,
+            "padding": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#9fa4a8",
+              "fontSize": 12,
+              "letterSpacing": 1,
+              "marginBottom": 8,
+              "textTransform": "uppercase",
+            }
+          }
+        >
+          Route Detail (Teide, colors/X axis)
+        </Text>
+        <View
+          style={
+            {
+              "height": 160,
+            }
+          }
+        />
+      </View>
+      <View
+        style={
+          {
+            "backgroundColor": "rgba(255,255,255,0.05)",
+            "borderRadius": 8,
+            "marginBottom": 30,
+            "padding": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#9fa4a8",
+              "fontSize": 12,
+              "letterSpacing": 1,
+              "marginBottom": 8,
+              "textTransform": "uppercase",
+            }
+          }
+        >
+          2km Preview (Sydney Loop, both axes)
+        </Text>
+        <View
+          style={
+            {
+              "height": 140,
+            }
+          }
+        />
+      </View>
+      <View
+        style={
+          {
+            "backgroundColor": "rgba(255,255,255,0.05)",
+            "borderRadius": 8,
+            "marginBottom": 30,
+            "padding": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#9fa4a8",
+              "fontSize": 12,
+              "letterSpacing": 1,
+              "marginBottom": 8,
+              "textTransform": "uppercase",
+            }
+          }
+        >
+          Full Route (Sydney, Lap Mode, Group Markers)
+        </Text>
+        <View
+          style={
+            {
+              "height": 100,
+            }
+          }
+        />
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;

--- a/src/pages/NotImplemented/NotImplementedPage.test.tsx
+++ b/src/pages/NotImplemented/NotImplementedPage.test.tsx
@@ -8,6 +8,20 @@ jest.mock('../../components', () => ({
     NavigationBar: () => null,
     MainBackground: ({ children }: any) => children,
 }));
+jest.mock('incyclist-services', () => ({
+    useIncyclist: () => ({
+        onAppExit: jest.fn().mockResolvedValue(undefined),
+    }),
+}));
+jest.mock('../../bindings/ui', () => ({
+    getUIBinding: () => ({
+        quit: jest.fn(),
+    }),
+}));
+
+jest.mock('../../services', () => ({
+    navigate: jest.fn(),
+}));
 
 describe('NotImplementedView', () => {
     const mockProps: any = {

--- a/src/pages/NotImplemented/NotImplementedPage.test.tsx
+++ b/src/pages/NotImplemented/NotImplementedPage.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { NotImplementedView } from './NotImplementedPage';
+import { useScreenLayout } from '../../hooks/render/useScreenLayout';
+
+jest.mock('../../hooks/render/useScreenLayout');
+jest.mock('../../components', () => ({
+    NavigationBar: () => null,
+    MainBackground: ({ children }: any) => children,
+}));
+
+describe('NotImplementedView', () => {
+    const mockProps: any = {
+        onClick: jest.fn(),
+        selected: 'routes',
+    };
+
+    it('renders correctly in normal layout', () => {
+        (useScreenLayout as jest.Mock).mockReturnValue('normal');
+        const { toJSON } = render(<NotImplementedView {...mockProps} />);
+        expect(toJSON()).toMatchSnapshot();
+    });
+
+    it('renders correctly in compact layout', () => {
+        (useScreenLayout as jest.Mock).mockReturnValue('compact');
+        const { toJSON } = render(<NotImplementedView {...mockProps} />);
+        expect(toJSON()).toMatchSnapshot();
+    });
+});

--- a/src/pages/NotImplemented/NotImplementedPage.tsx
+++ b/src/pages/NotImplemented/NotImplementedPage.tsx
@@ -1,22 +1,25 @@
-import { StyleSheet, Text, View } from "react-native";
-import { colors, textSizes } from "../../theme";
-import { useIncyclist } from "incyclist-services";
+import { StyleSheet, Text, View } from 'react-native';
+import { colors, textSizes } from '../../theme';
+import { useIncyclist } from 'incyclist-services';
 import { NavigationBar, MainBackground, TNavigationItem } from '../../components';
-import { getUIBinding } from "../../bindings/ui";
-import { navigate } from "../../services";
+import { getUIBinding } from '../../bindings/ui';
+import { navigate } from '../../services';
+import { useScreenLayout } from '../../hooks/render/useScreenLayout';
 
 interface NotImplementedViewProps {
-    onClick:( item:TNavigationItem)=>void,
-    selected:TNavigationItem
+    onClick: (item: TNavigationItem) => void;
+    selected: TNavigationItem;
 }
 
-export const NotImplementedView = ( {onClick,selected}:NotImplementedViewProps) => {
+export const NotImplementedView = ({ onClick, selected }: NotImplementedViewProps) => {
+    const layout = useScreenLayout();
+    const isCompact = layout === 'compact';
     
     return (
         <MainBackground>
-            <View style={styles.layout}>
-                <View style={styles.navColumn}>
-                    <NavigationBar selected={selected} onClick={onClick} />
+            <View style={[styles.layout, isCompact && styles.layoutCompact]}>
+                <View style={[styles.navColumn, isCompact && styles.navColumnCompact]}>
+                    <NavigationBar selected={selected} onClick={onClick} compact={isCompact} />
                 </View>
                 
                 <View style={styles.content}>
@@ -35,10 +38,16 @@ const styles = StyleSheet.create({
         flex: 1,
         flexDirection: 'row',
     },  
+    layoutCompact: {
+        flexDirection: 'column',
+    },
     navColumn: {
         width: 150,
     },
-  
+    navColumnCompact: {
+        width: '100%',
+        height: 56,
+    },
     container: {
         flex: 1,
     },
@@ -54,16 +63,16 @@ const styles = StyleSheet.create({
     },
 });
 
-export const NotImplementedPage= ( {selected}:{selected?:TNavigationItem}) => {
-    const incyclist = useIncyclist()
+export const NotImplementedPage = ({ selected }: { selected?: TNavigationItem }) => {
+    const incyclist = useIncyclist();
 
-    const onClick=( item:TNavigationItem)=> {
-        if (item==='exit') {
+    const onClick = (item: TNavigationItem) => {
+        if (item === 'exit') {
             incyclist.onAppExit()
-                .then( ()=>{ getUIBinding().quit()})
+                .then(() => { getUIBinding().quit(); });
         }
         else 
-            navigate(item)
-    }
-    return <NotImplementedView selected={selected!} onClick={onClick}/>
-}
+            navigate(item);
+    };
+    return <NotImplementedView selected={selected!} onClick={onClick} />;
+};

--- a/src/pages/NotImplemented/__snapshots__/NotImplementedPage.test.tsx.snap
+++ b/src/pages/NotImplemented/__snapshots__/NotImplementedPage.test.tsx.snap
@@ -1,0 +1,106 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotImplementedView renders correctly in compact layout 1`] = `
+<View
+  style={
+    [
+      {
+        "flex": 1,
+        "flexDirection": "row",
+      },
+      {
+        "flexDirection": "column",
+      },
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {
+          "width": 150,
+        },
+        {
+          "height": 56,
+          "width": "100%",
+        },
+      ]
+    }
+  />
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "bottom": 0,
+        "gap": 24,
+        "justifyContent": "center",
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "#FFFFFF",
+          "fontSize": 24,
+        }
+      }
+    >
+      Not yet implemented
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`NotImplementedView renders correctly in normal layout 1`] = `
+<View
+  style={
+    [
+      {
+        "flex": 1,
+        "flexDirection": "row",
+      },
+      false,
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {
+          "width": 150,
+        },
+        false,
+      ]
+    }
+  />
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "bottom": 0,
+        "gap": 24,
+        "justifyContent": "center",
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "#FFFFFF",
+          "fontSize": 24,
+        }
+      }
+    >
+      Not yet implemented
+    </Text>
+  </View>
+</View>
+`;

--- a/src/pages/RoutesPage/View.test.tsx
+++ b/src/pages/RoutesPage/View.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { RoutesPageView } from './View';
+
+jest.mock('../../components', () => ({
+    NavigationBar: () => null,
+    MainBackground: ({ children }: any) => children,
+    RoutesTable: () => null,
+    FilterPanel: () => null,
+}));
+
+const MOCK_PROPS: any = {
+    loading: false,
+    synchronizing: false,
+    routes: [],
+    filters: {},
+    filterOptions: { countries: [], contentTypes: [], routeTypes: [], routeSources: [] },
+    filterVisible: false,
+    compact: false,
+    showImportDialog: false,
+    onFilterToggle: jest.fn(),
+    onNavigate: jest.fn(),
+    onImportClicked: jest.fn(),
+    onFilterChanged: jest.fn(),
+    onImportClose: jest.fn(),
+};
+
+describe('RoutesPageView', () => {
+    it('renders correctly in normal layout', () => {
+        const { toJSON } = render(<RoutesPageView {...MOCK_PROPS} compact={false} />);
+        expect(toJSON()).toMatchSnapshot();
+    });
+
+    it('renders correctly in compact layout', () => {
+        const { toJSON } = render(<RoutesPageView {...MOCK_PROPS} compact={true} />);
+        expect(toJSON()).toMatchSnapshot();
+    });
+});

--- a/src/pages/RoutesPage/View.tsx
+++ b/src/pages/RoutesPage/View.tsx
@@ -48,8 +48,8 @@ export const RoutesPageView = (props: RoutesPageViewProps) => {
 
     return (
         <MainBackground>
-            <View style={styles.container}>
-                <View style={[styles.navColumn, { width: compact ? 70 : 150 }]}>
+            <View style={[styles.container, compact && styles.containerCompact]}>
+                <View style={[styles.navColumn, compact ? styles.navColumnCompact : styles.navColumnNormal]}>
                     <NavigationBar
                         compact={compact}
                         selected="routes"
@@ -124,9 +124,19 @@ const styles = StyleSheet.create({
         flex: 1,
         flexDirection: 'row',
     },
+    containerCompact: {
+        flexDirection: 'column',
+    },
     navColumn: {
         flexDirection: 'column',
         alignSelf: 'stretch',
+    },
+    navColumnNormal: {
+        width: 150,
+    },
+    navColumnCompact: {
+        height: 56,
+        width: '100%',
     },
     contentColumn: {
         flex: 1,

--- a/src/pages/RoutesPage/__snapshots__/View.test.tsx.snap
+++ b/src/pages/RoutesPage/__snapshots__/View.test.tsx.snap
@@ -1,0 +1,414 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RoutesPageView renders correctly in compact layout 1`] = `
+<View
+  style={
+    [
+      {
+        "flex": 1,
+        "flexDirection": "row",
+      },
+      {
+        "flexDirection": "column",
+      },
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {
+          "alignSelf": "stretch",
+          "flexDirection": "column",
+        },
+        {
+          "height": 56,
+          "width": "100%",
+        },
+      ]
+    }
+  />
+  <View
+    style={
+      {
+        "flex": 1,
+        "flexDirection": "column",
+        "overflow": "hidden",
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+          "paddingHorizontal": 12,
+          "paddingVertical": 8,
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "flex-end",
+          }
+        }
+      />
+      <Text
+        style={
+          {
+            "color": "#FFFFFF",
+            "fontSize": 28,
+            "fontWeight": "700",
+            "textAlign": "center",
+          }
+        }
+      >
+        ROUTES
+      </Text>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "flex-end",
+          }
+        }
+      >
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "borderColor": "#dd9933",
+              "borderRadius": 8,
+              "borderWidth": 1,
+              "flexDirection": "row",
+              "gap": 6,
+              "opacity": 1,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            }
+          }
+        >
+          <RNSVGSvgView
+            align="xMidYMid"
+            bbHeight={20}
+            bbWidth={20}
+            focusable={false}
+            height={20}
+            meetOrSlice={0}
+            minX={0}
+            minY={0}
+            style={
+              [
+                {
+                  "backgroundColor": "transparent",
+                  "borderWidth": 0,
+                },
+                {
+                  "flex": 0,
+                  "height": 20,
+                  "width": 20,
+                },
+              ]
+            }
+            vbHeight={24}
+            vbWidth={24}
+            width={20}
+          >
+            <RNSVGGroup
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+            >
+              <RNSVGPath
+                d="M12 3v12m0 0l-4-4m4 4l4-4M3 19h18"
+                fill={null}
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                    "strokeLinecap",
+                    "strokeLinejoin",
+                  ]
+                }
+                stroke={
+                  {
+                    "payload": 4292712755,
+                    "type": 0,
+                  }
+                }
+                strokeLinecap={1}
+                strokeLinejoin={1}
+                strokeWidth={2}
+              />
+            </RNSVGGroup>
+          </RNSVGSvgView>
+          <Text
+            style={
+              {
+                "color": "#dd9933",
+                "fontSize": 16,
+                "fontWeight": "600",
+              }
+            }
+          >
+            Import Route
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View
+      style={{}}
+    />
+    <View
+      style={
+        {
+          "flex": 1,
+        }
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`RoutesPageView renders correctly in normal layout 1`] = `
+<View
+  style={
+    [
+      {
+        "flex": 1,
+        "flexDirection": "row",
+      },
+      false,
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {
+          "alignSelf": "stretch",
+          "flexDirection": "column",
+        },
+        {
+          "width": 150,
+        },
+      ]
+    }
+  />
+  <View
+    style={
+      {
+        "flex": 1,
+        "flexDirection": "column",
+        "overflow": "hidden",
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+          "paddingHorizontal": 12,
+          "paddingVertical": 8,
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "flex-end",
+          }
+        }
+      />
+      <Text
+        style={
+          {
+            "color": "#FFFFFF",
+            "fontSize": 28,
+            "fontWeight": "700",
+            "textAlign": "center",
+          }
+        }
+      >
+        ROUTES
+      </Text>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "flex-end",
+          }
+        }
+      >
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "borderColor": "#dd9933",
+              "borderRadius": 8,
+              "borderWidth": 1,
+              "flexDirection": "row",
+              "gap": 6,
+              "opacity": 1,
+              "paddingHorizontal": 12,
+              "paddingVertical": 8,
+            }
+          }
+        >
+          <RNSVGSvgView
+            align="xMidYMid"
+            bbHeight={20}
+            bbWidth={20}
+            focusable={false}
+            height={20}
+            meetOrSlice={0}
+            minX={0}
+            minY={0}
+            style={
+              [
+                {
+                  "backgroundColor": "transparent",
+                  "borderWidth": 0,
+                },
+                {
+                  "flex": 0,
+                  "height": 20,
+                  "width": 20,
+                },
+              ]
+            }
+            vbHeight={24}
+            vbWidth={24}
+            width={20}
+          >
+            <RNSVGGroup
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+            >
+              <RNSVGPath
+                d="M12 3v12m0 0l-4-4m4 4l4-4M3 19h18"
+                fill={null}
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                    "strokeLinecap",
+                    "strokeLinejoin",
+                  ]
+                }
+                stroke={
+                  {
+                    "payload": 4292712755,
+                    "type": 0,
+                  }
+                }
+                strokeLinecap={1}
+                strokeLinejoin={1}
+                strokeWidth={2}
+              />
+            </RNSVGGroup>
+          </RNSVGSvgView>
+          <Text
+            style={
+              {
+                "color": "#dd9933",
+                "fontSize": 16,
+                "fontWeight": "600",
+              }
+            }
+          >
+            Import Route
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View
+      style={{}}
+    />
+    <View
+      style={
+        {
+          "flex": 1,
+        }
+      }
+    />
+  </View>
+</View>
+`;

--- a/src/pages/VideoDemo/View.test.tsx
+++ b/src/pages/VideoDemo/View.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { VideoDemoView } from './View';
+import { useScreenLayout } from '../../hooks/render/useScreenLayout';
+
+jest.mock('../../hooks/render/useScreenLayout');
+jest.mock('../../components', () => ({
+    NavigationBar: () => null,
+    Video: () => null,
+    Dynamic: ({ children }: any) => children,
+}));
+jest.mock('incyclist-services', () => ({
+    Observer: jest.fn().mockImplementation(() => ({
+        on: jest.fn(),
+        emit: jest.fn(),
+        stop: jest.fn(),
+    })),
+}));
+
+describe('VideoDemoView', () => {
+    const mockProps = {
+        onClick: jest.fn(),
+    };
+
+    it('renders correctly in normal layout', () => {
+        (useScreenLayout as jest.Mock).mockReturnValue('normal');
+        const { toJSON } = render(<VideoDemoView {...mockProps} />);
+        expect(toJSON()).toMatchSnapshot();
+    });
+
+    it('renders correctly in compact layout', () => {
+        (useScreenLayout as jest.Mock).mockReturnValue('compact');
+        const { toJSON } = render(<VideoDemoView {...mockProps} />);
+        expect(toJSON()).toMatchSnapshot();
+    });
+});

--- a/src/pages/VideoDemo/View.tsx
+++ b/src/pages/VideoDemo/View.tsx
@@ -3,6 +3,7 @@ import { View, StyleSheet, Text, TouchableOpacity, Platform } from 'react-native
 import { Dynamic, NavigationBar, Video } from '../../components';
 import { colors, textSizes } from '../../theme';
 import { useUnmountEffect } from '../../hooks';
+import { useScreenLayout } from '../../hooks/render/useScreenLayout';
 import type { TNavigationItem, VideoPlaybackEvent } from '../../components';
 import { IObserver, Observer } from 'incyclist-services';
 
@@ -22,30 +23,34 @@ interface PlaybackStatusProps {
     status: TStatusProps
 }
 
-const PlaybackStatus = ({ status}: PlaybackStatusProps) => {
+const PlaybackStatus = ({ status }: PlaybackStatusProps) => {
 
-    const {currentTime, currentRate,bufferedTime,statusLines=[] } = status
+    const { currentTime, currentRate, bufferedTime, statusLines = [] } = status;
 
-    return(
-    <View style={styles.statusSection}>
-        <Text style={styles.statusSummary}>
-            Time: {currentTime.toFixed(1)}s   Rate: {currentRate}×   Buf: {bufferedTime.toFixed(1)}s
-        </Text>        
-        {statusLines.map((line, index) => (
-            <Text key={index} style={styles.statusLine}>{line}</Text>
-        ))}
-    </View>
-)};
+    return (
+        <View style={styles.statusSection}>
+            <Text style={styles.statusSummary}>
+                Time: {currentTime.toFixed(1)}s   Rate: {currentRate}×   Buf: {bufferedTime.toFixed(1)}s
+            </Text>        
+            {statusLines.map((line, index) => (
+                <Text key={index} style={styles.statusLine}>{line}</Text>
+            ))}
+        </View>
+    );
+};
 
 export const VideoDemoView = ({ onClick }: RidePageViewProps) => {
     const [muted, setMuted] = useState(true);
 
+    const layout = useScreenLayout();
+    const isCompact = layout === 'compact';
+
     const refObserver = useRef<IObserver | null>(null);
     const refInitialized = useRef(false); // Gate for observer initialization
-    const [initialized, setInitialized] = useState(false)
+    const [initialized, setInitialized] = useState(false);
 
-    const refStatus = useRef<TStatusProps>({currentTime:0, currentRate:0, bufferedTime:0, statusLines:[]})
-    const refStatusUpdateObserver = useRef( new Observer())
+    const refStatus = useRef<TStatusProps>({ currentTime: 0, currentRate: 0, bufferedTime: 0, statusLines: [] });
+    const refStatusUpdateObserver = useRef(new Observer());
 
     // Initialize observer once on mount
     useEffect(() => {
@@ -53,7 +58,7 @@ export const VideoDemoView = ({ onClick }: RidePageViewProps) => {
             return;
         }
         refObserver.current = new Observer();
-        setInitialized(true)
+        setInitialized(true);
     }, [initialized]);
 
     // Cleanup observer on unmount
@@ -63,21 +68,21 @@ export const VideoDemoView = ({ onClick }: RidePageViewProps) => {
     });
 
     const addStatus = useCallback((line: string) => {
-        const prev = refStatus.current.statusLines
+        const prev = refStatus.current.statusLines;
         refStatus.current.statusLines = [`${new Date().toISOString()} ${line}`, ...prev].slice(0, 4);
 
-        console.log('# add Status',line)
+        console.log('# add Status', line);
     }, []);
 
     const emitRate = useCallback((rate: number) => {
-        refStatus.current.currentRate = rate
-        refStatusUpdateObserver.current.emit('update', refStatus.current)
+        refStatus.current.currentRate = rate;
+        refStatusUpdateObserver.current.emit('update', refStatus.current);
         refObserver.current?.emit('rate-update', rate);
     }, []);
 
     const emitSeek = useCallback((time: number) => {
-        refStatus.current.currentTime = time
-        refStatusUpdateObserver.current.emit('update', refStatus.current)
+        refStatus.current.currentTime = time;
+        refStatusUpdateObserver.current.emit('update', refStatus.current);
         refObserver.current?.emit('time-update', time);
     }, []);
 
@@ -110,44 +115,44 @@ export const VideoDemoView = ({ onClick }: RidePageViewProps) => {
 
 
     const handleLoaded = useCallback((bufferedTime: number) => {
-        console.log('# video loaded',bufferedTime)
+        console.log('# video loaded', bufferedTime);
         addStatus(`loaded buffer=${bufferedTime.toFixed(1)}s`);
     }, [addStatus]);
 
-    const handleLoadError = useCallback((error:any) => {
-        console.log('# video load error',error)
+    const handleLoadError = useCallback((error: any) => {
+        console.log('# video load error', error);
         addStatus(`load-error ${error.message ?? error.code}`);
     }, [addStatus]);
 
-    const handlePlaybackError = useCallback((error:any) => {
-        console.log('# video playback error',error)
+    const handlePlaybackError = useCallback((error: any) => {
+        console.log('# video playback error', error);
         addStatus(`playback-error ${error.message ?? error.code}`);
     }, [addStatus]);
 
-    const handleStalled = useCallback((time:number, bufferedTime:number) => {
-        console.log('# video stalled', time, bufferedTime)
+    const handleStalled = useCallback((time: number, bufferedTime: number) => {
+        console.log('# video stalled', time, bufferedTime);
         addStatus(`stalled t=${time.toFixed(1)}s buf=${bufferedTime.toFixed(1)}s`);
     }, [addStatus]);
 
-    const handleWaiting = useCallback((time:number, rate:number, bufferedTime:number) => {
-        console.log('# video waiting', time, rate,bufferedTime)
+    const handleWaiting = useCallback((time: number, rate: number, bufferedTime: number) => {
+        console.log('# video waiting', time, rate, bufferedTime);
         addStatus(`waiting t=${time.toFixed(1)}s rate=${rate} buf=${bufferedTime.toFixed(1)}s`);
     }, [addStatus]);
 
     const handleEnded = useCallback(() => {
-        console.log('# video ended' )
+        console.log('# video ended' );
         addStatus('ended');
     }, [addStatus]);
 
-    const handleProgress  =useCallback( (time:number, rate:number,event: VideoPlaybackEvent)=>{
-        console.log('# video progress', time, rate)
-        refStatus.current.currentTime = time
-        refStatus.current.currentRate = rate
-        refStatus.current.bufferedTime = event?.bufferedTime ?? 0
-        refStatusUpdateObserver.current.emit('update', refStatus.current)
+    const handleProgress = useCallback((time: number, rate: number, event: VideoPlaybackEvent) => {
+        console.log('# video progress', time, rate);
+        refStatus.current.currentTime = time;
+        refStatus.current.currentRate = rate;
+        refStatus.current.bufferedTime = event?.bufferedTime ?? 0;
+        refStatusUpdateObserver.current.emit('update', refStatus.current);
 
         // Do NOT add a status line here — fires too frequently
-    },[])
+    }, []);
 
 
 
@@ -159,8 +164,8 @@ export const VideoDemoView = ({ onClick }: RidePageViewProps) => {
                         src={videoSrc}
                         startTime={0}
                         observer={refObserver.current}
-                        width='100%'
-                        height='100%'
+                        width="100%"
+                        height="100%"
                         muted={muted}
                         loop={false}
                         hidden={false}
@@ -175,11 +180,11 @@ export const VideoDemoView = ({ onClick }: RidePageViewProps) => {
                 </View>
             )}
 
-            <View style={styles.navColumn}>
-                <NavigationBar onClick={onClick} />
+            <View style={isCompact ? styles.navColumnCompact : styles.navColumn}>
+                <NavigationBar onClick={onClick} compact={isCompact} />
             </View>
 
-            <View style={styles.controlPanel}>
+            <View style={[styles.controlPanel, isCompact && styles.controlPanelCompact]}>
                 <View style={styles.controlRow}>
                     <Text style={styles.controlLabel}>RATE</Text>
                     {renderRateButton(0, '0×')}
@@ -208,7 +213,7 @@ export const VideoDemoView = ({ onClick }: RidePageViewProps) => {
                     </TouchableOpacity>
                 </View>
 
-                <Dynamic observer={refStatusUpdateObserver.current } event='update' prop='status' >
+                <Dynamic observer={refStatusUpdateObserver.current } event="update" prop="status" >
                     <PlaybackStatus status={ refStatus.current} />
                 </Dynamic>
 
@@ -234,6 +239,14 @@ const styles = StyleSheet.create({
         width: 150, // Same width as MainPage
         zIndex: 1,
     },
+    navColumnCompact: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        height: 56,
+        zIndex: 1,
+    },
     controlPanel: {
         position: 'absolute',
         bottom: 0,
@@ -242,6 +255,10 @@ const styles = StyleSheet.create({
         backgroundColor: 'rgba(0, 0, 0, 0.55)',
         padding: 12,
         zIndex: 2,
+    },
+    controlPanelCompact: {
+        top: 56,
+        left: 0,
     },
     controlRow: {
         flexDirection: 'row',

--- a/src/pages/VideoDemo/__snapshots__/View.test.tsx.snap
+++ b/src/pages/VideoDemo/__snapshots__/View.test.tsx.snap
@@ -1,0 +1,1456 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VideoDemoView renders correctly in compact layout 1`] = `
+<View
+  style={
+    {
+      "backgroundColor": "#1E1E1E",
+      "flex": 1,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+        "zIndex": 0,
+      }
+    }
+  />
+  <View
+    style={
+      {
+        "height": 56,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+        "zIndex": 1,
+      }
+    }
+  />
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "rgba(0, 0, 0, 0.55)",
+          "bottom": 0,
+          "left": 150,
+          "padding": 12,
+          "position": "absolute",
+          "right": 0,
+          "zIndex": 2,
+        },
+        {
+          "left": 0,
+          "top": 56,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "gap": 8,
+          "marginBottom": 8,
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "#9fa4a8",
+            "fontSize": 16,
+            "marginRight": 8,
+            "minWidth": 50,
+            "textTransform": "uppercase",
+          }
+        }
+      >
+        RATE
+      </Text>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "#dd9933",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          0×
+        </Text>
+      </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255,255,255,0.12)",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          0.5×
+        </Text>
+      </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255,255,255,0.12)",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          1×
+        </Text>
+      </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255,255,255,0.12)",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          2×
+        </Text>
+      </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255,255,255,0.12)",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          4×
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "gap": 8,
+          "marginBottom": 8,
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "#9fa4a8",
+            "fontSize": 16,
+            "marginRight": 8,
+            "minWidth": 50,
+            "textTransform": "uppercase",
+          }
+        }
+      >
+        SEEK
+      </Text>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255,255,255,0.12)",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          0s
+        </Text>
+      </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255,255,255,0.12)",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          30s
+        </Text>
+      </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255,255,255,0.12)",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          60s
+        </Text>
+      </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255,255,255,0.12)",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          120s
+        </Text>
+      </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255,255,255,0.12)",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          300s
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "gap": 8,
+          "marginBottom": 8,
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "#9fa4a8",
+            "fontSize": 16,
+            "marginRight": 8,
+            "minWidth": 50,
+            "textTransform": "uppercase",
+          }
+        }
+      >
+        OPTIONS
+      </Text>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255,255,255,0.12)",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          UNMUTE
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        {
+          "borderTopColor": "rgba(255,255,255,0.1)",
+          "borderTopWidth": 1,
+          "marginTop": 10,
+          "paddingTop": 8,
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "#dd9933",
+            "fontSize": 16,
+            "fontWeight": "700",
+            "marginBottom": 4,
+          }
+        }
+      >
+        Time: 
+        0.0
+        s   Rate: 
+        0
+        ×   Buf: 
+        0.0
+        s
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`VideoDemoView renders correctly in normal layout 1`] = `
+<View
+  style={
+    {
+      "backgroundColor": "#1E1E1E",
+      "flex": 1,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+        "zIndex": 0,
+      }
+    }
+  />
+  <View
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "top": 0,
+        "width": 150,
+        "zIndex": 1,
+      }
+    }
+  />
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "rgba(0, 0, 0, 0.55)",
+          "bottom": 0,
+          "left": 150,
+          "padding": 12,
+          "position": "absolute",
+          "right": 0,
+          "zIndex": 2,
+        },
+        false,
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "gap": 8,
+          "marginBottom": 8,
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "#9fa4a8",
+            "fontSize": 16,
+            "marginRight": 8,
+            "minWidth": 50,
+            "textTransform": "uppercase",
+          }
+        }
+      >
+        RATE
+      </Text>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "#dd9933",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          0×
+        </Text>
+      </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255,255,255,0.12)",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          0.5×
+        </Text>
+      </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255,255,255,0.12)",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          1×
+        </Text>
+      </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255,255,255,0.12)",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          2×
+        </Text>
+      </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255,255,255,0.12)",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          4×
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "gap": 8,
+          "marginBottom": 8,
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "#9fa4a8",
+            "fontSize": 16,
+            "marginRight": 8,
+            "minWidth": 50,
+            "textTransform": "uppercase",
+          }
+        }
+      >
+        SEEK
+      </Text>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255,255,255,0.12)",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          0s
+        </Text>
+      </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255,255,255,0.12)",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          30s
+        </Text>
+      </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255,255,255,0.12)",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          60s
+        </Text>
+      </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255,255,255,0.12)",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          120s
+        </Text>
+      </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255,255,255,0.12)",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          300s
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "gap": 8,
+          "marginBottom": 8,
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "#9fa4a8",
+            "fontSize": 16,
+            "marginRight": 8,
+            "minWidth": 50,
+            "textTransform": "uppercase",
+          }
+        }
+      >
+        OPTIONS
+      </Text>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255,255,255,0.12)",
+            "borderRadius": 3,
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          UNMUTE
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        {
+          "borderTopColor": "rgba(255,255,255,0.1)",
+          "borderTopWidth": 1,
+          "marginTop": 10,
+          "paddingTop": 8,
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "#dd9933",
+            "fontSize": 16,
+            "fontWeight": "700",
+            "marginBottom": 4,
+          }
+        }
+      >
+        Time: 
+        0.0
+        s   Rate: 
+        0
+        ×   Buf: 
+        0.0
+        s
+      </Text>
+    </View>
+  </View>
+</View>
+`;


### PR DESCRIPTION
Closes #103

Updates `MainPage`, `RoutesPage`, `NotImplementedPage`, and `VideoDemo` to support the compact screen layout (height < 420px). 

Key changes:
- Switch `flexDirection` from `row` to `column` on compact screens.
- Update `NavigationBar` container to a fixed height of 56px at the top on compact screens.
- Adjusted absolute positioning in `VideoDemo` to handle the top-bar layout.
- Added unit tests for each view covering both compact and normal layout modes.