### PR TITLE
SettingsSlideIn and Dialog compact layout

### DIFF
--- a/__mocks__/react-native-safe-area-context.ts
+++ b/__mocks__/react-native-safe-area-context.ts
@@ -1,0 +1,3 @@
+export const useSafeAreaInsets = () => ({ top: 0, bottom: 0, left: 0, right: 0 });
+export const SafeAreaProvider = ({ children }: any) => children;
+export const SafeAreaConsumer = ({ children }: any) => children({ top: 0, bottom: 0, left: 0, right: 0 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   moduleNameMapper: {
     '^react-native-linear-gradient$': '<rootDir>/__mocks__/react-native-linear-gradient.tsx',
     '\\.svg$': '<rootDir>/__mocks__/svgMock.tsx',
+    'react-native-safe-area-context': '<rootDir>/__mocks__/react-native-safe-area-context.ts',
     '@react-navigation/native': '<rootDir>/src/__mocks__/@react-navigation/native.ts', // Added for ESM module support
   },
 };

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -14,6 +14,7 @@ import {
     Animated,
     useWindowDimensions,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ButtonBar } from '../ButtonBar';
 import { colors, textSizes } from '../../theme';
 import { useLogging, useUnmountEffect, useScreenLayout } from '../../hooks';
@@ -34,15 +35,25 @@ export const Dialog = ({
     const { logEvent } = useLogging('Incyclist');
     const refInitialized = useRef<boolean>(false);
     const layout = useScreenLayout();
-    const { width: screenWidth } = useWindowDimensions();
+    const { width: screenWidth, height: screenHeight } = useWindowDimensions();
+    const { top: safeAreaTop } = useSafeAreaInsets();
 
     const [isModalActive, setIsModalActive] = useState(false);
     const [isAnimating, setIsAnimating] = useState(false);
 
+    const isCompact = layout === 'compact';
+    const NAV_BAR_HEIGHT = 56;
+    const stripHeight = NAV_BAR_HEIGHT + safeAreaTop;
+
     const defaultSlideFrom = 'left';
     const actualSlideFrom = variant === 'full' ? (slideFrom || defaultSlideFrom) : undefined;
-    const initialTranslateX = actualSlideFrom === 'left' ? -screenWidth : 0;
-    const animTranslateX = useRef(new Animated.Value(initialTranslateX)).current;
+    
+    // Animation constants
+    const initialPos = isCompact 
+        ? -screenHeight 
+        : (actualSlideFrom === 'left' ? -screenWidth : screenWidth);
+    
+    const animPos = useRef(new Animated.Value(initialPos)).current;
 
     useEffect(() => {
         if (variant !== 'full') {
@@ -62,14 +73,14 @@ export const Dialog = ({
 
         if (visible && !isModalActive) {
             setIsModalActive(true);
-
-            animTranslateX.setValue(actualSlideFrom === 'left' ? -screenWidth : screenWidth);
+            animPos.setValue(initialPos);
             setIsAnimating(true);
-            Animated.timing(animTranslateX, {
+            Animated.timing(animPos, {
                 toValue: 0,
                 duration: 220,
                 useNativeDriver: true,
             }).start(() => {
+                setIsAnimating(true); // Should be false but matches logic to signal end of move
                 setIsAnimating(false);
                 if (!refInitialized.current) {
                     refInitialized.current = true;
@@ -79,8 +90,8 @@ export const Dialog = ({
             });
         } else if (!visible && isModalActive) {
             setIsAnimating(true);
-            Animated.timing(animTranslateX, {
-                toValue: actualSlideFrom === 'left' ? -screenWidth : screenWidth,
+            Animated.timing(animPos, {
+                toValue: initialPos,
                 duration: 220,
                 useNativeDriver: true,
             }).start(() => {
@@ -93,7 +104,7 @@ export const Dialog = ({
                 }
             });
         }
-    }, [visible, isModalActive, animTranslateX, screenWidth, actualSlideFrom, variant, logEvent, title]);
+    }, [visible, isModalActive, animPos, initialPos, variant, logEvent, title]);
 
     useUnmountEffect(() => {
         if (refInitialized.current) {
@@ -103,7 +114,7 @@ export const Dialog = ({
         }
     });
 
-    const styles = getStyles({ width, height, minWidth, minHeight, variant });
+    const styles = getStyles({ width, height, minWidth, minHeight, variant, isCompact, stripHeight });
 
     const gradientColors = colors.dialogBackground;
 
@@ -112,15 +123,15 @@ export const Dialog = ({
         ? [styles.container, { backgroundColor: gradientColors[gradientColors.length - 1] }]
         : styles.container;
 
-    const isCompact = layout === 'compact';
-    const stripWidth = isCompact ? 70 : 150;
-    const stripWidthStyle = { width: stripWidth };
-
     if (variant === 'full' && !isModalActive && !isAnimating) {
         return null;
     }
 
     if (variant === 'full') {
+        const dynamicTransform = isCompact 
+            ? { translateY: animPos } 
+            : { translateX: animPos };
+
         return (
             <Modal
                 transparent={true}
@@ -130,11 +141,11 @@ export const Dialog = ({
             >
                 <Animated.View style={[
                     styles.fullScreenWrapper,
-                    { transform: [{ translateX: animTranslateX }] },
+                    { transform: [dynamicTransform] },
                 ]}>
                     <View style={styles.fullLayout}>
                         <TouchableOpacity
-                            style={[styles.strip, stripWidthStyle]}
+                            style={styles.strip}
                             onPress={onOutsideClick}
                             activeOpacity={1}
                         />
@@ -214,7 +225,7 @@ type StyleProps = {
     variant?: DialogVariant
 }
 
-const getStyles = ({ width, height, minWidth, minHeight, variant = 'details' }: StyleProps) => {
+const getStyles = ({ width, height, minWidth, minHeight, variant = 'details', isCompact, stripHeight }: StyleProps & { isCompact: boolean, stripHeight: number }) => {
     return StyleSheet.create({
         overlay: {
             flex: 1,
@@ -243,7 +254,7 @@ const getStyles = ({ width, height, minWidth, minHeight, variant = 'details' }: 
         },
         scrollArea: {
             flexShrink: 1,
-            padding:8,
+            padding: 8,
         },
         content: {
             flexGrow: variant === 'details' || variant === 'full' ? 1 : 0,
@@ -259,14 +270,15 @@ const getStyles = ({ width, height, minWidth, minHeight, variant = 'details' }: 
         },
         fullLayout: {
             flex: 1,
-            flexDirection: 'row',
+            flexDirection: isCompact ? 'column' : 'row',
         },
         strip: {
-            height: '100%',
+            height: isCompact ? stripHeight : '100%',
+            width: isCompact ? '100%' : 150,
         },
         fullContentArea: {
             flex: 1,
-            height: '100%',
+            height: isCompact ? undefined : '100%',
             borderRadius: 0,
             maxHeight: '100%',
         },

--- a/src/components/SettingsSlideIn/SettingsSlideIn.tsx
+++ b/src/components/SettingsSlideIn/SettingsSlideIn.tsx
@@ -12,7 +12,7 @@ import {
 import LinearGradient from 'react-native-linear-gradient';
 import { SettingsSlideInProps } from './types';
 import { colors, textSizes } from '../../theme';
-import { useLogging, useScreenLayout } from '../../hooks'; // Add useScreenLayout
+import { useLogging, useScreenLayout } from '../../hooks';
 
 const gradientColors = colors.dialogBackground;
 const BackgroundContainer = Platform.OS === 'web' ? View : (LinearGradient as any);
@@ -26,18 +26,19 @@ export const SettingsSlideIn = ({
     onClose,
     onSectionPress
 }: SettingsSlideInProps) => {
-    const { width: screenWidth } = useWindowDimensions();
+    const { width: screenWidth, height: screenHeight } = useWindowDimensions();
     const { logEvent } = useLogging('SettingsSlideIn');
-    const layout = useScreenLayout(); // Get screen layout
-    const isCompact = layout === 'compact'; // Determine if compact
+    const layout = useScreenLayout();
+    const isCompact = layout === 'compact';
+    const NAV_BAR_HEIGHT = 56;
 
-    // Calculate widths as per instructions
-    const stripWidth = isCompact ? 70 : 150;
-    const panelWidth = screenWidth * 0.35; // Unchanged fixed panel width
-    const totalWidth = stripWidth + panelWidth; // Total width of the sliding unit
+    // Layout calculations
+    const stripSize = isCompact ? NAV_BAR_HEIGHT : 150;
+    const panelWidth = screenWidth * 0.35;
+    const totalSize = isCompact ? screenHeight : (stripSize + panelWidth);
     
-    // Start off-screen (left)
-    const animTranslateX = useRef(new Animated.Value(-totalWidth)).current; // Use totalWidth for initial position
+    // Start off-screen
+    const animPos = useRef(new Animated.Value(-totalSize)).current;
     
     // Track animation state to handle backdrop visibility and pointer events
     const [isAnimating, setIsAnimating] = useState(false);
@@ -52,14 +53,14 @@ export const SettingsSlideIn = ({
             }
         }
 
-        const targetValue = visible ? 0 : -totalWidth; // Use totalWidth for target
+        const targetValue = visible ? 0 : -totalSize;
         
         if (visible) {
             setIsFullyClosed(false);
         }
         setIsAnimating(true);
 
-        Animated.timing(animTranslateX, {
+        Animated.timing(animPos, {
             toValue: targetValue,
             duration: 220,
             useNativeDriver: true,
@@ -69,20 +70,35 @@ export const SettingsSlideIn = ({
                 setIsFullyClosed(true);
             }
         });
-    }, [visible, animTranslateX, totalWidth]); // Add totalWidth to deps
+    }, [visible, animPos, totalSize]);
 
     const handleSectionPress = (label: string) => {
         logEvent({ message: 'menu item clicked', item: label, eventSource: 'user' });
         onSectionPress(label);
     };
 
-    // If fully closed and not animating, don't show the backdrop/content
     if (isFullyClosed && !isAnimating) {
         return null;
     }
 
     const backdropPointerEvents = visible ? 'auto' : 'none';
     const backdropOpacity = visible ? 1 : 0;
+
+    const dynamicContainerStyle = isCompact 
+        ? { height: totalSize, width: screenWidth, flexDirection: 'column' as const } 
+        : { width: totalSize, flexDirection: 'row' as const };
+
+    const dynamicTransform = isCompact 
+        ? { translateY: animPos } 
+        : { translateX: animPos };
+
+    const dynamicStripStyle = isCompact 
+        ? { height: stripSize, width: '100%' } 
+        : { width: stripSize, height: '100%' };
+
+    const dynamicPanelStyle = isCompact 
+        ? { flex: 1, width: '100%' } 
+        : { width: panelWidth, height: '100%' };
 
     return (
         <View 
@@ -102,22 +118,22 @@ export const SettingsSlideIn = ({
             {/* Sliding Unit (Tap Zone + Panel) */}
             <Animated.View
                 style={[
-                    styles.panelContainer, // Container for both strip and panel
-                    { width: totalWidth }, // Apply total width to the animated unit
-                    { transform: [{ translateX: animTranslateX }] }
+                    styles.panelContainer,
+                    dynamicContainerStyle,
+                    { transform: [dynamicTransform] }
                 ]}
             >
-                {/* Transparent Tap Zone Column */}
+                {/* Transparent Tap Zone */}
                 <TouchableOpacity 
                     onPress={onClose} 
-                    style={[styles.stripZone, { width: stripWidth }]} 
+                    style={[styles.stripZone, dynamicStripStyle]} 
                     testID="settings-slide-in-tap-zone"
                 />
 
                 {/* Sections Panel */}
                 <BackgroundContainer
                     colors={gradientColors}
-                    style={[panelBackgroundStyle, { width: panelWidth }]} // Explicit panel width
+                    style={[panelBackgroundStyle, dynamicPanelStyle]}
                 >
                     <View style={styles.content}>
                         {sections.map((section) => (
@@ -143,20 +159,18 @@ const styles = StyleSheet.create({
         ...StyleSheet.absoluteFill,
         backgroundColor: 'rgba(0,0,0,0.4)',
     },
-    panelContainer: { // New style for the sliding unit wrapper
+    panelContainer: {
         position: 'absolute',
         left: 0,
         top: 0,
         bottom: 0,
         zIndex: 1000,
-        flexDirection: 'row', // Arrange strip and panel side-by-side
     },
     stripZone: {
-        alignSelf: 'stretch', // Ensures it takes full height of panelContainer
-        // No background color, it should be transparent
+        alignSelf: 'stretch',
     },
     content: {
-        flex: 1, // Content needs to flex within its parent BackgroundContainer
+        flex: 1,
         paddingTop: 20,
     },
     row: {

--- a/src/components/SettingsSlideIn/SettingsSlideIn.tsx
+++ b/src/components/SettingsSlideIn/SettingsSlideIn.tsx
@@ -7,7 +7,8 @@ import {
     TouchableWithoutFeedback,
     useWindowDimensions,
     Platform,
-    Text
+    Text,
+    DimensionValue
 } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import { SettingsSlideInProps } from './types';
@@ -93,12 +94,12 @@ export const SettingsSlideIn = ({
         : { translateX: animPos };
 
     const dynamicStripStyle = isCompact 
-        ? { height: stripSize, width: '100%' } 
-        : { width: stripSize, height: '100%' };
+        ? { height: stripSize, width: '100%' as DimensionValue } 
+        : { width: stripSize, height: '100%' as DimensionValue };
 
     const dynamicPanelStyle = isCompact 
-        ? { flex: 1, width: '100%' } 
-        : { width: panelWidth, height: '100%' };
+        ? { flex: 1, width: '100%' as DimensionValue } 
+        : { width: panelWidth, height: '100%' as DimensionValue };
 
     return (
         <View 


### PR DESCRIPTION
Closes #104

This PR updates `SettingsSlideIn` and `Dialog` (full variant) to adapt to the compact layout (phone landscape):
- Both components now slide down from the top using `translateY` on compact screens.
- `SettingsSlideIn` strip zone becomes a horizontal top bar (height 56) with the panel filling the remaining space.
- `Dialog` (full variant) strip zone becomes a horizontal top bar with height accounting for the safe area top inset (`56 + safeAreaTop`).
- On normal layout, both components continue to slide from the side as before.
- Safe area top inset is handled for compact Dialogs to ensure camera cutout areas remain empty.