### PR TITLE
FreeMap: snap draggable marker to nearest route point

### DIFF
--- a/src/components/FreeMap/FreeMap.tsx
+++ b/src/components/FreeMap/FreeMap.tsx
@@ -15,9 +15,17 @@ export const FreeMap = (props: TFreeMapProps) => {
         center,
         zoom,
         bounds,
+        onPositionChanged,
+        onRoutePositionChanged,
+        draggable,
+        routeOptions,
+        position,
+        points: propsPoints,
+        route,
+        activity,
     } = props;
 
-    const points = useMemo(() => getPointsFromProps(props), [props]);
+    const points = useMemo(() => getPointsFromProps({ points: propsPoints, route, activity }), [propsPoints, route, activity]);
 
     const polylineData = useMemo((): GeoJSON.FeatureCollection<GeoJSON.LineString> => {
         const features: GeoJSON.Feature<GeoJSON.LineString>[] = [];
@@ -61,8 +69,8 @@ export const FreeMap = (props: TFreeMapProps) => {
             });
         }
 
-        if (props.routeOptions) {
-            props.routeOptions.forEach((opt) => {
+        if (routeOptions) {
+            routeOptions.forEach((opt) => {
                 features.push({
                     type: 'Feature',
                     properties: { color: opt.selected ? 'green' : (opt.color || 'blue') },
@@ -75,12 +83,12 @@ export const FreeMap = (props: TFreeMapProps) => {
         }
 
         return { type: 'FeatureCollection', features };
-    }, [points, startPos, endPos, colorActive, colorInactive, props.routeOptions]);
+    }, [points, startPos, endPos, colorActive, colorInactive, routeOptions]);
 
     const cameraProps = useMemo(() => {
         // 1. Use explicit bounds prop if provided
         // 2. Otherwise, attempt to compute bounds from points and route options
-        const effectiveBounds = bounds || computeBoundsFromPoints(points, props.routeOptions);
+        const effectiveBounds = bounds || computeBoundsFromPoints(points, routeOptions);
 
         if (effectiveBounds) {
             return {
@@ -103,10 +111,10 @@ export const FreeMap = (props: TFreeMapProps) => {
             centerCoordinate: toMapCoord(mapCenter),
             zoomLevel: mapZoom,
         };
-    }, [bounds, center, viewport, zoom, points, props.routeOptions]);
+    }, [bounds, center, viewport, zoom, points, routeOptions]);
 
-    const markerCoordinate = props.position 
-        ? toMapCoord(props.position) 
+    const markerCoordinate = position 
+        ? toMapCoord(position) 
         : undefined;
 
     const handlePositionChanged = useCallback(
@@ -114,13 +122,13 @@ export const FreeMap = (props: TFreeMapProps) => {
             if (!points?.length) return;
             const snapped = getPosition(points as unknown as Array<RoutePoint>, { nearest: true, latlng });
             if (!snapped) return;
-            props.onPositionChanged?.({ lat: snapped.lat, lng: snapped.lng });
-            props.onRoutePositionChanged?.(snapped.routeDistance ?? 0);
+            onPositionChanged?.({ lat: snapped.lat, lng: snapped.lng });
+            onRoutePositionChanged?.(snapped.routeDistance ?? 0);
         },
-        [points, props.onPositionChanged, props.onRoutePositionChanged]
+        [points, onPositionChanged, onRoutePositionChanged]
     );
 
-    const activeOnPositionChanged = props.draggable ? handlePositionChanged : props.onPositionChanged;
+    const activeOnPositionChanged = draggable ? handlePositionChanged : onPositionChanged;
 
     return (
         <FreeMapView

--- a/src/components/FreeMap/FreeMap.tsx
+++ b/src/components/FreeMap/FreeMap.tsx
@@ -1,5 +1,7 @@
-import React, { useMemo } from 'react';
-import { TFreeMapProps, MapCoord } from './types';
+import React, { useMemo, useCallback } from 'react';
+import { getPosition } from 'incyclist-services';
+import type { RoutePoint } from 'incyclist-services';
+import { TFreeMapProps, MapCoord, LatLng } from './types';
 import { FreeMapView } from './FreeMapView';
 import { getPointsFromProps, toMapCoord, computeBoundsFromPoints } from './utils';
 
@@ -107,9 +109,23 @@ export const FreeMap = (props: TFreeMapProps) => {
         ? toMapCoord(props.position) 
         : undefined;
 
+    const handlePositionChanged = useCallback(
+        (latlng: LatLng) => {
+            if (!points?.length) return;
+            const snapped = getPosition(points as unknown as Array<RoutePoint>, { nearest: true, latlng });
+            if (!snapped) return;
+            props.onPositionChanged?.({ lat: snapped.lat, lng: snapped.lng });
+            props.onRoutePositionChanged?.(snapped.routeDistance ?? 0);
+        },
+        [points, props.onPositionChanged, props.onRoutePositionChanged]
+    );
+
+    const activeOnPositionChanged = props.draggable ? handlePositionChanged : props.onPositionChanged;
+
     return (
         <FreeMapView
             {...props}
+            onPositionChanged={activeOnPositionChanged}
             cameraProps={cameraProps}
             polylineData={polylineData}
             markerCoordinate={markerCoordinate}

--- a/src/components/FreeMap/FreeMapView.android.tsx
+++ b/src/components/FreeMap/FreeMapView.android.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { Platform, StyleSheet, Text, View, DimensionValue } from 'react-native';
 import MapLibreRN, { 
     MapView, 
@@ -70,7 +70,15 @@ export const FreeMapView = ({
         );
     }
 
-
+    const handleDragEnd = useCallback(
+        (e: any) => {
+            if (onPositionChanged) {
+                const coords = e.geometry.coordinates;
+                onPositionChanged(fromMapCoord(coords));
+            }
+        },
+        [onPositionChanged]
+    );
 
     if (!mapStyle) return null;
 
@@ -108,12 +116,7 @@ export const FreeMapView = ({
                         id='marker'
                         coordinate={markerCoordinate}
                         draggable={draggable}
-                        onDragEnd={(e) => {
-                            if (onPositionChanged) {
-                                const coords = e.geometry.coordinates;
-                                onPositionChanged(fromMapCoord(coords));
-                            }
-                        }}
+                        onDragEnd={handleDragEnd}
                     >
                         <View style={styles.marker} />
                     </PointAnnotation>

--- a/src/components/FreeMap/FreeMapView.android.tsx
+++ b/src/components/FreeMap/FreeMapView.android.tsx
@@ -57,10 +57,12 @@ export const FreeMapView = ({
         
     }, [mapStyle]);
 
+    const dynamicStyle = { width: width as DimensionValue, height: height as DimensionValue };
+
    // Web Fallback for Storybook-Vite
     if (Platform.OS === 'web') {
         return (
-            <View style={[styles.container, { width: width as DimensionValue, height: height as DimensionValue, backgroundColor: '#e0e0e0' }, style]}>
+            <View style={[styles.container, styles.webContainer, dynamicStyle, style]}>
                 <Text style={styles.webPlaceholder}>
                     MapLibre Native Component (Not available on Web)
                 </Text>
@@ -85,7 +87,7 @@ export const FreeMapView = ({
     
 
     return (
-        <View style={[styles.container, { width: width as DimensionValue, height: height as DimensionValue }, style]}>
+        <View style={[styles.container, dynamicStyle, style]}>
             <MapView
                 style={styles.map}
                 mapStyle={JSON.stringify(mapStyle)} // Replaced styleJSON with mapStyle
@@ -101,13 +103,7 @@ export const FreeMapView = ({
                 <ShapeSource id='routeSource' shape={polylineData}>
                     <LineLayer
                         id='routeLayer'
-                        style={{
-                            lineColor: ['get', 'color'],
-                            lineWidth: 5,
-                            lineOpacity: 0.8,
-                            lineCap: 'round',
-                            lineJoin: 'round',
-                        }}
+                        style={styles.routeLayer}
                     />
                 </ShapeSource>
 
@@ -150,5 +146,15 @@ const styles = StyleSheet.create({
         paddingTop: '20%',
         color: '#666',
         fontWeight: 'bold',
-    },    
+    },
+    webContainer: {
+        backgroundColor: '#e0e0e0',
+    },
+    routeLayer: {
+        lineColor: ['get', 'color'],
+        lineWidth: 5,
+        lineOpacity: 0.8,
+        lineCap: 'round',
+        lineJoin: 'round',
+    } as any,
 });

--- a/src/components/FreeMap/types.ts
+++ b/src/components/FreeMap/types.ts
@@ -58,6 +58,7 @@ export interface TFreeMapProps {
     height?: number | string;
     style?: StyleProp<ViewStyle>;
     onPositionChanged?: (position: LatLng) => void;
+    onRoutePositionChanged?: (distanceMeters: number) => void;
     onViewportChanged?: (viewport: TViewPort) => void;
     children?: ReactNode;
     colorActive?: string;


### PR DESCRIPTION
Closes #130

This PR implements marker snapping for the FreeMap component. When the marker is draggable and dragged to a new position, it now snaps to the nearest route point (if points are available) using `getPosition` from `incyclist-services`. It also emits the `onRoutePositionChanged` event with the route distance in meters.