### PR TITLE
feat: Loader integration — secrets status passing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,8 @@ import {
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { PropsWithChildren, ReactElement, useEffect, useRef, useState } from 'react';
-import { AppFeatures, IncyclistBindings, useIncyclist } from 'incyclist-services';
+import { AppFeatures, IncyclistBindings } from 'incyclist-services';
+import { useIncyclist } from './services';
 import { initBindings } from './bindings/factory';
 import app from '../app.json';
 import { useLogging, useUnmountEffect } from './hooks';
@@ -23,13 +24,13 @@ import { logDeviceInfo } from './utils/deviceInfo';
 import { useOnlineStatusMonitoringInit } from './hooks/network/useOnlineStatusMonitoring';
 import { MainPage } from './pages/MainPage/MainPage';
 import { NavigationBar } from '@zoontek/react-native-navigation-bar';
-import { SecretsStatus } from './bindings/secret/types'; // Import new type
+import { SecretsStatus } from './bindings/secret/types';
 
 LogBox.ignoreLogs(['new NativeEventEmitter()']);
 let lastState = AppState.currentState;
 
 interface AppProps {
-    secretsStatus?: SecretsStatus; // new — not yet used internally, just accepted
+    secretsStatus?: SecretsStatus;
 }
 
 const DeviceInfoLogger = ({ children }: PropsWithChildren<{}>): ReactElement => {
@@ -53,9 +54,9 @@ const DeviceInfoLogger = ({ children }: PropsWithChildren<{}>): ReactElement => 
     return <>{children}</>;
 };
 
-export const App = ({ secretsStatus: _secretsStatus }: AppProps) => { // Accept new prop
+export const App = ({ secretsStatus }: AppProps) => {
     const isDarkMode = useColorScheme() === 'dark';
-    const service = useIncyclist();
+    const service = useIncyclist({ secretsStatus });
     const ble = getBleBinding();
     const [initialized, setInitialized] = useState<boolean>(false);
 
@@ -64,7 +65,6 @@ export const App = ({ secretsStatus: _secretsStatus }: AppProps) => { // Accept 
     const { stopMonitoring } = useOnlineStatusMonitoringInit();
     const refStopMonitoring = useRef<() => void>(stopMonitoring);
 
-    
     useEffect(() => {
         const sub = AppState.addEventListener('change', nextState => {
             if (lastState === 'active' && nextState !== 'active') {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,4 +1,35 @@
-export * from './PermissionsService'
-export * from './Navigation'
-export * from './IncyclistApi'
-export * from './RestLogging'
+import { 
+    useIncyclist as useIncyclistBase, 
+    getRidePageService as getRidePageServiceBase 
+} from 'incyclist-services';
+import { SecretsStatus } from '../bindings/secret/types';
+
+export * from './PermissionsService';
+export * from './Navigation';
+export * from './IncyclistApi';
+export * from './RestLogging';
+
+let currentSecretsStatus: SecretsStatus = 'missing';
+
+/**
+ * Hook to access the main Incyclist service.
+ * Extended to accept initialization options including secretsStatus.
+ */
+export const useIncyclist = (options?: { secretsStatus?: SecretsStatus }) => {
+    if (options?.secretsStatus) {
+        currentSecretsStatus = options.secretsStatus;
+    }
+    return useIncyclistBase();
+};
+
+/**
+ * Accessor for RidePageService.
+ * Extended to provide getSecretsStatus() for use during page initialization.
+ */
+export const getRidePageService = () => {
+    const service = getRidePageServiceBase();
+    if (service && !(service as any).getSecretsStatus) {
+        (service as any).getSecretsStatus = () => currentSecretsStatus;
+    }
+    return service;
+};


### PR DESCRIPTION
Closes #150

This PR completes the wiring of `secretsStatus` from the `Loader` through the `App` component into the service layer, ensuring it is available for `RidePageService`.

Key changes:
- Updated `App.tsx` to pass the `secretsStatus` prop into the `useIncyclist` hook during initialization.
- Extended `src/services/index.ts` to wrap the `useIncyclist` hook, capturing the `secretsStatus` and making it available via a module-level variable.
- Wrapped `getRidePageService()` in the service layer to inject the `getSecretsStatus()` method into the service instance, satisfying the requirement for it to be accessible during `initPage()`.