### PR TITLE
fix(136): improve marker touch target and visibility on iOS

### DIFF
--- a/src/components/FreeMap/FreeMapView.ios.tsx
+++ b/src/components/FreeMap/FreeMapView.ios.tsx
@@ -90,6 +90,7 @@ export const FreeMapView = ({
         }
     }, [mapRef, cameraProps.bounds, initialRegionSet]);
 
+    const dynamicStyle = { width: width as DimensionValue, height: height as DimensionValue };
 
     const handleMarkerDragEnd = useCallback((e: any) => {
         if (onPositionChanged) {
@@ -104,8 +105,6 @@ export const FreeMapView = ({
     if (!polylineCoordinates.length && !markerCoordinate && !cameraProps?.centerCoordinate) {
         return null;
     }
-
-    const dynamicStyle = { width: width as DimensionValue, height: height as DimensionValue };
 
     return (
         <View style={[styles.container, dynamicStyle, style]}>

--- a/src/components/FreeMap/FreeMapView.ios.tsx
+++ b/src/components/FreeMap/FreeMapView.ios.tsx
@@ -105,8 +105,10 @@ export const FreeMapView = ({
         return null;
     }
 
+    const dynamicStyle = { width: width as DimensionValue, height: height as DimensionValue };
+
     return (
-        <View style={[styles.container, { width: width as DimensionValue, height: height as DimensionValue }, style]}>
+        <View style={[styles.container, dynamicStyle, style]}>
             <MapView
                 ref={mapRef}
                 provider={undefined} // Use Apple Maps
@@ -126,12 +128,15 @@ export const FreeMapView = ({
 
                 {markerCoordinate && (
                     <Marker
+                        key={`marker-${markerCoordinate[0].toFixed(5)}-${markerCoordinate[1].toFixed(5)}`}
                         coordinate={toRNLatLng(markerCoordinate)}
                         draggable={draggable}
                         onDragEnd={handleMarkerDragEnd}
                     >
-                        {/* Custom marker view to match Android's red circular marker */}
-                        <View style={styles.marker} />
+                        {/* Custom marker view with enlarged touch target */}
+                        <View style={styles.markerTouchTarget}>
+                            <View style={styles.marker} />
+                        </View>
                     </Marker>
                 )}
                 {children}
@@ -146,6 +151,13 @@ const styles = StyleSheet.create({
     },
     map: {
         flex: 1,
+    },
+    markerTouchTarget: {
+        width: 44,
+        height: 44,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'transparent',
     },
     marker: {
         height: 20,


### PR DESCRIPTION
Closes #136

This PR fixes two issues with the marker on iOS:
1. Increases the touch target size to 44x44 by wrapping the marker dot in a transparent container.
2. Forces a marker remount on coordinate change using a unique `key` prop, preventing the marker from disappearing during position updates.
3. Refactors inline styles to comply with project standards.