### PR TITLE
feat(145): Implement loading screen status messages and init sequencing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,7 +53,7 @@ const DeviceInfoLogger = ({ children }: PropsWithChildren<{}>): ReactElement => 
     return <>{children}</>;
 };
 
-export const App = ({ secretsStatus }: AppProps) => { // Accept new prop
+export const App = ({ secretsStatus: _secretsStatus }: AppProps) => { // Accept new prop
     const isDarkMode = useColorScheme() === 'dark';
     const service = useIncyclist();
     const ble = getBleBinding();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,9 +23,14 @@ import { logDeviceInfo } from './utils/deviceInfo';
 import { useOnlineStatusMonitoringInit } from './hooks/network/useOnlineStatusMonitoring';
 import { MainPage } from './pages/MainPage/MainPage';
 import { NavigationBar } from '@zoontek/react-native-navigation-bar';
+import { SecretsStatus } from './bindings/secret/types'; // Import new type
 
 LogBox.ignoreLogs(['new NativeEventEmitter()']);
 let lastState = AppState.currentState;
+
+interface AppProps {
+    secretsStatus?: SecretsStatus; // new — not yet used internally, just accepted
+}
 
 const DeviceInfoLogger = ({ children }: PropsWithChildren<{}>): ReactElement => {
     const refLogged = useRef(false);
@@ -48,7 +53,7 @@ const DeviceInfoLogger = ({ children }: PropsWithChildren<{}>): ReactElement => 
     return <>{children}</>;
 };
 
-export const App = () => {
+export const App = ({ secretsStatus }: AppProps) => { // Accept new prop
     const isDarkMode = useColorScheme() === 'dark';
     const service = useIncyclist();
     const ble = getBleBinding();

--- a/src/Loader.tsx
+++ b/src/Loader.tsx
@@ -9,15 +9,16 @@ import { LoadingScreen } from './pages/LoadingScreen/LoadingScreen';
 
 import app from '../app.json'
 import { UpdateService } from './services/UpdateManager';
+import { initSecrets } from './bindings/secret';
+import { SecretsStatus } from './bindings/secret/types';
 
 export const Loader = () =>{
     const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [statusMessage, setStatusMessage] = useState<string>('Starting up...');
+    const [secretsStatus, setSecretsStatus] = useState<SecretsStatus>('ok');
 
-
-    const refChecking = useRef<Promise<any>>(null)
+    const refChecking = useRef<Promise<any> | null>(null)
     
-
-
     const initLogging =() =>{
         const logAdapter  = new RNConsoleAdapter( {depth:1}) as LogAdapter
         EventLogger.registerAdapter(logAdapter)
@@ -25,42 +26,40 @@ export const Loader = () =>{
         initRestLogging()
     }
 
-
-    // Load and replace UI bundle
     useEffect(() => {
         if ( refChecking.current)
-                return
-        // Lock to landscape when the app starts
+            return
+        
         Orientation.lockToLandscape();
         initLogging()
         
-        const checkUpdate = async () => {
+        const run = async () => {
+            setStatusMessage('Setting up infrastructure...');
+            const status = await initSecrets({ timeout: 7000 });
+            setSecretsStatus(status);
 
-            // TODO: Wait with timeout, Consider termination or pause during bundle update
-
+            setStatusMessage('Checking for updates...');
             UpdateService.checkForUpdates();
 
-            // 2. Simple delay for Splash Screen visibility
-            setTimeout(() => {
-                setIsLoading(false);
-            }, 2000);
+            setStatusMessage('Almost ready...');
+            setIsLoading(false);
             refChecking.current    = null
-
         }
-        refChecking.current  = checkUpdate();
+        refChecking.current  = run();
         
 
-    }, [isLoading]);
-
+    }, []);
 
 
     if (isLoading) {
         return (
-            <LoadingScreen appVersion={app.appVersion} bundleVersion={app.bundleVersion}/>
+            <LoadingScreen 
+                appVersion={app.appVersion} 
+                bundleVersion={app.bundleVersion}
+                statusMessage={statusMessage}
+            />
         );
     }
 
-  // Once loading is finished, show the main app
-    return <App />;
+    return <App secretsStatus={secretsStatus} />;
 }
-

--- a/src/bindings/secret/index.ts
+++ b/src/bindings/secret/index.ts
@@ -1,5 +1,6 @@
 import { getUserSettingsBinding } from "../user-settings"
 import defSettings from '@settings'
+import { SecretsStatus } from "./types"; // Import new type
 
 class SecretBinding  {
     protected static _instance: SecretBinding;
@@ -19,3 +20,7 @@ class SecretBinding  {
 }
 
 export const getSecretBinding =() => SecretBinding.getInstance()
+
+export const initSecrets = async (_opts: { timeout: number }): Promise<SecretsStatus> => {
+    return 'ok';
+};

--- a/src/bindings/secret/types.ts
+++ b/src/bindings/secret/types.ts
@@ -1,0 +1,1 @@
+export type SecretsStatus = 'ok' | 'stale' | 'missing';

--- a/src/pages/LoadingScreen/LoadingScreen.tsx
+++ b/src/pages/LoadingScreen/LoadingScreen.tsx
@@ -5,8 +5,9 @@ import { NavigationBar } from '@zoontek/react-native-navigation-bar';
 interface LoadingScreenProps  {
     appVersion: string
     bundleVersion: string
+    statusMessage?: string
 }
-export const LoadingScreen = ( {appVersion, bundleVersion}:LoadingScreenProps)=> {
+export const LoadingScreen = ( {appVersion, bundleVersion, statusMessage}:LoadingScreenProps)=> {
     const isDarkMode = useColorScheme() === 'dark';
 
     return (
@@ -22,6 +23,7 @@ export const LoadingScreen = ( {appVersion, bundleVersion}:LoadingScreenProps)=>
                 />
                 {appVersion && <Text style={styles.versionText}>App Version {appVersion}</Text>}
                 {bundleVersion && <Text style={styles.versionText}>UI Version {bundleVersion}</Text>}
+                {statusMessage && <Text style={styles.versionText}>{statusMessage}</Text>}
                 <ActivityIndicator size="large" color="#007AFF" />
             </View>
         </SafeAreaView>
@@ -49,4 +51,3 @@ const styles = StyleSheet.create({
     marginBottom: 3,
   },
 });
-


### PR DESCRIPTION
Closes #145

This PR addresses GitHub Issue #145 by implementing loading screen status messages and refactoring the app's initialization sequence.

Key changes include:
- Added an optional `statusMessage` prop to `LoadingScreen` to display user feedback during startup.
- Refactored `Loader.tsx` to manage a `statusMessage` state and guide the user through the initialization process.
- Introduced `initSecrets` binding call and awaited its completion before proceeding to `checkForUpdates`.
- Removed the hardcoded 2-second `setTimeout` in `Loader.tsx`, allowing `setIsLoading(false)` to fire after the update check is initiated.
- Defined the `SecretsStatus` type and added a placeholder `initSecrets` function in `src/bindings/secret/` to establish the contract for future secret management.
- Updated `App.tsx` to accept a `secretsStatus` prop for future use.

The new initialization sequence now provides clear feedback to the user, improving the perceived performance during app launch.
