### PR TITLE
Fix #124: ActivitySummaryDialogView — post-save buttons, graph min-height, delete confirm contrast

### DIFF
--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.test.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.test.tsx
@@ -113,8 +113,11 @@ describe('ActivitySummaryDialogView', () => {
     it('renders with isSaving=true', () => {
         render(<ActivitySummaryDialogView {...MOCK_PROPS} isSaving={true} />);
     });
-    it('renders with isSaved=true', () => {
-        render(<ActivitySummaryDialogView {...MOCK_PROPS} isSaved={true} />);
+    it('renders with isSaved true', () => {
+        render(<ActivitySummaryDialogView {...MOCK_PROPS} isSaved={true} compact={false} />);
+    });
+    it('renders with isSaved true compact', () => {
+        render(<ActivitySummaryDialogView {...MOCK_PROPS} isSaved={true} compact={true} />);
     });
     it('renders delete confirmation', () => {
         render(<ActivitySummaryDialogView {...MOCK_PROPS} showDeleteConfirm={true} />);

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.tsx
@@ -42,22 +42,18 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
     const isCompact = compact ?? layout === 'compact';
     const converter = useUnitConverter();
 
-    const dialogButtons = [
-        ...(showSave && !isSaved ? [{
-            label: isSaving ? 'Saving...' : 'Save',
-            onClick: onSave,
-            primary: true,
-            disabled: isSaving,
-        }] : []),
-        {
-            label: 'Delete',
-            onClick: onDelete,
-        },
-        {
-            label: 'Close',
-            onClick: onClose,
-        },
-    ];
+    const dialogButtons = isSaved
+        ? [{ label: 'Close', onClick: onClose, primary: true }]
+        : [
+            ...(showSave ? [{
+                label: isSaving ? 'Saving...' : 'Save',
+                onClick: onSave,
+                primary: true,
+                disabled: isSaving,
+            }] : []),
+            { label: 'Delete', onClick: onDelete },
+            { label: 'Close', onClick: onClose },
+        ];
 
     const renderKeyFact = (label: string, value: any, unitKey?: 'distance' | 'elevation' | 'speed' | 'time' | 'power') => {
         let displayValue: string;
@@ -250,17 +246,19 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
             {MainContent}
 
             {showDeleteConfirm && (
-                <Dialog
-                    variant="info"
-                    title="Delete Ride"
-                    buttons={[
-                        { label: 'Cancel', onClick: onDeleteCancel },
-                        { label: 'Delete', onClick: onDeleteConfirm, attention: true },
-                    ]}
-                    onOutsideClick={onDeleteCancel}
-                >
-                    <Text style={styles.confirmText}>This will permanently delete this ride. Are you sure?</Text>
-                </Dialog>
+                <View style={styles.deleteConfirmWrapper}>
+                    <Dialog
+                        variant="info"
+                        title="Delete Ride"
+                        buttons={[
+                            { label: 'Cancel', onClick: onDeleteCancel },
+                            { label: 'Delete', onClick: onDeleteConfirm, attention: true },
+                        ]}
+                        onOutsideClick={onDeleteCancel}
+                    >
+                        <Text style={styles.confirmText}>This will permanently delete this ride. Are you sure?</Text>
+                    </Dialog>
+                </View>
             )}
         </Dialog>
     );
@@ -434,11 +432,18 @@ const styles = StyleSheet.create({
         flex: 1,
         width: '100%',
         marginTop: 16,
+        minHeight: 200, // Added minHeight
     },
     confirmText: {
         fontSize: textSizes.normalText,
         color: colors.text,
         padding: 16,
         textAlign: 'center',
+    },
+    deleteConfirmWrapper: { // Added style for delete confirmation wrapper
+        borderWidth: 1,
+        borderColor: 'rgba(255,255,255,0.4)',
+        borderRadius: 8,
+        overflow: 'hidden',
     },
 });


### PR DESCRIPTION
Closes #124

This PR addresses three visual fixes for the `ActivitySummaryDialogView` component:

1.  **Post-save button state:** Modified the `dialogButtons` logic so that when an activity is successfully saved (`isSaved === true`), only a single 'Close' button is displayed as the primary action. The 'Delete' button is now only visible before an activity is saved.

2.  **Activity graph minimum height:** Added `minHeight: 200` to `styles.graphContainer` to ensure the activity graph is always readable, regardless of layout mode.

3.  **Delete confirmation dialog contrast:** Wrapped the nested delete confirmation `Dialog` with a `View` that applies a border and `borderRadius` (`styles.deleteConfirmWrapper`). This improves visual distinction from the main dialog background.
