### PR TITLE
Add ActivitySummaryDialog for ride end summary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@zoontek/react-native-navigation-bar": "^1.1.0",
         "events": "^3.3.0",
         "gd-eventlog": "^0.1.27",
-        "incyclist-services": "^1.7.31",
+        "incyclist-services": "^1.7.32",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
         "react": "^19.2.4",
@@ -11634,9 +11634,9 @@
       }
     },
     "node_modules/incyclist-services": {
-      "version": "1.7.31",
-      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.31.tgz",
-      "integrity": "sha512-rN9q0mI/8sLzkIOzwY7Db90yPn1vnb/wfreA7U6qX1Fzbq/FXl1apxpe8wReFcwJgHCcgcse3jIhXgCFzNP8hw==",
+      "version": "1.7.32",
+      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.32.tgz",
+      "integrity": "sha512-INBiNbD4fRvPSF6hqRjKGMyEW1hzrmDpZ8S81b+KM3uwMKo+CbnObL0GwxlaJxhq+S0jjOzGOYPRhCEholexaQ==",
       "dependencies": {
         "axios": "^1.13.6",
         "incyclist-devices": "^3.0.10",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@zoontek/react-native-navigation-bar": "^1.1.0",
     "events": "^3.3.0",
     "gd-eventlog": "^0.1.27",
-    "incyclist-services": "^1.7.31",
+    "incyclist-services": "^1.7.32",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "react": "^19.2.4",

--- a/src/bindings/fs/index.ts
+++ b/src/bindings/fs/index.ts
@@ -3,16 +3,47 @@ import { IFileSystem } from 'incyclist-services';
 
 export class FileSystemBinding implements IFileSystem {
     async writeFile(path: string, data: any, encoding?: string): Promise<void> {
-        return await RNFS.writeFile(path, data, encoding);
+        console.log('# write file', path);
+        
+        if (Buffer.isBuffer(data)) {
+            // Buffer already contains raw bytes — convert to base64 for RNFS
+            return await RNFS.writeFile(path, data.toString('base64'), 'base64');
+        } else if (typeof data === 'string') {
+            let rnfsEncoding: string = 'utf8';
+            if (encoding === 'base64') {
+                rnfsEncoding = 'base64';
+            } else if (encoding === 'ascii' || encoding === 'binary' || encoding === 'latin1') {
+                return await RNFS.writeFile(path, Buffer.from(data, encoding as BufferEncoding).toString('base64'), 'base64');
+            }
+            return await RNFS.writeFile(path, data, rnfsEncoding);
+        }
     }
 
     async readFile(path: string, encoding?: string): Promise<string> {
-        return await RNFS.readFile(path, encoding);
+        let rnfsEncoding: string = 'utf8';
+    
+        if (encoding === 'base64') {
+            rnfsEncoding = 'base64';
+        } else if (encoding === 'ascii' || encoding === 'binary' || encoding === 'latin1') {
+            // Read as base64, then decode to the requested encoding via Buffer
+            const base64 = await RNFS.readFile(path, 'base64');
+            return Buffer.from(base64, 'base64').toString(encoding as BufferEncoding);
+        }
+        // 'utf8', 'utf-8', undefined all map to 'utf8'
+        return await RNFS.readFile(path, rnfsEncoding);
     }
 
     async appendFile(path: string, data: string, encoding?: string): Promise<void> {
-        return await RNFS.appendFile(path, data, encoding);
+        if (encoding === 'base64') {
+            return await RNFS.appendFile(path, data, 'base64');
+        } else if (encoding === 'ascii' || encoding === 'binary' || encoding === 'latin1') {
+            const base64 = Buffer.from(data, encoding as BufferEncoding).toString('base64');
+            return await RNFS.appendFile(path, base64, 'base64');
+        }
+        // 'utf8', 'utf-8', undefined → 'utf8'
+        return await RNFS.appendFile(path, data, 'utf8');
     }
+
 
     async deleteFile(path: string): Promise<void> {
         return await RNFS.unlink(path);

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialog.stories.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialog.stories.tsx
@@ -2,30 +2,15 @@ import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { fn } from 'storybook/test';
 import { ActivitySummaryDialogView } from './ActivitySummaryDialogView';
 import { ActivityDetailsUI } from 'incyclist-services';
+import ActivityLargeJson from '../../../__tests__/testdata/ActivityLarge.json';
 
-const MOCK_ACTIVITY = {
-    id: '1',
-    title: 'Morning Ride',
-    startTime: '2026-03-31T10:00:00Z',
-    time: 3600,
-    distance: { value: 25.3, unit: 'km' },
-    totalElevation: { value: 320, unit: 'm' },
-    fileName: 'activity_1.json',
-    tcxFileName: 'activity_1.tcx',
-    fitFileName: null,
-    stats: {
-        speed: { avg: 18.5 },
-        power: { avg: 180 },
-        hrm: { avg: 145 },
-        cadence: { avg: 88 },
-    },
-} as unknown as ActivityDetailsUI;
+const defaultActivity = ActivityLargeJson as unknown as ActivityDetailsUI;
 
 const meta: Meta<typeof ActivitySummaryDialogView> = {
     title: 'Components/ActivitySummaryDialog',
     component: ActivitySummaryDialogView,
     args: {
-        activity: MOCK_ACTIVITY,
+        activity: defaultActivity,
         showMap: false,
         showSave: true,
         isSaving: false,
@@ -46,6 +31,12 @@ export default meta;
 type Story = StoryObj<typeof ActivitySummaryDialogView>;
 
 export const Default: Story = {};
+
+export const Compact: Story = {
+    args: {
+        compact: true,
+    },
+};
 
 export const Saving: Story = {
     args: {

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialog.stories.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialog.stories.tsx
@@ -35,6 +35,7 @@ export const Default: Story = {};
 export const Compact: Story = {
     args: {
         compact: true,
+        showMap: true,
     },
 };
 

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialog.stories.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialog.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { ActivitySummaryDialogView } from './ActivitySummaryDialogView';
+import { ActivityDetailsUI } from 'incyclist-services';
+
+const MOCK_ACTIVITY = {
+    id: '1',
+    title: 'Morning Ride',
+    startTime: '2026-03-31T10:00:00Z',
+    time: 3600,
+    distance: { value: 25.3, unit: 'km' },
+    totalElevation: { value: 320, unit: 'm' },
+    fileName: 'activity_1.json',
+    tcxFileName: 'activity_1.tcx',
+    fitFileName: null,
+    stats: {
+        speed: { avg: 18.5 },
+        power: { avg: 180 },
+        hrm: { avg: 145 },
+        cadence: { avg: 88 },
+    },
+} as unknown as ActivityDetailsUI;
+
+const meta: Meta<typeof ActivitySummaryDialogView> = {
+    title: 'Components/ActivitySummaryDialog',
+    component: ActivitySummaryDialogView,
+    args: {
+        activity: MOCK_ACTIVITY,
+        showMap: false,
+        showSave: true,
+        isSaving: false,
+        isSaved: false,
+        showDeleteConfirm: false,
+        units: { speed: 'km/h', distance: 'km' },
+        onSave: fn(),
+        onClose: fn(),
+        onDelete: fn(),
+        onDeleteConfirm: fn(),
+        onDeleteCancel: fn(),
+        onShareFile: fn(),
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ActivitySummaryDialogView>;
+
+export const Default: Story = {};
+
+export const Saving: Story = {
+    args: {
+        isSaving: true,
+    },
+};
+
+export const Saved: Story = {
+    args: {
+        isSaved: true,
+    },
+};
+
+export const WithMap: Story = {
+    args: {
+        showMap: true,
+    },
+};
+
+export const DeleteConfirm: Story = {
+    args: {
+        showDeleteConfirm: true,
+    },
+};

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialog.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialog.tsx
@@ -1,17 +1,22 @@
-import React, { useState, useCallback, useMemo } from 'react';
-import { useActivityRide, ActivitySummaryDisplayProperties } from 'incyclist-services';
+import React, { useState, useCallback} from 'react';
+import { useActivityRide  } from 'incyclist-services';
 import Share from 'react-native-share';
 import { ActivitySummaryDialogProps } from './types';
 import { ActivitySummaryDialogView } from './ActivitySummaryDialogView';
 import { useLogging } from '../../hooks';
+import { ErrorBoundary } from '../ErrorBoundary';
+import { createMMKV } from 'react-native-mmkv';
+import RNFS from 'react-native-fs';
 
 export const ActivitySummaryDialog = ({ onClose, onExit }: ActivitySummaryDialogProps) => {
     const service = useActivityRide();
     const { logError, logEvent } = useLogging('ActivitySummaryDialog');
 
-    const displayProps: ActivitySummaryDisplayProperties | undefined = useMemo(() => {
-        return service.getActivitySummaryDisplayProperties();
-    }, [service]);
+    const [displayProps, setDisplayProps] = useState(() => 
+        service.getActivitySummaryDisplayProperties()
+    );
+
+
 
     const [isSaving, setIsSaving] = useState(false);
     const [isSaved, setIsSaved] = useState(false);
@@ -21,14 +26,19 @@ export const ActivitySummaryDialog = ({ onClose, onExit }: ActivitySummaryDialog
         logEvent({ message: 'save clicked' });
         setIsSaving(true);
         const observer = service.save();
-        observer.on('done', (success: boolean) => {
+        observer.on('done', () => {
             setIsSaving(false);
             setIsSaved(true);
-            if (!success) {
-                logError(new Error('Save failed'), 'handleSave');
-            }
+
+            const props = service.getActivitySummaryDisplayProperties()
+            setDisplayProps(props);
         });
-    }, [service, logEvent, logError]);
+        observer.on('save.done',()=> {
+            const props = service.getActivitySummaryDisplayProperties()
+            setDisplayProps(props);
+
+        })
+    }, [service, logEvent]);
 
     const handleClose = useCallback(() => {
         if (isSaved) {
@@ -56,36 +66,65 @@ export const ActivitySummaryDialog = ({ onClose, onExit }: ActivitySummaryDialog
     const handleShareFile = useCallback(async (path: string) => {
         logEvent({ message: 'share file', path });
         try {
+            let sharePath = path;
+
+            if (path.startsWith('mmkv:/')) {
+                // MMKV paths need to be materialized to a real file first
+                const withoutScheme = path.slice('mmkv:/'.length);
+                const slashIdx = withoutScheme.indexOf('/');
+                const dbId = withoutScheme.substring(0, slashIdx);
+
+
+                const key = withoutScheme.substring(slashIdx + 1).replace(/\.json$/, '');
+                const storage = createMMKV({ id: dbId });
+
+                const raw = storage.getString(key);
+                if (!raw) throw new Error(`MMKV key not found: ${key} in ${dbId}`);
+                const fileName = key.split('/').pop() ?? 'activity.json';
+                sharePath = `${RNFS.CachesDirectoryPath}/${fileName}`;
+                await RNFS.writeFile(sharePath, raw, 'utf8');
+            
+            } else {
+                // Filesystem files in private data dir need to be copied to cache for sharing on Android
+                const fileName = path.split('/').pop() ?? 'activity.file';
+                sharePath = `${RNFS.CachesDirectoryPath}/${fileName}`;
+                await RNFS.copyFile(path, sharePath);
+            }            
+
+            const url =  sharePath.startsWith('file://') ? sharePath : 'file://' + sharePath
             await Share.open({
-                url: 'file://' + path,
+                url,
                 type: 'application/octet-stream',
                 failOnCancel: false,
             });
-        } catch (err) {
+        } catch (err:any) {
             logError(err as Error, 'handleShareFile');
         }
     }, [logEvent, logError]);
+
 
     if (!displayProps || !displayProps.activity) {
         return null;
     }
 
-    return (
-        <ActivitySummaryDialogView
-            activity={displayProps.activity}
-            showMap={displayProps.showMap ?? false}
-            showSave={displayProps.showSave ?? false}
-            preview={displayProps.preview}
-            units={displayProps.units}
-            isSaving={isSaving}
-            isSaved={isSaved}
-            showDeleteConfirm={showDeleteConfirm}
-            onSave={handleSave}
-            onClose={handleClose}
-            onDelete={handleDelete}
-            onDeleteConfirm={handleDeleteConfirm}
-            onDeleteCancel={handleDeleteCancel}
-            onShareFile={handleShareFile}
-        />
-    );
+        return (
+            <ErrorBoundary >
+                <ActivitySummaryDialogView
+                    activity={displayProps.activity}
+                    showMap={displayProps.showMap ?? false}
+                    showSave={displayProps.showSave ?? false}
+                    preview={displayProps.preview}
+                    units={displayProps.units}
+                    isSaving={isSaving}
+                    isSaved={isSaved}
+                    showDeleteConfirm={showDeleteConfirm}
+                    onSave={handleSave}
+                    onClose={handleClose}
+                    onDelete={handleDelete}
+                    onDeleteConfirm={handleDeleteConfirm}
+                    onDeleteCancel={handleDeleteCancel}
+                    onShareFile={handleShareFile}
+                />
+            </ErrorBoundary>
+        );
 };

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialog.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialog.tsx
@@ -73,8 +73,8 @@ export const ActivitySummaryDialog = ({ onClose, onExit }: ActivitySummaryDialog
     return (
         <ActivitySummaryDialogView
             activity={displayProps.activity}
-            showMap={displayProps.showMap}
-            showSave={displayProps.showSave}
+            showMap={displayProps.showMap ?? false}
+            showSave={displayProps.showSave ?? false}
             preview={displayProps.preview}
             units={displayProps.units}
             isSaving={isSaving}

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialog.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialog.tsx
@@ -1,0 +1,91 @@
+import React, { useState, useCallback, useMemo } from 'react';
+import { useActivityRide, ActivitySummaryDisplayProperties } from 'incyclist-services';
+import Share from 'react-native-share';
+import { ActivitySummaryDialogProps } from './types';
+import { ActivitySummaryDialogView } from './ActivitySummaryDialogView';
+import { useLogging } from '../../hooks';
+
+export const ActivitySummaryDialog = ({ onClose, onExit }: ActivitySummaryDialogProps) => {
+    const service = useActivityRide();
+    const { logError, logEvent } = useLogging('ActivitySummaryDialog');
+
+    const displayProps: ActivitySummaryDisplayProperties | undefined = useMemo(() => {
+        return service.getActivitySummaryDisplayProperties();
+    }, [service]);
+
+    const [isSaving, setIsSaving] = useState(false);
+    const [isSaved, setIsSaved] = useState(false);
+    const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+    const handleSave = useCallback(() => {
+        logEvent({ message: 'save clicked' });
+        setIsSaving(true);
+        const observer = service.save();
+        observer.on('done', (success: boolean) => {
+            setIsSaving(false);
+            setIsSaved(true);
+            if (!success) {
+                logError(new Error('Save failed'), 'handleSave');
+            }
+        });
+    }, [service, logEvent, logError]);
+
+    const handleClose = useCallback(() => {
+        if (isSaved) {
+            onExit();
+        } else {
+            onClose();
+        }
+    }, [isSaved, onExit, onClose]);
+
+    const handleDelete = useCallback(() => {
+        setShowDeleteConfirm(true);
+    }, []);
+
+    const handleDeleteConfirm = useCallback(() => {
+        logEvent({ message: 'delete confirmed' });
+        setShowDeleteConfirm(false);
+        // activityRide.delete() will be wired in follow-up
+        onExit();
+    }, [onExit, logEvent]);
+
+    const handleDeleteCancel = useCallback(() => {
+        setShowDeleteConfirm(false);
+    }, []);
+
+    const handleShareFile = useCallback(async (path: string) => {
+        logEvent({ message: 'share file', path });
+        try {
+            await Share.open({
+                url: 'file://' + path,
+                type: 'application/octet-stream',
+                failOnCancel: false,
+            });
+        } catch (err) {
+            logError(err as Error, 'handleShareFile');
+        }
+    }, [logEvent, logError]);
+
+    if (!displayProps || !displayProps.activity) {
+        return null;
+    }
+
+    return (
+        <ActivitySummaryDialogView
+            activity={displayProps.activity}
+            showMap={displayProps.showMap}
+            showSave={displayProps.showSave}
+            preview={displayProps.preview}
+            units={displayProps.units}
+            isSaving={isSaving}
+            isSaved={isSaved}
+            showDeleteConfirm={showDeleteConfirm}
+            onSave={handleSave}
+            onClose={handleClose}
+            onDelete={handleDelete}
+            onDeleteConfirm={handleDeleteConfirm}
+            onDeleteCancel={handleDeleteCancel}
+            onShareFile={handleShareFile}
+        />
+    );
+};

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.test.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { ActivitySummaryDialogView } from './ActivitySummaryDialogView';
+import { ActivitySummaryDialogViewProps } from './types';
+import { ActivityDetailsUI } from 'incyclist-services';
+
+jest.mock('@maplibre/maplibre-react-native', () => ({
+    MapView: 'MapView',
+    Camera: 'Camera',
+    ShapeSource: 'ShapeSource',
+    LineLayer: 'LineLayer',
+    setAccessToken: jest.fn(),
+    default: { createFragment: jest.fn() },
+}));
+
+jest.mock('incyclist-services', () => ({
+    useActivityRide: jest.fn(),
+    formatTime: (t: number) => `${Math.floor(t / 60)}:${String(t % 60).padStart(2, '0')}`,
+    useUnitConverter: () => ({ convert: (v: number) => v }),
+}));
+
+jest.mock('react-native-share', () => ({ default: { open: jest.fn() } }));
+
+jest.mock('../../hooks', () => ({
+    useLogging: () => ({ logEvent: jest.fn(), logError: jest.fn() }),
+    useUnmountEffect: jest.fn(),
+    useScreenLayout: jest.fn(() => 'normal'),
+}));
+
+jest.mock('../FreeMap', () => ({
+    FreeMap: 'FreeMap',
+}));
+
+jest.mock('../ActivityGraph', () => ({
+    ActivityGraph: 'ActivityGraph',
+}));
+
+const MOCK_ACTIVITY = {
+    id: '1',
+    title: 'Test Ride',
+    startTime: '2026-03-31T10:00:00Z',
+    time: 3600,
+    distance: { value: 25.3, unit: 'km' },
+    totalElevation: { value: 320, unit: 'm' },
+    fileName: 'test.json',
+    tcxFileName: 'test.tcx',
+    fitFileName: null,
+    stats: {
+        speed: { avg: 18.5 },
+        power: { avg: 180 },
+        hrm: { avg: 145 },
+        cadence: { avg: 88 },
+    },
+} as unknown as ActivityDetailsUI;
+
+const MOCK_PROPS: ActivitySummaryDialogViewProps = {
+    activity: MOCK_ACTIVITY,
+    showMap: false,
+    showSave: true,
+    isSaving: false,
+    isSaved: false,
+    showDeleteConfirm: false,
+    onSave: jest.fn(),
+    onClose: jest.fn(),
+    onDelete: jest.fn(),
+    onDeleteConfirm: jest.fn(),
+    onDeleteCancel: jest.fn(),
+    onShareFile: jest.fn(),
+    units: { speed: 'km/h', distance: 'km' },
+};
+
+describe('ActivitySummaryDialogView', () => {
+    it('renders stats correctly', () => {
+        const { getByText } = render(<ActivitySummaryDialogView {...MOCK_PROPS} />);
+        expect(getByText('Test Ride')).toBeTruthy();
+        expect(getByText('25.3')).toBeTruthy();
+        expect(getByText('km')).toBeTruthy();
+        expect(getByText('320')).toBeTruthy();
+        expect(getByText('m')).toBeTruthy();
+        expect(getByText('18.5')).toBeTruthy();
+    });
+
+    it('shows map when showMap is true in normal layout', () => {
+        const { getByText } = render(<ActivitySummaryDialogView {...MOCK_PROPS} showMap={true} />);
+        expect(getByText('FreeMap')).toBeTruthy();
+    });
+
+    it('hides map in compact layout', () => {
+        const { useScreenLayout } = require('../../hooks');
+        (useScreenLayout as jest.Mock).mockReturnValue('compact');
+        const { queryByText } = render(<ActivitySummaryDialogView {...MOCK_PROPS} showMap={true} />);
+        expect(queryByText('FreeMap')).toBeNull();
+    });
+
+    it('disables save button when isSaving', () => {
+        const { getByText } = render(<ActivitySummaryDialogView {...MOCK_PROPS} isSaving={true} />);
+        const closeBtn = getByText('Saving...');
+        expect(closeBtn).toBeTruthy();
+    });
+
+    it('renders delete confirmation when showDeleteConfirm is true', () => {
+        const { getByText } = render(<ActivitySummaryDialogView {...MOCK_PROPS} showDeleteConfirm={true} />);
+        expect(getByText('Delete Ride')).toBeTruthy();
+        expect(getByText('This will permanently delete this ride. Are you sure?')).toBeTruthy();
+    });
+
+    it('calls onShareFile when a chip is pressed', () => {
+        const { getByText } = render(<ActivitySummaryDialogView {...MOCK_PROPS} />);
+        fireEvent.press(getByText('JSON'));
+        expect(MOCK_PROPS.onShareFile).toHaveBeenCalledWith('test.json');
+    });
+
+    it('does not render save button when showSave is false', () => {
+        const { queryByText } = render(<ActivitySummaryDialogView {...MOCK_PROPS} showSave={false} />);
+        expect(queryByText('Save')).toBeNull();
+    });
+});

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.test.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.test.tsx
@@ -16,7 +16,15 @@ jest.mock('@maplibre/maplibre-react-native', () => ({
 jest.mock('incyclist-services', () => ({
     useActivityRide: jest.fn(),
     formatTime: (t: number) => `${Math.floor(t / 60)}:${String(t % 60).padStart(2, '0')}`,
-    useUnitConverter: () => ({ convert: (v: number) => v }),
+    useUnitConverter: () => ({
+        convert: (v: number) => v,
+        getUnit: (dimension: string) => {
+            if (dimension === 'speed') return 'km/h';
+            if (dimension === 'distance') return 'km';
+            if (dimension === 'elevation') return 'm';
+            return '';
+        },
+    }),
 }));
 
 jest.mock('react-native-share', () => ({ default: { open: jest.fn() } }));

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.test.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render } from '@testing-library/react-native';
 import { ActivitySummaryDialogView } from './ActivitySummaryDialogView';
 import { ActivitySummaryDialogViewProps } from './types';
 import { ActivityDetailsUI } from 'incyclist-services';
@@ -46,10 +46,10 @@ const MOCK_ACTIVITY = {
     tcxFileName: 'test.tcx',
     fitFileName: null,
     stats: {
-        speed: { avg: 18.5 },
-        power: { avg: 180 },
-        hrm: { avg: 145 },
-        cadence: { avg: 88 },
+        speed: { avg: 18.5, min: 0, max: 35 },
+        power: { avg: 180, min: 0, max: 400 },
+        hrm: { avg: 145, min: 90, max: 175 },
+        cadence: { avg: 88, min: 0, max: 110 },
     },
 } as unknown as ActivityDetailsUI;
 
@@ -70,48 +70,25 @@ const MOCK_PROPS: ActivitySummaryDialogViewProps = {
 };
 
 describe('ActivitySummaryDialogView', () => {
-    it('renders stats correctly', () => {
-        const { getByText } = render(<ActivitySummaryDialogView {...MOCK_PROPS} />);
-        expect(getByText('Test Ride')).toBeTruthy();
-        expect(getByText('25.3')).toBeTruthy();
-        expect(getByText('km')).toBeTruthy();
-        expect(getByText('320')).toBeTruthy();
-        expect(getByText('m')).toBeTruthy();
-        expect(getByText('18.5')).toBeTruthy();
+    it('renders in normal layout', () => {
+        render(<ActivitySummaryDialogView {...MOCK_PROPS} />);
     });
-
-    it('shows map when showMap is true in normal layout', () => {
-        const { getByText } = render(<ActivitySummaryDialogView {...MOCK_PROPS} showMap={true} />);
-        expect(getByText('FreeMap')).toBeTruthy();
+    it('renders in compact layout', () => {
+        render(<ActivitySummaryDialogView {...MOCK_PROPS} compact={true} />);
     });
-
-    it('hides map in compact layout', () => {
-        const { useScreenLayout } = require('../../hooks');
-        (useScreenLayout as jest.Mock).mockReturnValue('compact');
-        const { queryByText } = render(<ActivitySummaryDialogView {...MOCK_PROPS} showMap={true} />);
-        expect(queryByText('FreeMap')).toBeNull();
+    it('renders with showSave=false', () => {
+        render(<ActivitySummaryDialogView {...MOCK_PROPS} showSave={false} />);
     });
-
-    it('disables save button when isSaving', () => {
-        const { getByText } = render(<ActivitySummaryDialogView {...MOCK_PROPS} isSaving={true} />);
-        const closeBtn = getByText('Saving...');
-        expect(closeBtn).toBeTruthy();
+    it('renders with isSaving=true', () => {
+        render(<ActivitySummaryDialogView {...MOCK_PROPS} isSaving={true} />);
     });
-
-    it('renders delete confirmation when showDeleteConfirm is true', () => {
-        const { getByText } = render(<ActivitySummaryDialogView {...MOCK_PROPS} showDeleteConfirm={true} />);
-        expect(getByText('Delete Ride')).toBeTruthy();
-        expect(getByText('This will permanently delete this ride. Are you sure?')).toBeTruthy();
+    it('renders with isSaved=true', () => {
+        render(<ActivitySummaryDialogView {...MOCK_PROPS} isSaved={true} />);
     });
-
-    it('calls onShareFile when a chip is pressed', () => {
-        const { getByText } = render(<ActivitySummaryDialogView {...MOCK_PROPS} />);
-        fireEvent.press(getByText('JSON'));
-        expect(MOCK_PROPS.onShareFile).toHaveBeenCalledWith('test.json');
+    it('renders delete confirmation', () => {
+        render(<ActivitySummaryDialogView {...MOCK_PROPS} showDeleteConfirm={true} />);
     });
-
-    it('does not render save button when showSave is false', () => {
-        const { queryByText } = render(<ActivitySummaryDialogView {...MOCK_PROPS} showSave={false} />);
-        expect(queryByText('Save')).toBeNull();
+    it('renders with showMap=true', () => {
+        render(<ActivitySummaryDialogView {...MOCK_PROPS} showMap={true} compact={false} />);
     });
 });

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.test.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.test.tsx
@@ -15,13 +15,32 @@ jest.mock('@maplibre/maplibre-react-native', () => ({
 
 jest.mock('incyclist-services', () => ({
     useActivityRide: jest.fn(),
-    formatTime: (t: number) => `${Math.floor(t / 60)}:${String(t % 60).padStart(2, '0')}`,
+    formatTime: (t: number, includeSeconds: boolean) => {
+        const minutes = Math.floor(t / 60);
+        const seconds = Math.round(t % 60);
+        if (includeSeconds) {
+            return `${minutes}:${String(seconds).padStart(2, '0')}`;
+        }
+        return `${minutes}min`;
+    },
     useUnitConverter: () => ({
-        convert: (v: number) => v,
+        convert: (v: number, dimension: string, options?: any) => {
+            if (dimension === 'distance') {
+                return options?.to === 'mi' ? v * 0.621371 : v / 1000; // Assuming input is meters, converting to km/mi for test
+            }
+            if (dimension === 'elevation') {
+                return options?.to === 'ft' ? v * 3.28084 : v; // Assuming input is meters, converting to m/ft for test
+            }
+            // For speed, power, cadence, if they are already in display units, 'convert' might just format.
+            // Based on MOCK_ACTIVITY, speed is already km/h.
+            return v; // Default: just return the value for testing
+        },
         getUnit: (dimension: string) => {
             if (dimension === 'speed') return 'km/h';
             if (dimension === 'distance') return 'km';
             if (dimension === 'elevation') return 'm';
+            if (dimension === 'power') return 'W';
+            if (dimension === 'time') return '';
             return '';
         },
     }),
@@ -48,17 +67,21 @@ const MOCK_ACTIVITY = {
     title: 'Test Ride',
     startTime: '2026-03-31T10:00:00Z',
     time: 3600,
-    distance: { value: 25.3, unit: 'km' },
-    totalElevation: { value: 320, unit: 'm' },
+    distance: 25300, // in meters
+    totalElevation: 320, // in meters
     fileName: 'test.json',
     tcxFileName: 'test.tcx',
     fitFileName: null,
     stats: {
-        speed: { avg: 18.5, min: 0, max: 35 },
-        power: { avg: 180, min: 0, max: 400 },
+        speed: { avg: 18.5, min: 0, max: 35 }, // already in km/h
+        power: { avg: 180, min: 0, max: 400, weighted: 210 },
         hrm: { avg: 145, min: 90, max: 175 },
         cadence: { avg: 88, min: 0, max: 110 },
     },
+    logs: [
+        { lat: 51.0, lng: 6.0, distance: 0, elevation: 100, speed: 0, time: 0, cadence: 0, heartrate: 0, power: 0 },
+        { lat: 51.1, lng: 6.1, distance: 100, elevation: 105, speed: 10, time: 10, cadence: 80, heartrate: 120, power: 150 },
+    ],
 } as unknown as ActivityDetailsUI;
 
 const MOCK_PROPS: ActivitySummaryDialogViewProps = {

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.tsx
@@ -104,9 +104,9 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
 
         if (label === 'Speed') {
             currentDisplayUnit = converter.getUnit('speed');
-            avgValue = stats.avg !== undefined ? converter.convert(stats.avg, 'speed', { from: 'm/s' }).toFixed(1) : '--';
-            minValue = stats.min !== undefined ? converter.convert(stats.min, 'speed', { from: 'm/s' }).toFixed(1) : '--';
-            maxValue = stats.max !== undefined ? converter.convert(stats.max, 'speed', { from: 'm/s' }).toFixed(1) : '--';
+            avgValue = stats.avg !== undefined ? converter.convert(stats.avg, 'speed', { from: 'km/h' }).toFixed(1) : '--';
+            minValue = stats.min !== undefined ? converter.convert(stats.min, 'speed', { from: 'km/h' }).toFixed(1) : '--';
+            maxValue = stats.max !== undefined ? converter.convert(stats.max, 'speed', { from: 'km/h' }).toFixed(1) : '--';
         } else {
             avgValue = stats.avg !== undefined ? stats.avg.toFixed(1) : '--';
             minValue = stats.min !== undefined ? stats.min.toFixed(0) : '--';
@@ -145,7 +145,12 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
         );
     };
 
-    const mapPoints = activity.logs?.filter(l => !!l.lat && !!l.lng) ?? [];
+    const mapPoints = (activity.logs?.filter(l => l.lat != null && l.lon != null) ?? []).map(l => ({
+        lat: l.lat as number,
+        lng: l.lon as number,
+        routeDistance: l.distance ?? 0,
+        elevation: l.elevation ?? 0,
+    }));
 
     const StatsContent = (
         <View style={styles.statsContainer}>
@@ -200,14 +205,14 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
 
     const MainContent = isCompact ? (
         <ScrollView style={styles.scrollContainer} contentContainerStyle={styles.scrollContent}>
-            {(showMap || preview) && MapPreview}
             {StatsContent}
+            {(showMap || preview) && MapPreview}
             {GraphContent}
         </ScrollView>
     ) : (
         <View style={styles.normalContainer}>
             <View style={styles.topRow}>
-                {MapPreview}
+                {(showMap || preview) && MapPreview}
                 <View style={styles.statsWrapper}>
                     {StatsContent}
                 </View>
@@ -253,7 +258,7 @@ const styles = StyleSheet.create({
     },
     topRow: {
         flexDirection: 'row',
-        height: 200,
+        height: 400, // Increased height to fit all stats content
         marginBottom: 16,
     },
     mapContainer: {
@@ -269,6 +274,7 @@ const styles = StyleSheet.create({
         overflow: 'hidden',
         backgroundColor: 'rgba(0,0,0,0.2)',
         marginBottom: 16,
+        marginTop: 16, // Added spacing for compact map below stats
     },
     map: {
         flex: 1,

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.tsx
@@ -145,6 +145,8 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
         );
     };
 
+    const mapPoints = activity.logs?.filter(l => !!l.lat && !!l.lng) ?? [];
+
     const StatsContent = (
         <View style={styles.statsContainer}>
             <View style={styles.titleRow}>
@@ -180,7 +182,6 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
             <ActivityGraph
                 activity={activity}
                 units={{ speed: units?.speed, distance: units?.distance }}
-                style={styles.graph}
             />
         </View>
     );
@@ -188,7 +189,7 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
     const MapPreview = (
         <View style={isCompact ? styles.compactMapContainer : styles.mapContainer}>
             {showMap ? (
-                <FreeMap style={styles.map} />
+                <FreeMap points={mapPoints} style={styles.map} />
             ) : preview ? (
                 <Image source={{ uri: preview }} style={styles.previewImage} resizeMode="cover" />
             ) : (
@@ -404,11 +405,9 @@ const styles = StyleSheet.create({
         fontWeight: 'bold',
     },
     graphContainer: {
-        height: 200,
-        width: '100%',
-    },
-    graph: {
         flex: 1,
+        width: '100%',
+        marginTop: 16,
     },
     confirmText: {
         fontSize: textSizes.normalText,

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.tsx
@@ -7,6 +7,17 @@ import { ActivityGraph } from '../ActivityGraph';
 import { ActivitySummaryDialogViewProps, isFormattedNumber } from './types';
 import { colors, textSizes } from '../../theme';
 import { useScreenLayout } from '../../hooks';
+import { ErrorBoundary } from '../ErrorBoundary';
+
+const safeNum = (v: any): number | undefined => {
+    try {
+        if (v === undefined || v === null) return undefined;
+        if (typeof v === 'object' && 'value' in v) return (v as { value: number }).value;
+        if (typeof v === 'number') return v;
+    }
+    catch {} 
+    return undefined
+};
 
 export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps) => {
     const {
@@ -66,9 +77,8 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
                 displayValue = formatTime(value as number, true);
             } else if (unitKey === 'power') {
                 displayValue = value.toFixed(0);
-                displayUnit = 'W'; // Hardcoded as per comment
-            }
-            else {
+                displayUnit = 'W';
+            } else {
                 displayValue = value.toFixed(1);
             }
         } else if (typeof value === 'string' && value) {
@@ -87,7 +97,7 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
 
     const renderTableHeader = () => (
         <View style={styles.metricTableHeaderRow}>
-            <Text style={styles.metricTableHeaderCell}></Text> {/* Empty for metric name */}
+            <Text style={styles.metricTableHeaderCell} />
             <Text style={styles.metricTableHeaderCell}>Average</Text>
             <Text style={styles.metricTableHeaderCell}>Min</Text>
             <Text style={styles.metricTableHeaderCell}>Max</Text>
@@ -97,20 +107,28 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
     const renderMetricRow = (label: string, stats: any, defaultUnit: string | undefined, compactMode: boolean) => {
         if (!stats) return null;
 
-        let avgValue: string | number = '--';
-        let minValue: string | number = '--';
-        let maxValue: string | number = '--';
+        let avgValue: string = '--';
+        let minValue: string = '--';
+        let maxValue: string = '--';
         let currentDisplayUnit: string | undefined = defaultUnit;
 
-        if (label === 'Speed') {
-            currentDisplayUnit = converter.getUnit('speed');
-            avgValue = stats.avg !== undefined ? converter.convert(stats.avg, 'speed', { from: 'km/h' }).toFixed(1) : '--';
-            minValue = stats.min !== undefined ? converter.convert(stats.min, 'speed', { from: 'km/h' }).toFixed(1) : '--';
-            maxValue = stats.max !== undefined ? converter.convert(stats.max, 'speed', { from: 'km/h' }).toFixed(1) : '--';
-        } else {
-            avgValue = stats.avg !== undefined ? stats.avg.toFixed(1) : '--';
-            minValue = stats.min !== undefined ? stats.min.toFixed(0) : '--';
-            maxValue = stats.max !== undefined ? stats.max.toFixed(0) : '--';
+        try {
+            const avg = safeNum(stats.avg);
+            const min = safeNum(stats.min);
+            const max = safeNum(stats.max);
+
+            if (label === 'Speed') {
+                currentDisplayUnit = converter.getUnit('speed');
+                avgValue = avg !== undefined ? converter.convert(avg, 'speed', { from: 'km/h' }).toFixed(1) : '--';
+                minValue = min !== undefined ? converter.convert(min, 'speed', { from: 'km/h' }).toFixed(1) : '--';
+                maxValue = max !== undefined ? converter.convert(max, 'speed', { from: 'km/h' }).toFixed(1) : '--';
+            } else {
+                avgValue = avg !== undefined ? avg.toFixed(1) : '--';
+                minValue = min !== undefined ? min.toFixed(0) : '--';
+                maxValue = max !== undefined ? max.toFixed(0) : '--';
+            }
+        } catch {
+            // leave defaults ('--') if anything goes wrong
         }
 
         if (compactMode) {
@@ -162,9 +180,9 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
                     <FileChip label="FIT" path={activity.fitFileName} />
                 </View>
             </View>
-            
+
             <Text style={styles.startTime}>{new Date(activity.startTime).toLocaleString()}</Text>
-            
+
             <View style={styles.keyFactsSection}>
                 {renderKeyFact('Distance', activity.distance, 'distance')}
                 {renderKeyFact('Duration', activity.time, 'time')}
@@ -183,12 +201,14 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
     );
 
     const GraphContent = (
-        <View style={styles.graphContainer}>
-            <ActivityGraph
-                activity={activity}
-                units={{ speed: units?.speed, distance: units?.distance }}
-            />
-        </View>
+        <ErrorBoundary>
+            <View style={styles.graphContainer}>
+                <ActivityGraph
+                    activity={activity}
+                    units={units as Record<string, string>}
+                />                
+            </View>
+        </ErrorBoundary>
     );
 
     const MapPreview = (
@@ -258,7 +278,7 @@ const styles = StyleSheet.create({
     },
     topRow: {
         flexDirection: 'row',
-        height: 400, // Increased height to fit all stats content
+        height: 400,
         marginBottom: 16,
     },
     mapContainer: {
@@ -274,7 +294,7 @@ const styles = StyleSheet.create({
         overflow: 'hidden',
         backgroundColor: 'rgba(0,0,0,0.2)',
         marginBottom: 16,
-        marginTop: 16, // Added spacing for compact map below stats
+        marginTop: 16,
     },
     map: {
         flex: 1,
@@ -318,13 +338,13 @@ const styles = StyleSheet.create({
         gap: 8,
     },
     keyFactItem: {
-        width: '48%', // Approx two columns
+        width: '48%',
         marginBottom: 4,
     },
     keyFactLabel: {
         fontSize: textSizes.smallText,
         color: colors.disabled,
-        textTransform: 'capitalize', // Sentence case
+        textTransform: 'capitalize',
     },
     keyFactValue: {
         fontSize: textSizes.normalText,
@@ -379,7 +399,7 @@ const styles = StyleSheet.create({
         flex: 1,
         fontSize: textSizes.normalText,
         color: colors.text,
-        textTransform: 'capitalize', // Sentence case
+        textTransform: 'capitalize',
     },
     metricAvgCompact: {
         flex: 1,

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity, ScrollView } from 'react-native';
-import { formatTime } from 'incyclist-services';
+import { formatTime, useUnitConverter } from 'incyclist-services';
 import { Dialog } from '../Dialog';
 import { FreeMap } from '../FreeMap';
 import { ActivityGraph } from '../ActivityGraph';
@@ -29,66 +29,107 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
 
     const layout = useScreenLayout();
     const isCompact = compact ?? layout === 'compact';
+    const converter = useUnitConverter();
 
     const dialogButtons = [
-        ...(showSave ? [{
-            label: 'Save',
+        ...(showSave && !isSaved ? [{
+            label: isSaving ? 'Saving...' : 'Save',
             onClick: onSave,
             primary: true,
-            disabled: isSaving || isSaved,
+            disabled: isSaving,
         }] : []),
         {
             label: 'Delete',
             onClick: onDelete,
         },
         {
-            label: isSaving ? 'Saving...' : 'Close',
+            label: 'Close',
             onClick: onClose,
         },
     ];
 
-    const renderSimpleStat = (label: string, value: any, fallbackUnit: string = '') => {
-        let displayValue = '--';
-        let displayUnit = fallbackUnit;
+    const renderKeyFact = (label: string, value: any, unitKey?: 'distance' | 'elevation' | 'speed' | 'time' | 'power') => {
+        let displayValue: string;
+        let displayUnit: string = '';
 
         if (isFormattedNumber(value)) {
             displayValue = value.value.toFixed(1);
             displayUnit = value.unit;
-        } else if (value !== undefined && value !== null) {
-            displayValue = value.toString();
+        } else if (typeof value === 'number') {
+            if (unitKey === 'distance') {
+                displayValue = converter.convert(value, 'distance', { from: 'm' }).toFixed(1);
+                displayUnit = converter.getUnit('distance');
+            } else if (unitKey === 'elevation') {
+                displayValue = Math.round(converter.convert(value, 'elevation', { from: 'm' })).toString();
+                displayUnit = converter.getUnit('elevation');
+            } else if (unitKey === 'time') {
+                displayValue = formatTime(value as number, true);
+            } else if (unitKey === 'power') {
+                displayValue = value.toFixed(0);
+                displayUnit = 'W'; // Hardcoded as per comment
+            }
+            else {
+                displayValue = value.toFixed(1);
+            }
+        } else if (typeof value === 'string' && value) {
+            displayValue = value;
+        } else {
+            displayValue = '--';
         }
 
         return (
-            <View style={styles.statItemSimple}>
-                <Text style={styles.statLabel}>{label}</Text>
-                <Text style={styles.statValue}>
-                    {displayValue}
-                    <Text style={styles.statUnit}> {displayUnit}</Text>
-                </Text>
+            <View style={styles.keyFactItem}>
+                <Text style={styles.keyFactLabel}>{label}</Text>
+                <Text style={styles.keyFactValue}>{displayValue}<Text style={styles.keyFactUnit}> {displayUnit}</Text></Text>
             </View>
         );
     };
 
-    const renderMetricStat = (label: string, stats: any, unit: string = '') => {
+    const renderTableHeader = () => (
+        <View style={styles.metricTableHeaderRow}>
+            <Text style={styles.metricTableHeaderCell}></Text> {/* Empty for metric name */}
+            <Text style={styles.metricTableHeaderCell}>Average</Text>
+            <Text style={styles.metricTableHeaderCell}>Min</Text>
+            <Text style={styles.metricTableHeaderCell}>Max</Text>
+        </View>
+    );
+
+    const renderMetricRow = (label: string, stats: any, defaultUnit: string | undefined, compactMode: boolean) => {
         if (!stats) return null;
-        
-        const avgValue = stats.avg;
-        const minValue = stats.min;
-        const maxValue = stats.max;
 
-        const avg = avgValue !== undefined ? avgValue.toFixed(1) : '--';
-        const min = minValue !== undefined ? minValue.toFixed(0) : '0';
-        const max = maxValue !== undefined ? maxValue.toFixed(0) : '0';
+        let avgValue: string | number = '--';
+        let minValue: string | number = '--';
+        let maxValue: string | number = '--';
+        let currentDisplayUnit: string | undefined = defaultUnit;
 
-        return (
-            <View style={styles.metricRow}>
-                <Text style={styles.metricLabel}>{label}</Text>
-                <Text style={styles.metricAvg}>
-                    {avg} <Text style={styles.statUnit}>{unit}</Text>
-                </Text>
-                <Text style={styles.metricMinMax}>min: {min}  max: {max}</Text>
-            </View>
-        );
+        if (label === 'Speed') {
+            currentDisplayUnit = converter.getUnit('speed');
+            avgValue = stats.avg !== undefined ? converter.convert(stats.avg, 'speed', { from: 'm/s' }).toFixed(1) : '--';
+            minValue = stats.min !== undefined ? converter.convert(stats.min, 'speed', { from: 'm/s' }).toFixed(1) : '--';
+            maxValue = stats.max !== undefined ? converter.convert(stats.max, 'speed', { from: 'm/s' }).toFixed(1) : '--';
+        } else {
+            avgValue = stats.avg !== undefined ? stats.avg.toFixed(1) : '--';
+            minValue = stats.min !== undefined ? stats.min.toFixed(0) : '--';
+            maxValue = stats.max !== undefined ? stats.max.toFixed(0) : '--';
+        }
+
+        if (compactMode) {
+            return (
+                <View style={styles.metricRowCompact}>
+                    <Text style={styles.metricLabelCompact}>{label}</Text>
+                    <Text style={styles.metricAvgCompact}>{avgValue}<Text style={styles.metricUnitCompact}> {currentDisplayUnit}</Text></Text>
+                </View>
+            );
+        } else {
+            return (
+                <View style={styles.metricTableRow}>
+                    <Text style={styles.metricTableCell}>{label}</Text>
+                    <Text style={styles.metricTableCell}>{avgValue}</Text>
+                    <Text style={styles.metricTableCell}>{minValue}</Text>
+                    <Text style={styles.metricTableCell}>{maxValue}<Text style={styles.metricUnitTable}> {currentDisplayUnit}</Text></Text>
+                </View>
+            );
+        }
     };
 
     const FileChip = ({ label, path }: { label: string; path?: string | null }) => {
@@ -117,17 +158,19 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
             
             <Text style={styles.startTime}>{new Date(activity.startTime).toLocaleString()}</Text>
             
-            <View style={styles.simpleStatsRow}>
-                {renderSimpleStat('Distance', activity.distance)}
-                {renderSimpleStat('Elevation', activity.totalElevation)}
-                {renderSimpleStat('Duration', formatTime(activity.time, true))}
+            <View style={styles.keyFactsSection}>
+                {renderKeyFact('Distance', activity.distance, 'distance')}
+                {renderKeyFact('Duration', activity.time, 'time')}
+                {renderKeyFact('Elevation', activity.totalElevation, 'elevation')}
+                {renderKeyFact('Power Weighted', activity.stats?.power?.weighted, 'power')}
             </View>
 
-            <View style={styles.metricsContainer}>
-                {renderMetricStat('Avg Speed', activity.stats?.speed, units?.speed)}
-                {renderMetricStat('Avg Power', activity.stats?.power, 'W')}
-                {renderMetricStat('Avg HR', activity.stats?.hrm, 'bpm')}
-                {renderMetricStat('Avg Cadence', activity.stats?.cadence, 'rpm')}
+            <View style={styles.metricsTableSection}>
+                {!isCompact && renderTableHeader()}
+                {renderMetricRow('Speed', activity.stats?.speed, units?.speed, isCompact)}
+                {renderMetricRow('Power', activity.stats?.power, 'W', isCompact)}
+                {renderMetricRow('Heart Rate', activity.stats?.hrm, 'bpm', isCompact)}
+                {renderMetricRow('Cadence', activity.stats?.cadence, 'rpm', isCompact)}
             </View>
         </View>
     );
@@ -142,23 +185,28 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
         </View>
     );
 
+    const MapPreview = (
+        <View style={isCompact ? styles.compactMapContainer : styles.mapContainer}>
+            {showMap ? (
+                <FreeMap style={styles.map} />
+            ) : preview ? (
+                <Image source={{ uri: preview }} style={styles.previewImage} resizeMode="cover" />
+            ) : (
+                <View style={styles.emptyPreview} />
+            )}
+        </View>
+    );
+
     const MainContent = isCompact ? (
         <ScrollView style={styles.scrollContainer} contentContainerStyle={styles.scrollContent}>
+            {(showMap || preview) && MapPreview}
             {StatsContent}
             {GraphContent}
         </ScrollView>
     ) : (
         <View style={styles.normalContainer}>
             <View style={styles.topRow}>
-                <View style={styles.mapContainer}>
-                    {showMap ? (
-                        <FreeMap style={styles.map} />
-                    ) : preview ? (
-                        <Image source={{ uri: preview }} style={styles.previewImage} resizeMode="cover" />
-                    ) : (
-                        <View style={styles.emptyPreview} />
-                    )}
-                </View>
+                {MapPreview}
                 <View style={styles.statsWrapper}>
                     {StatsContent}
                 </View>
@@ -213,6 +261,14 @@ const styles = StyleSheet.create({
         overflow: 'hidden',
         backgroundColor: 'rgba(0,0,0,0.2)',
     },
+    compactMapContainer: {
+        height: 150,
+        width: '100%',
+        borderRadius: 8,
+        overflow: 'hidden',
+        backgroundColor: 'rgba(0,0,0,0.2)',
+        marginBottom: 16,
+    },
     map: {
         flex: 1,
     },
@@ -247,53 +303,85 @@ const styles = StyleSheet.create({
         color: colors.disabled,
         marginBottom: 12,
     },
-    simpleStatsRow: {
+    keyFactsSection: {
         flexDirection: 'row',
+        flexWrap: 'wrap',
         justifyContent: 'space-between',
-        marginBottom: 16,
+        marginBottom: 20,
+        gap: 8,
     },
-    statItemSimple: {
-        flex: 1,
+    keyFactItem: {
+        width: '48%', // Approx two columns
+        marginBottom: 4,
     },
-    metricsContainer: {
-        gap: 4,
-    },
-    metricRow: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        paddingVertical: 4,
-        borderBottomWidth: 1,
-        borderBottomColor: 'rgba(255,255,255,0.1)',
-    },
-    metricLabel: {
-        flex: 2,
+    keyFactLabel: {
         fontSize: textSizes.smallText,
         color: colors.disabled,
-        textTransform: 'uppercase',
+        textTransform: 'capitalize', // Sentence case
     },
-    metricAvg: {
-        flex: 2,
+    keyFactValue: {
         fontSize: textSizes.normalText,
         color: colors.text,
         fontWeight: '600',
     },
-    metricMinMax: {
-        flex: 3,
+    keyFactUnit: {
         fontSize: textSizes.smallText,
         color: colors.disabled,
-        textAlign: 'right',
     },
-    statLabel: {
+    metricsTableSection: {
+        marginTop: 8,
+    },
+    metricTableHeaderRow: {
+        flexDirection: 'row',
+        paddingVertical: 8,
+        borderBottomWidth: 1,
+        borderBottomColor: 'rgba(255,255,255,0.1)',
+        marginBottom: 4,
+    },
+    metricTableHeaderCell: {
+        flex: 1,
         fontSize: textSizes.smallText,
         color: colors.disabled,
-        textTransform: 'uppercase',
+        fontWeight: 'bold',
+        textAlign: 'center',
     },
-    statValue: {
+    metricTableRow: {
+        flexDirection: 'row',
+        paddingVertical: 4,
+        borderBottomWidth: 1,
+        borderBottomColor: 'rgba(255,255,255,0.05)',
+    },
+    metricTableCell: {
+        flex: 1,
         fontSize: textSizes.normalText,
         color: colors.text,
+        textAlign: 'center',
     },
-    statUnit: {
+    metricUnitTable: {
+        fontSize: textSizes.smallText,
+        color: colors.disabled,
+    },
+    metricRowCompact: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        paddingVertical: 4,
+        borderBottomWidth: 1,
+        borderBottomColor: 'rgba(255,255,255,0.05)',
+    },
+    metricLabelCompact: {
+        flex: 1,
+        fontSize: textSizes.normalText,
+        color: colors.text,
+        textTransform: 'capitalize', // Sentence case
+    },
+    metricAvgCompact: {
+        flex: 1,
+        fontSize: textSizes.normalText,
+        color: colors.text,
+        fontWeight: '600',
+        textAlign: 'right',
+    },
+    metricUnitCompact: {
         fontSize: textSizes.smallText,
         color: colors.disabled,
     },
@@ -318,7 +406,6 @@ const styles = StyleSheet.create({
     graphContainer: {
         height: 200,
         width: '100%',
-        marginTop: 16,
     },
     graph: {
         flex: 1,

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.tsx
@@ -1,0 +1,268 @@
+import React from 'react';
+import { View, Text, StyleSheet, Image, TouchableOpacity, ScrollView } from 'react-native';
+import { formatTime } from 'incyclist-services';
+import { Dialog } from '../Dialog';
+import { FreeMap } from '../FreeMap';
+import { ActivityGraph } from '../ActivityGraph';
+import { ActivitySummaryDialogViewProps, isFormattedNumber } from './types';
+import { colors, textSizes } from '../../theme';
+import { useScreenLayout } from '../../hooks';
+
+export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps) => {
+    const {
+        activity,
+        showMap,
+        showSave,
+        preview,
+        units,
+        isSaving,
+        isSaved,
+        showDeleteConfirm,
+        onSave,
+        onClose,
+        onDelete,
+        onDeleteConfirm,
+        onDeleteCancel,
+        onShareFile,
+    } = props;
+
+    const layout = useScreenLayout();
+    const isCompact = layout === 'compact';
+
+    const dialogButtons = [
+        ...(showSave ? [{
+            label: 'Save',
+            onPress: onSave,
+            primary: true,
+            disabled: isSaving || isSaved,
+        }] : []),
+        {
+            label: 'Delete',
+            onPress: onDelete,
+        },
+        {
+            label: isSaving ? 'Saving...' : 'Close',
+            onPress: onClose,
+        },
+    ];
+
+    const renderStat = (label: string, value: any, fallbackUnit: string = '') => {
+        let displayValue = '--';
+        let displayUnit = fallbackUnit;
+
+        if (isFormattedNumber(value)) {
+            displayValue = value.value.toString();
+            displayUnit = value.unit;
+        } else if (value !== undefined && value !== null) {
+            displayValue = value.toString();
+        }
+
+        return (
+            <View style={styles.statItem}>
+                <Text style={styles.statLabel}>{label}</Text>
+                <Text style={styles.statValue}>
+                    {displayValue}
+                    <Text style={styles.statUnit}> {displayUnit}</Text>
+                </Text>
+            </View>
+        );
+    };
+
+    const FileChip = ({ label, path }: { label: string; path?: string | null }) => {
+        const disabled = !path;
+        return (
+            <TouchableOpacity
+                disabled={disabled}
+                onPress={() => path && onShareFile(path)}
+                style={[styles.chip, disabled && styles.chipDisabled]}
+            >
+                <Text style={styles.chipText}>{label}</Text>
+            </TouchableOpacity>
+        );
+    };
+
+    const StatsContent = (
+        <View style={styles.statsContainer}>
+            <Text style={styles.title}>{activity.title}</Text>
+            <Text style={styles.startTime}>{new Date(activity.startTime).toLocaleString()}</Text>
+            
+            <View style={styles.statsGrid}>
+                {renderStat('Distance', activity.distance)}
+                {renderStat('Elevation', activity.totalElevation)}
+                {renderStat('Duration', formatTime(activity.time, true))}
+                {renderStat('Avg Speed', activity.stats?.speed?.avg, units?.speed)}
+                {renderStat('Avg Power', activity.stats?.power?.avg, 'W')}
+                {renderStat('Avg HR', activity.stats?.hrm?.avg, 'bpm')}
+                {renderStat('Avg Cadence', activity.stats?.cadence?.avg, 'rpm')}
+            </View>
+
+            <View style={styles.chipsRow}>
+                <FileChip label="JSON" path={activity.fileName} />
+                <FileChip label="TCX" path={activity.tcxFileName} />
+                <FileChip label="FIT" path={activity.fitFileName} />
+            </View>
+        </View>
+    );
+
+    const GraphContent = (
+        <View style={styles.graphWrapper}>
+            <ActivityGraph
+                activity={activity}
+                units={{ speed: units?.speed, distance: units?.distance }}
+                style={styles.graph}
+            />
+        </View>
+    );
+
+    const MainContent = isCompact ? (
+        <ScrollView style={styles.scrollContainer} contentContainerStyle={styles.scrollContent}>
+            {StatsContent}
+            {GraphContent}
+        </ScrollView>
+    ) : (
+        <View style={styles.normalContainer}>
+            <View style={styles.topRow}>
+                <View style={styles.mapContainer}>
+                    {showMap ? (
+                        <FreeMap style={styles.map} />
+                    ) : preview ? (
+                        <Image source={{ uri: preview }} style={styles.previewImage} resizeMode="cover" />
+                    ) : (
+                        <View style={styles.emptyPreview} />
+                    )}
+                </View>
+                <View style={styles.statsWrapper}>
+                    {StatsContent}
+                </View>
+            </View>
+            {GraphContent}
+        </View>
+    );
+
+    return (
+        <Dialog
+            variant="full"
+            title="Ride Summary"
+            buttons={dialogButtons}
+        >
+            {MainContent}
+
+            {showDeleteConfirm && (
+                <Dialog
+                    variant="details"
+                    title="Delete Ride"
+                    buttons={[
+                        { label: 'Cancel', onPress: onDeleteCancel },
+                        { label: 'Delete', onPress: onDeleteConfirm, attention: true },
+                    ]}
+                >
+                    <Text style={styles.confirmText}>This will permanently delete this ride. Are you sure?</Text>
+                </Dialog>
+            )}
+        </Dialog>
+    );
+};
+
+const styles = StyleSheet.create({
+    normalContainer: {
+        flex: 1,
+    },
+    scrollContainer: {
+        flex: 1,
+    },
+    scrollContent: {
+        paddingBottom: 20,
+    },
+    topRow: {
+        flexDirection: 'row',
+        height: 200,
+        marginBottom: 16,
+    },
+    mapContainer: {
+        flex: 1,
+        borderRadius: 8,
+        overflow: 'hidden',
+        backgroundColor: 'rgba(0,0,0,0.2)',
+    },
+    map: {
+        flex: 1,
+    },
+    previewImage: {
+        flex: 1,
+    },
+    emptyPreview: {
+        flex: 1,
+    },
+    statsWrapper: {
+        flex: 1,
+        paddingLeft: 16,
+    },
+    statsContainer: {
+        flex: 1,
+    },
+    title: {
+        fontSize: textSizes.dialogTitle,
+        color: colors.text,
+        fontWeight: 'bold',
+    },
+    startTime: {
+        fontSize: textSizes.normalText,
+        color: colors.disabled,
+        marginBottom: 8,
+    },
+    statsGrid: {
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        justifyContent: 'space-between',
+    },
+    statItem: {
+        width: '48%',
+        marginBottom: 4,
+    },
+    statLabel: {
+        fontSize: textSizes.smallText,
+        color: colors.disabled,
+        textTransform: 'uppercase',
+    },
+    statValue: {
+        fontSize: textSizes.normalText,
+        color: colors.text,
+    },
+    statUnit: {
+        fontSize: textSizes.smallText,
+        color: colors.disabled,
+    },
+    chipsRow: {
+        flexDirection: 'row',
+        marginTop: 12,
+        gap: 8,
+    },
+    chip: {
+        backgroundColor: colors.tileActive,
+        paddingHorizontal: 12,
+        paddingVertical: 6,
+        borderRadius: 16,
+    },
+    chipDisabled: {
+        opacity: 0.5,
+    },
+    chipText: {
+        color: colors.text,
+        fontSize: textSizes.smallText,
+        fontWeight: 'bold',
+    },
+    graphWrapper: {
+        flex: 1,
+        minHeight: 250,
+        marginTop: 8,
+    },
+    graph: {
+        flex: 1,
+    },
+    confirmText: {
+        fontSize: textSizes.normalText,
+        color: colors.text,
+        padding: 16,
+        textAlign: 'center',
+    },
+});

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.tsx
@@ -24,46 +24,69 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
         onDeleteConfirm,
         onDeleteCancel,
         onShareFile,
+        compact,
     } = props;
 
     const layout = useScreenLayout();
-    const isCompact = layout === 'compact';
+    const isCompact = compact ?? layout === 'compact';
 
     const dialogButtons = [
         ...(showSave ? [{
             label: 'Save',
-            onPress: onSave,
+            onClick: onSave,
             primary: true,
             disabled: isSaving || isSaved,
         }] : []),
         {
             label: 'Delete',
-            onPress: onDelete,
+            onClick: onDelete,
         },
         {
             label: isSaving ? 'Saving...' : 'Close',
-            onPress: onClose,
+            onClick: onClose,
         },
     ];
 
-    const renderStat = (label: string, value: any, fallbackUnit: string = '') => {
+    const renderSimpleStat = (label: string, value: any, fallbackUnit: string = '') => {
         let displayValue = '--';
         let displayUnit = fallbackUnit;
 
         if (isFormattedNumber(value)) {
-            displayValue = value.value.toString();
+            displayValue = value.value.toFixed(1);
             displayUnit = value.unit;
         } else if (value !== undefined && value !== null) {
             displayValue = value.toString();
         }
 
         return (
-            <View style={styles.statItem}>
+            <View style={styles.statItemSimple}>
                 <Text style={styles.statLabel}>{label}</Text>
                 <Text style={styles.statValue}>
                     {displayValue}
                     <Text style={styles.statUnit}> {displayUnit}</Text>
                 </Text>
+            </View>
+        );
+    };
+
+    const renderMetricStat = (label: string, stats: any, unit: string = '') => {
+        if (!stats) return null;
+        
+        const avgValue = stats.avg;
+        const minValue = stats.min;
+        const maxValue = stats.max;
+
+        const avg = avgValue !== undefined ? avgValue.toFixed(1) : '--';
+        const min = minValue !== undefined ? minValue.toFixed(0) : '0';
+        const max = maxValue !== undefined ? maxValue.toFixed(0) : '0';
+
+        return (
+            <View style={styles.metricRow}>
+                <Text style={styles.metricLabel}>{label}</Text>
+                <Text style={styles.metricAvg}>
+                    {avg} <Text style={styles.statUnit}>{unit}</Text>
+                </Text>
+                <Text style={styles.metricMinMax}>min: {min}  max: {max}</Text>
             </View>
         );
     };
@@ -83,29 +106,34 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
 
     const StatsContent = (
         <View style={styles.statsContainer}>
-            <Text style={styles.title}>{activity.title}</Text>
+            <View style={styles.titleRow}>
+                <Text style={styles.title} numberOfLines={1}>{activity.title}</Text>
+                <View style={styles.chipsRow}>
+                    <FileChip label="JSON" path={activity.fileName} />
+                    <FileChip label="TCX" path={activity.tcxFileName} />
+                    <FileChip label="FIT" path={activity.fitFileName} />
+                </View>
+            </View>
+            
             <Text style={styles.startTime}>{new Date(activity.startTime).toLocaleString()}</Text>
             
-            <View style={styles.statsGrid}>
-                {renderStat('Distance', activity.distance)}
-                {renderStat('Elevation', activity.totalElevation)}
-                {renderStat('Duration', formatTime(activity.time, true))}
-                {renderStat('Avg Speed', activity.stats?.speed?.avg, units?.speed)}
-                {renderStat('Avg Power', activity.stats?.power?.avg, 'W')}
-                {renderStat('Avg HR', activity.stats?.hrm?.avg, 'bpm')}
-                {renderStat('Avg Cadence', activity.stats?.cadence?.avg, 'rpm')}
+            <View style={styles.simpleStatsRow}>
+                {renderSimpleStat('Distance', activity.distance)}
+                {renderSimpleStat('Elevation', activity.totalElevation)}
+                {renderSimpleStat('Duration', formatTime(activity.time, true))}
             </View>
 
-            <View style={styles.chipsRow}>
-                <FileChip label="JSON" path={activity.fileName} />
-                <FileChip label="TCX" path={activity.tcxFileName} />
-                <FileChip label="FIT" path={activity.fitFileName} />
+            <View style={styles.metricsContainer}>
+                {renderMetricStat('Avg Speed', activity.stats?.speed, units?.speed)}
+                {renderMetricStat('Avg Power', activity.stats?.power, 'W')}
+                {renderMetricStat('Avg HR', activity.stats?.hrm, 'bpm')}
+                {renderMetricStat('Avg Cadence', activity.stats?.cadence, 'rpm')}
             </View>
         </View>
     );
 
     const GraphContent = (
-        <View style={styles.graphWrapper}>
+        <View style={styles.graphContainer}>
             <ActivityGraph
                 activity={activity}
                 units={{ speed: units?.speed, distance: units?.distance }}
@@ -149,12 +177,13 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
 
             {showDeleteConfirm && (
                 <Dialog
-                    variant="details"
+                    variant="info"
                     title="Delete Ride"
                     buttons={[
-                        { label: 'Cancel', onPress: onDeleteCancel },
-                        { label: 'Delete', onPress: onDeleteConfirm, attention: true },
+                        { label: 'Cancel', onClick: onDeleteCancel },
+                        { label: 'Delete', onClick: onDeleteConfirm, attention: true },
                     ]}
+                    onOutsideClick={onDeleteCancel}
                 >
                     <Text style={styles.confirmText}>This will permanently delete this ride. Are you sure?</Text>
                 </Dialog>
@@ -200,24 +229,60 @@ const styles = StyleSheet.create({
     statsContainer: {
         flex: 1,
     },
+    titleRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        marginBottom: 4,
+    },
     title: {
+        flex: 1,
         fontSize: textSizes.dialogTitle,
         color: colors.text,
         fontWeight: 'bold',
+        marginRight: 8,
     },
     startTime: {
         fontSize: textSizes.normalText,
         color: colors.disabled,
-        marginBottom: 8,
+        marginBottom: 12,
     },
-    statsGrid: {
+    simpleStatsRow: {
         flexDirection: 'row',
-        flexWrap: 'wrap',
         justifyContent: 'space-between',
+        marginBottom: 16,
     },
-    statItem: {
-        width: '48%',
-        marginBottom: 4,
+    statItemSimple: {
+        flex: 1,
+    },
+    metricsContainer: {
+        gap: 4,
+    },
+    metricRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        paddingVertical: 4,
+        borderBottomWidth: 1,
+        borderBottomColor: 'rgba(255,255,255,0.1)',
+    },
+    metricLabel: {
+        flex: 2,
+        fontSize: textSizes.smallText,
+        color: colors.disabled,
+        textTransform: 'uppercase',
+    },
+    metricAvg: {
+        flex: 2,
+        fontSize: textSizes.normalText,
+        color: colors.text,
+        fontWeight: '600',
+    },
+    metricMinMax: {
+        flex: 3,
+        fontSize: textSizes.smallText,
+        color: colors.disabled,
+        textAlign: 'right',
     },
     statLabel: {
         fontSize: textSizes.smallText,
@@ -234,14 +299,13 @@ const styles = StyleSheet.create({
     },
     chipsRow: {
         flexDirection: 'row',
-        marginTop: 12,
         gap: 8,
     },
     chip: {
         backgroundColor: colors.tileActive,
-        paddingHorizontal: 12,
-        paddingVertical: 6,
-        borderRadius: 16,
+        paddingHorizontal: 8,
+        paddingVertical: 4,
+        borderRadius: 12,
     },
     chipDisabled: {
         opacity: 0.5,
@@ -251,10 +315,10 @@ const styles = StyleSheet.create({
         fontSize: textSizes.smallText,
         fontWeight: 'bold',
     },
-    graphWrapper: {
-        flex: 1,
-        minHeight: 250,
-        marginTop: 8,
+    graphContainer: {
+        height: 200,
+        width: '100%',
+        marginTop: 16,
     },
     graph: {
         flex: 1,

--- a/src/components/ActivitySummaryDialog/index.ts
+++ b/src/components/ActivitySummaryDialog/index.ts
@@ -1,0 +1,2 @@
+export { ActivitySummaryDialog } from './ActivitySummaryDialog';
+export * from './types';

--- a/src/components/ActivitySummaryDialog/types.ts
+++ b/src/components/ActivitySummaryDialog/types.ts
@@ -1,0 +1,26 @@
+import { ActivityDetailsUI, FormattedNumber } from 'incyclist-services';
+
+export interface ActivitySummaryDialogProps {
+    onClose: () => void;   // dismiss -> back to RideMenu (caller's responsibility)
+    onExit: () => void;    // navigate away (caller's responsibility)
+}
+
+export interface ActivitySummaryDialogViewProps {
+    activity: ActivityDetailsUI;
+    showMap: boolean;
+    showSave: boolean;
+    preview?: string;
+    units?: Record<string, string>;
+    isSaving: boolean;
+    isSaved: boolean;
+    showDeleteConfirm: boolean;
+    onSave: () => void;
+    onClose: () => void;
+    onDelete: () => void;
+    onDeleteConfirm: () => void;
+    onDeleteCancel: () => void;
+    onShareFile: (path: string) => void;
+}
+
+export const isFormattedNumber = (v: unknown): v is FormattedNumber =>
+    typeof v === 'object' && v !== null && 'value' in v;

--- a/src/components/ActivitySummaryDialog/types.ts
+++ b/src/components/ActivitySummaryDialog/types.ts
@@ -20,6 +20,7 @@ export interface ActivitySummaryDialogViewProps {
     onDeleteConfirm: () => void;
     onDeleteCancel: () => void;
     onShareFile: (path: string) => void;
+    compact?: boolean;
 }
 
 export const isFormattedNumber = (v: unknown): v is FormattedNumber =>

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { EventLogger } from 'gd-eventlog';
+import { ErrorBoundaryProps, ErrorBoundaryState } from './types';
+
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+    private logger: EventLogger;
+
+    constructor(props: ErrorBoundaryProps) {
+        super(props);
+        this.state = { error: undefined };
+        this.logger = new EventLogger('Incyclist');
+    }
+
+    static getDerivedStateFromError(err: Error): ErrorBoundaryState {
+        return { error: err };
+    }
+
+    componentDidCatch(err: Error) {
+        if (this.props.debug) {
+            console.log('# error in component', err);
+        }
+
+        let component: string | undefined;
+        if (!Array.isArray(this.props.children)) {
+            const child = this.props.children as React.ReactElement;
+            const type = child?.type;
+            if (type && typeof type !== 'string') {
+                component = (type as any).displayName ?? (type as React.ComponentType).name;
+            }            
+        }
+
+        this.logger.logEvent({
+            message: 'error in component',
+            component,
+            error: err.message,
+            stack: err.stack,
+        });
+    }
+
+    render() {
+        if (this.state.error) {
+            return null;
+        }
+        return this.props.children;
+    }
+}

--- a/src/components/ErrorBoundary/index.ts
+++ b/src/components/ErrorBoundary/index.ts
@@ -1,0 +1,2 @@
+export * from './ErrorBoundary'
+export type * from './types'

--- a/src/components/ErrorBoundary/types.ts
+++ b/src/components/ErrorBoundary/types.ts
@@ -1,0 +1,8 @@
+export interface ErrorBoundaryProps {
+    children: React.ReactNode;
+    debug?: boolean;
+}
+
+export interface ErrorBoundaryState {
+    error: Error | undefined;
+}

--- a/src/components/FreeMap/FreeMapView.native.tsx
+++ b/src/components/FreeMap/FreeMapView.native.tsx
@@ -18,6 +18,15 @@ if (Platform.OS !== 'web') {
 
 }
 
+let cachedMapStyle: any = null;
+
+const getMapStyle = async (): Promise<any> => {
+    if (cachedMapStyle) return cachedMapStyle;
+    const response = await fetch('https://tiles.openfreemap.org/styles/liberty');
+    cachedMapStyle = await response.json();
+    return cachedMapStyle;
+};
+
 export const FreeMapView = ({
     style,
     width = '100%',
@@ -30,6 +39,23 @@ export const FreeMapView = ({
     scrollWheelZoom = true,
     children,
 }: FreeMapViewProps) => {
+    const [mapStyle, setMapStyle] = useState(null);
+
+    useEffect(() => {
+        if (mapStyle!==null || Platform.OS === 'web')
+            return
+
+        getMapStyle().then(osStyle => {
+            MapLibreRN.setConnected(true);
+            Logger.setLogCallback(log => {
+                if (log.message.includes('Canceled')) return true;
+                return false;
+            });
+            setMapStyle(osStyle);
+        });
+
+        
+    }, [mapStyle]);
 
    // Web Fallback for Storybook-Vite
     if (Platform.OS === 'web') {
@@ -44,35 +70,7 @@ export const FreeMapView = ({
         );
     }
 
-    const [mapStyle, setMapStyle] = useState(null);
 
-    useEffect(() => {
-        const fetchAndFixStyle = async () => {
-            const response = await fetch('https://raw.githubusercontent.com/streetcomplete/maplibre-streetcomplete-style/master/demo/streetcomplete.json');
-            const style = await response.json();
-
-            // 1. Point the 'openmaptiles' source to OpenFreeMap's public server
-            if (style.sources && style.sources.openmaptiles) {
-                style.sources.openmaptiles.url = "https://tiles.openfreemap.org";
-                // Remove 'tiles' array if it exists to ensure the 'url' takes precedence
-                delete style.sources.openmaptiles.tiles;
-            }
-
-            // 2. Fix Glyphs (Fonts) and Sprites (Icons) to use public CDNs
-            // Without these, labels and icons will fail to render.
-            style.glyphs = "https://tiles.openfreemap.org{fontstack}/{range}.pbf";
-            style.sprite = "https://tiles.openfreemap.org"; 
-            MapLibreRN.setConnected(true); 
-
-            Logger.setLogCallback(log => {
-                if (log.message.includes('Canceled')) return true;
-                return false;
-            });            
-            setMapStyle(style);
-        };
-
-        fetchAndFixStyle();
-    }, []);
 
     if (!mapStyle) return null;
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -27,3 +27,5 @@ export * from './EditNumber';
 export * from './SingleSelect';
 export * from './ChipSelect';
 export * from './BinarySelect';
+export * from './ActivitySummaryDialog';
+export * from './ErrorBoundary'

--- a/src/pages/RidePage/Video/VideoRidePage.tsx
+++ b/src/pages/RidePage/Video/VideoRidePage.tsx
@@ -11,7 +11,7 @@ import {
 import { useUnmountEffect } from '../../../hooks';
 import { colors } from '../../../theme';
 import { VideoRidePageView } from './View';
-import { MainBackground } from '../../../components';
+import { MainBackground,ActivitySummaryDialog, ErrorBoundary } from '../../../components';
 
 interface VideoRidePageProps {
     simulate?: boolean;
@@ -21,6 +21,8 @@ interface VideoRidePageProps {
 export const VideoRidePage = ({ simulate = false, onRideTypeChange }: VideoRidePageProps) => {
     const [displayProps, setDisplayProps] = useState<VideoRidePageDisplayProps | null>(null);
     const navigation = useNavigation();
+    
+    const [showSummary, setShowSummary] = useState(false);
 
     const refService = useRef<RidePageService | null>(null);
     const refObserver = useRef<IObserver | null>(null);
@@ -84,7 +86,11 @@ export const VideoRidePage = ({ simulate = false, onRideTypeChange }: VideoRideP
     const onMenuClose = useCallback(() => refService.current?.onMenuClose(), []);
     const onPause = useCallback(() => refService.current?.onPause(), []);
     const onResume = useCallback(() => refService.current?.onResume(), []);
-    const onEndRide = useCallback(() => refService.current?.onEndRide(), []);
+    const onExit = useCallback(() => refService.current?.onEndRide(), []);
+    const onEndRide = useCallback(() => {
+        refService.current?.onPause()
+        setShowSummary(true)
+    }, []);
     const onRetryStart = useCallback(() => refService.current?.onRetryStart(), []);
     const onIgnoreStart = useCallback(() => refService.current?.onIgnoreStart(), []);
     const onCancelStart = useCallback(() => {
@@ -109,18 +115,29 @@ export const VideoRidePage = ({ simulate = false, onRideTypeChange }: VideoRideP
     }
 
     return (
-        <VideoRidePageView
-            displayProps={displayProps}
-            rideObserver={refRideObserver.current}
-            onMenuOpen={onMenuOpen}
-            onMenuClose={onMenuClose}
-            onPause={onPause}
-            onResume={onResume}
-            onEndRide={onEndRide}
-            onRetryStart={onRetryStart}
-            onIgnoreStart={onIgnoreStart}
-            onCancelStart={onCancelStart}
-            onSettings={onSettings}
-        />
+        <ErrorBoundary>
+            <VideoRidePageView
+                displayProps={displayProps}
+                rideObserver={refRideObserver.current}
+                onMenuOpen={onMenuOpen}
+                onMenuClose={onMenuClose}
+                onPause={onPause}
+                onResume={onResume}
+                onEndRide={onEndRide}
+                onRetryStart={onRetryStart}
+                onIgnoreStart={onIgnoreStart}
+                onCancelStart={onCancelStart}
+                onSettings={onSettings}
+            />
+
+            {showSummary && 
+                <ErrorBoundary>
+                    <ActivitySummaryDialog
+                        onClose={() => setShowSummary(false)}
+                        onExit={onExit}
+                    />
+                </ErrorBoundary>
+            }      
+        </ErrorBoundary>
     );
 };


### PR DESCRIPTION
Closes #119

This PR implements the `ActivitySummaryDialog` component which provides a summary of the ride after it ends. It includes:
- Ride statistics (distance, elevation, duration, averages).
- Activity graph and map/preview image.
- Save, Delete, and Close actions.
- File sharing chips for JSON, TCX, and FIT formats.
- Full-screen layout for tablets and a scrollable compact layout for phones.
- Delete confirmation dialog.