### PR TITLE
fix(154): FreeMap camera modes, overlay visibility, and bounds reset

### DIFF
--- a/src/components/FreeMap/FreeMap.tsx
+++ b/src/components/FreeMap/FreeMap.tsx
@@ -23,6 +23,7 @@ export const FreeMap = (props: TFreeMapProps) => {
         points: propsPoints,
         route,
         activity,
+        followPosition,
     } = props;
 
     const points = useMemo(() => getPointsFromProps({ points: propsPoints, route, activity }), [propsPoints, route, activity]);
@@ -137,6 +138,7 @@ export const FreeMap = (props: TFreeMapProps) => {
             cameraProps={cameraProps}
             polylineData={polylineData}
             markerCoordinate={markerCoordinate}
+            followPosition={followPosition}
         />
     );
 };

--- a/src/components/FreeMap/FreeMapView.android.tsx
+++ b/src/components/FreeMap/FreeMapView.android.tsx
@@ -97,7 +97,7 @@ export const FreeMapView = ({
         effectiveCameraProps = cameraProps;
     } else {
         // After initial fit, remove bounds property and handle followPosition
-        const { bounds: _, ...rest } = cameraProps;
+        const { bounds: _bounds, ...rest } = cameraProps;
         if (followPosition && markerCoordinate) {
             effectiveCameraProps = { ...rest, centerCoordinate: markerCoordinate };
         } else {

--- a/src/components/FreeMap/FreeMapView.android.tsx
+++ b/src/components/FreeMap/FreeMapView.android.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { Platform, StyleSheet, Text, View, DimensionValue } from 'react-native';
 import MapLibreRN, { 
     MapView, 
@@ -38,8 +38,10 @@ export const FreeMapView = ({
     onPositionChanged,
     scrollWheelZoom = true,
     children,
+    followPosition,
 }: FreeMapViewProps) => {
     const [mapStyle, setMapStyle] = useState(null);
+    const refBoundsApplied = useRef(false);
 
     useEffect(() => {
         if (mapStyle!==null || Platform.OS === 'web')
@@ -56,6 +58,11 @@ export const FreeMapView = ({
 
         
     }, [mapStyle]);
+
+    // Reset when bounds change (route extension mid-ride)
+    useEffect(() => {
+        refBoundsApplied.current = false;
+    }, [cameraProps.bounds]);
 
     const dynamicStyle = { width: width as DimensionValue, height: height as DimensionValue };
 
@@ -84,6 +91,19 @@ export const FreeMapView = ({
 
     if (!mapStyle) return null;
 
+    let effectiveCameraProps: typeof cameraProps;
+    if (!refBoundsApplied.current) {
+        // Apply bounds only for the initial fit
+        effectiveCameraProps = cameraProps;
+    } else {
+        // After initial fit, remove bounds property and handle followPosition
+        const { bounds: _, ...rest } = cameraProps;
+        if (followPosition && markerCoordinate) {
+            effectiveCameraProps = { ...rest, centerCoordinate: markerCoordinate };
+        } else {
+            effectiveCameraProps = rest;
+        }
+    }
     
 
     return (
@@ -94,9 +114,10 @@ export const FreeMapView = ({
                 scrollEnabled={scrollWheelZoom}
                 logoEnabled={false}
                 attributionEnabled={true}
+                onDidFinishRenderingMapFully={() => { refBoundsApplied.current = true; }}
             >
                 <Camera 
-                    {...cameraProps}
+                    {...effectiveCameraProps}
                     animationDuration={0}
                 />
 

--- a/src/components/FreeMap/FreeMapView.android.tsx
+++ b/src/components/FreeMap/FreeMapView.android.tsx
@@ -97,7 +97,9 @@ export const FreeMapView = ({
         effectiveCameraProps = cameraProps;
     } else {
         // After initial fit, remove bounds property and handle followPosition
-        const { bounds: _bounds, ...rest } = cameraProps;
+        const rest = Object.fromEntries(
+            Object.entries(cameraProps).filter(([key]) => key !== 'bounds')
+        ) as Omit<typeof cameraProps, 'bounds'>;
         if (followPosition && markerCoordinate) {
             effectiveCameraProps = { ...rest, centerCoordinate: markerCoordinate };
         } else {

--- a/src/components/FreeMap/FreeMapView.ios.tsx
+++ b/src/components/FreeMap/FreeMapView.ios.tsx
@@ -37,6 +37,7 @@ export const FreeMapView = ({
     draggable = false,
     onPositionChanged,
     children,
+    followPosition,
 }: FreeMapViewProps) => {
     const mapRef = useRef<MapView | null>(null);
     const [initialRegionSet, setInitialRegionSet] = useState(false);
@@ -89,6 +90,27 @@ export const FreeMapView = ({
             setInitialRegionSet(true); // Mark as set to avoid re-running if bounds are static
         }
     }, [mapRef, cameraProps.bounds, initialRegionSet]);
+
+    // Reset initialRegionSet when bounds change (route extension mid-ride)
+    useEffect(() => {
+        setInitialRegionSet(false);
+    }, [cameraProps.bounds]);
+
+    // Effect to re-center the map on marker position if followPosition is true
+    useEffect(() => {
+        if (!followPosition || !initialRegionSet || !markerCoordinate || !mapRef.current) return;
+        mapRef.current.getCamera().then(camera => {
+            // Check mapRef.current again in case component unmounted during async operation
+            if (!mapRef.current) return;
+            mapRef.current.animateCamera({
+                center: {
+                    latitude: markerCoordinate[1],
+                    longitude: markerCoordinate[0],
+                },
+                zoom: camera.zoom, // Preserve current zoom level
+            }, { duration: 300 });
+        });
+    }, [markerCoordinate, followPosition, initialRegionSet]);
 
     const dynamicStyle = { width: width as DimensionValue, height: height as DimensionValue };
 

--- a/src/components/FreeMap/types.ts
+++ b/src/components/FreeMap/types.ts
@@ -63,6 +63,7 @@ export interface TFreeMapProps {
     children?: ReactNode;
     colorActive?: string;
     colorInactive?: string;
+    followPosition?: boolean;
 }
 
 // Internal type for MapLibre which uses [longitude, latitude]
@@ -83,4 +84,5 @@ export interface FreeMapViewProps extends TFreeMapProps {
     };
     polylineData: GeoJSON.FeatureCollection<GeoJSON.LineString>;
     markerCoordinate?: MapCoord;
+    followPosition?: boolean;
 }

--- a/src/pages/RidePage/Video/View.tsx
+++ b/src/pages/RidePage/Video/View.tsx
@@ -161,20 +161,22 @@ export const VideoRidePageView = (props: VideoRidePageViewProps) => {
 
                 {/* Map Overlay */}
                 {!isCompact && route?.description?.hasGpx && !!routeData?.points?.length && (
-                    <Dynamic
-                        observer={rideObserver ?? undefined}
-                        event='position-update'
-                        prop='position'
-                        transform={transformPosition}
-                    >
-                        <FreeMap
-                            points={routeData.points}
-                            draggable={false}
-                            colorActive='blue'
-                            colorInactive='rgba(255,255,255,0.4)'
-                            style={[styles.mapOverlay, mapOverlayDynamicStyle]}
-                        />
-                    </Dynamic>
+                    <View style={[styles.mapOverlay, mapOverlayDynamicStyle]}>
+                        <Dynamic
+                            observer={rideObserver ?? undefined}
+                            event='position-update'
+                            prop='position'
+                            transform={transformPosition}
+                        >
+                            <FreeMap
+                                points={routeData.points}
+                                draggable={false}
+                                followPosition={true}
+                                colorActive='blue'
+                                colorInactive='rgba(255,255,255,0.4)'
+                            />
+                        </Dynamic>
+                    </View>
                 )}
 
                 {infoText && <InfoText {...infoText} />}
@@ -276,5 +278,7 @@ const styles = StyleSheet.create({
         backgroundColor: 'rgba(0,0,0,0.45)',
         borderRadius: 4,
         overflow: 'hidden',
+        zIndex: 10,
+        elevation: 10,
     },
 });


### PR DESCRIPTION
Closes #154

This PR addresses several issues related to the FreeMap component:

1.  **Map Overlay Visibility**: The map overlay on `VideoRidePage` was invisible due to a style merging conflict with the `Dynamic` component. This is fixed by wrapping `Dynamic` and `FreeMap` in a dedicated `View` container that owns the positioning and dimensions, preventing `position: 'absolute'` from being incorrectly applied to `FreeMap` itself.
2.  **Follow-Position Camera Mode**: Introduced a `followPosition` prop. When `true`, the map camera automatically re-centers on the rider's current position while preserving the user's zoom level. This improves the rider's experience by keeping their position in view without losing their preferred zoom.
3.  **Bounds Reset on Route Change**: Implemented logic to reset the map's initial bounds fitting when the underlying route data (`points` prop) changes. This ensures that if a route is extended mid-ride, the map automatically re-fits to the new, full route bounds.
4.  **Platform-Specific Camera Handling**: The camera behavior is implemented with platform-specific logic for `MapLibre` (Android) and `react-native-maps` (iOS) to ensure optimal performance and user experience on both platforms.