### PR TITLE
Ride start gate — mobile UI integration

### DIFF
--- a/src/bindings/secret/index.ts
+++ b/src/bindings/secret/index.ts
@@ -186,6 +186,10 @@ class SecretBinding {
         return getSecret(key) ?? '';
     }
 
+    getSecretsStatus(): SecretsStatus {
+        return getSecretsStatus();
+    }
+
     async init(opts: { timeout: number } = { timeout: 5000 }): Promise<void> {
         await initSecrets(opts);
     }

--- a/src/pages/RidePage/RidePage.tsx
+++ b/src/pages/RidePage/RidePage.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { View, StyleSheet, Text } from 'react-native';
-import { getRidePageService, RideType } from 'incyclist-services';
-import { MainBackground, Button } from '../../components';
+import { getRidePageService, RideType, StartGateProps } from 'incyclist-services';
+import { MainBackground, Button, Dialog, ButtonBar } from '../../components';
 import { VideoRidePage } from './Video';
 import { colors } from '../../theme';
 import { textSizes } from '../../theme';
+import { initSecrets } from '../../bindings/secret';
 
 interface RidePageProps {
     simulate?: boolean;
@@ -29,24 +30,69 @@ const NotImplementedView = ( {onBack}:NotImplementedViewProps) => {
 
 export const RidePage = ({ simulate = false }: RidePageProps) => {
     const refInitialized = useRef(false);
+    const refPendingType = useRef<RideType | null>(null);
     const [rideType, setRideType] = useState<RideType | null>(null);
-    const service = getRidePageService()
+    const [startGateProps, setStartGateProps] = useState<StartGateProps | null>(null);
+    const service = getRidePageService();
 
     const onRideTypeChange = useCallback((updated: RideType) => {
         setRideType(updated);
     }, []);
 
+    const onRefreshSecrets = useCallback(async () => {
+        await initSecrets({ timeout: 10000 });
+        service.onRefreshSecrets();
+        setStartGateProps(null);
+        if (refPendingType.current) {
+            setRideType(refPendingType.current);
+        }
+    }, [service]);
+
+    const onContinueAnyway = useCallback(() => {
+        service.onContinueAnyway();
+        setStartGateProps(null);
+        if (refPendingType.current) {
+            setRideType(refPendingType.current);
+        }
+    }, [service]);
+
     useEffect(() => {
         if (refInitialized.current) return;
         refInitialized.current = true;
 
-        getRidePageService().initPage().then(type => {
-            setRideType(type);
+        service.initPage().then(type => {
+            const props = service.getPageDisplayProps();
+            if (props?.startGateProps) {
+                refPendingType.current = type;
+                setStartGateProps(props.startGateProps);
+            } else {
+                setRideType(type);
+            }
         });
-    }, []);
+    }, [service]);
 
     if (rideType === null) {
-        return <NotImplementedView onBack={()=>service.onEndRide()}/>;
+        return (
+            <>
+                <NotImplementedView onBack={() => service.onEndRide()} />
+                {startGateProps && (
+                    <Dialog
+                        title={startGateProps.title}
+                        variant="info"
+                        presentationStyle="overFullScreen"
+                        supportedOrientations={['landscape']}
+                        buttons={
+                            <ButtonBar>
+                                <Button id="connect" label="Connect now" primary onClick={onRefreshSecrets} />
+                                <Button id="continue" label="Continue anyway" onClick={onContinueAnyway} />
+                            </ButtonBar>
+                        }
+                    >
+                        <Text style={styles.gateBody}>{startGateProps.body}</Text>
+                    </Dialog>
+                )}
+            </>
+        );
     }
 
     if (rideType === 'Video') {
@@ -70,5 +116,10 @@ content: {
 message: {
     color: colors.text,
     fontSize: textSizes.noDataText,
+},
+gateBody: {
+    color: colors.text,
+    fontSize: textSizes.normalText,
+    textAlign: 'center',
 },
 });

--- a/src/pages/RidePage/RidePage.tsx
+++ b/src/pages/RidePage/RidePage.tsx
@@ -82,8 +82,6 @@ export const RidePage = ({ simulate = false }: RidePageProps) => {
                     <Dialog
                         title={startGateProps.title}
                         variant="info"
-                        presentationStyle="overFullScreen"
-                        supportedOrientations={['landscape']}
                         buttons={[
                             { id: 'connect', label: 'Connect now', primary: true, onClick: onRefreshSecrets },
                             { id: 'continue', label: 'Continue anyway', onClick: onContinueAnyway },

--- a/src/pages/RidePage/RidePage.tsx
+++ b/src/pages/RidePage/RidePage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import { getRidePageService, RideType, StartGateProps } from 'incyclist-services';
-import { MainBackground, Button, Dialog, ButtonBar } from '../../components';
+import { MainBackground, Button, Dialog } from '../../components';
 import { VideoRidePage } from './Video';
 import { colors } from '../../theme';
 import { textSizes } from '../../theme';
@@ -12,17 +12,16 @@ interface RidePageProps {
 }
 
 interface NotImplementedViewProps {
-    onBack:()=>void
+    onBack: () => void;
 }
 
-const NotImplementedView = ( {onBack}:NotImplementedViewProps) => {
-    
+const NotImplementedView = ({ onBack }: NotImplementedViewProps) => {
     return (
         <View style={styles.container}>
             <MainBackground />
             <View style={styles.content}>
                 <Text style={styles.message}>Not yet implemented</Text>
-                <Button id='back' label='Back' primary onClick={onBack} />
+                <Button id="back" label="Back" primary onClick={onBack} />
             </View>
         </View>
     );
@@ -38,6 +37,10 @@ export const RidePage = ({ simulate = false }: RidePageProps) => {
     const onRideTypeChange = useCallback((updated: RideType) => {
         setRideType(updated);
     }, []);
+
+    const onEndRide = useCallback(() => {
+        service.onEndRide();
+    }, [service]);
 
     const onRefreshSecrets = useCallback(async () => {
         await initSecrets({ timeout: 10000 });
@@ -74,19 +77,17 @@ export const RidePage = ({ simulate = false }: RidePageProps) => {
     if (rideType === null) {
         return (
             <>
-                <NotImplementedView onBack={() => service.onEndRide()} />
+                <NotImplementedView onBack={onEndRide} />
                 {startGateProps && (
                     <Dialog
                         title={startGateProps.title}
                         variant="info"
                         presentationStyle="overFullScreen"
                         supportedOrientations={['landscape']}
-                        buttons={
-                            <ButtonBar>
-                                <Button id="connect" label="Connect now" primary onClick={onRefreshSecrets} />
-                                <Button id="continue" label="Continue anyway" onClick={onContinueAnyway} />
-                            </ButtonBar>
-                        }
+                        buttons={[
+                            { id: 'connect', label: 'Connect now', primary: true, onClick: onRefreshSecrets },
+                            { id: 'continue', label: 'Continue anyway', onClick: onContinueAnyway },
+                        ]}
                     >
                         <Text style={styles.gateBody}>{startGateProps.body}</Text>
                     </Dialog>
@@ -100,26 +101,26 @@ export const RidePage = ({ simulate = false }: RidePageProps) => {
     }
 
     // Default case for any other rideType not explicitly handled
-    return <NotImplementedView onBack={()=>service.onEndRide()}/>;
+    return <NotImplementedView onBack={onEndRide} />;
 };
 
 const styles = StyleSheet.create({
-container: {
-    flex: 1,
-},
-content: {
-    ...StyleSheet.absoluteFill,
-    justifyContent: 'center',
-    alignItems: 'center',
-    gap: 24,
-},
-message: {
-    color: colors.text,
-    fontSize: textSizes.noDataText,
-},
-gateBody: {
-    color: colors.text,
-    fontSize: textSizes.normalText,
-    textAlign: 'center',
-},
+    container: {
+        flex: 1,
+    },
+    content: {
+        ...StyleSheet.absoluteFill,
+        justifyContent: 'center',
+        alignItems: 'center',
+        gap: 24,
+    },
+    message: {
+        color: colors.text,
+        fontSize: textSizes.noDataText,
+    },
+    gateBody: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        textAlign: 'center',
+    },
 });

--- a/src/pages/RidePage/Video/VideoRidePage.stories.tsx
+++ b/src/pages/RidePage/Video/VideoRidePage.stories.tsx
@@ -1,10 +1,18 @@
 import React from 'react';
-import { StyleSheet, useWindowDimensions, View } from 'react-native';
+import { StyleSheet, useWindowDimensions, View, Text } from 'react-native';
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { fn } from 'storybook/test';
 import { VideoRidePageTestView } from './TestView';
+import { Dialog, ButtonBar, Button } from '../../../components';
+import { colors, textSizes } from '../../../theme';
+import { StartGateProps } from 'incyclist-services';
 import sydneyRoute from '../../../../__tests__/testdata/sydney.json';
 import teideRoute from '../../../../__tests__/testdata/ES_Teide.json';
+
+const MOCK_START_GATE_PROPS: StartGateProps = {
+    title: 'Session refresh needed',
+    body: 'Please connect to the internet before starting your ride',
+};
 
 const callbacks = {
     onMenuOpen: fn(),
@@ -18,7 +26,12 @@ const callbacks = {
 };
 
 const styles = StyleSheet.create( {
-    container: {flex: 1, position: 'relative', width: '100%'}
+    container: {flex: 1, position: 'relative', width: '100%'},
+    gateBody: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        textAlign: 'center',
+    },
 })
 
 const meta: Meta<typeof VideoRidePageTestView> = {
@@ -121,5 +134,39 @@ export const Starting: Story = {
             route: teideRoute as any,
             video: { src: '', hidden: false } as any,
         },
+    },
+};
+
+export const WithStartGate: Story = {
+    args: {
+        ...ActiveRide.args,
+        displayProps: {
+            ...ActiveRide.args!.displayProps!,
+            startGateProps: MOCK_START_GATE_PROPS,
+        },
+    },
+    render: (args) => {
+        const startGateProps = args.displayProps?.startGateProps;
+        return (
+            <View style={styles.container}>
+                <VideoRidePageTestView {...args} />
+                {startGateProps && (
+                    <Dialog
+                        title={startGateProps.title}
+                        variant="info"
+                        presentationStyle="overFullScreen"
+                        supportedOrientations={['landscape']}
+                        buttons={
+                            <ButtonBar>
+                                <Button id="connect" label="Connect now" primary onClick={fn()} />
+                                <Button id="continue" label="Continue anyway" onClick={fn()} />
+                            </ButtonBar>
+                        }
+                    >
+                        <Text style={styles.gateBody}>{startGateProps.body}</Text>
+                    </Dialog>
+                )}
+            </View>
+        );
     },
 };

--- a/src/pages/RidePage/Video/VideoRidePage.stories.tsx
+++ b/src/pages/RidePage/Video/VideoRidePage.stories.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, useWindowDimensions, View, Text } from 'react-native';
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { fn } from 'storybook/test';
 import { VideoRidePageTestView } from './TestView';
-import { Dialog, ButtonBar, Button } from '../../../components';
+import { Dialog } from '../../../components';
 import { colors, textSizes } from '../../../theme';
 import { StartGateProps } from 'incyclist-services';
 import sydneyRoute from '../../../../__tests__/testdata/sydney.json';
@@ -25,28 +25,29 @@ const callbacks = {
     onCancelStart: fn(),
 };
 
-const styles = StyleSheet.create( {
-    container: {flex: 1, position: 'relative', width: '100%'},
+const styles = StyleSheet.create({
+    container: { flex: 1, position: 'relative', width: '100%' },
     gateBody: {
         color: colors.text,
         fontSize: textSizes.normalText,
         textAlign: 'center',
     },
-})
+});
 
 const meta: Meta<typeof VideoRidePageTestView> = {
     title: 'Pages/VideoRidePage',
     component: VideoRidePageTestView,
     decorators: [
-        (Story) => { 
-            const {width, height} = useWindowDimensions()
+        (Story) => {
+            const { width, height } = useWindowDimensions();
 
-            const fullScreen = {minHeight:height||500, minWidth:width||800}
+            const fullScreen = { minHeight: height || 500, minWidth: width || 800 };
             return (
-            <View style={[styles.container,fullScreen]}>
-                <Story />
-            </View>        
-        )},
+                <View style={[styles.container, fullScreen]}>
+                    <Story />
+                </View>
+            );
+        },
     ],
 };
 
@@ -62,6 +63,7 @@ export const ActiveRide: Story = {
             rideState: 'Active',
             rideType: 'Video',
             startOverlayProps: null,
+            startGateProps: null,
             menuProps: null,
             route: sydneyRoute as any,
             video: { src: '', hidden: false } as any,
@@ -72,11 +74,12 @@ export const ActiveRideTop: Story = {
     args: {
         ...callbacks,
         rideObserver: null,
-        dbLayout:'icon-top',
+        dbLayout: 'icon-top',
         displayProps: {
             rideState: 'Active',
             rideType: 'Video',
             startOverlayProps: null,
+            startGateProps: null,
             menuProps: null,
             route: sydneyRoute as any,
             video: { src: '', hidden: false } as any,
@@ -92,6 +95,7 @@ export const MenuOpenActive: Story = {
             rideState: 'Active',
             rideType: 'Video',
             startOverlayProps: null,
+            startGateProps: null,
             menuProps: { showResume: false },
             route: sydneyRoute as any,
             video: { src: '', hidden: false } as any,
@@ -107,6 +111,7 @@ export const MenuOpenPaused: Story = {
             rideState: 'Paused',
             rideType: 'Video',
             startOverlayProps: null,
+            startGateProps: null,
             menuProps: { showResume: true },
             route: sydneyRoute as any,
             video: { src: '', hidden: false } as any,
@@ -130,6 +135,7 @@ export const Starting: Story = {
                 readyToStart: false,
                 videoState: 'Buffering',
             } as any,
+            startGateProps: null,
             menuProps: null,
             route: teideRoute as any,
             video: { src: '', hidden: false } as any,
@@ -156,12 +162,10 @@ export const WithStartGate: Story = {
                         variant="info"
                         presentationStyle="overFullScreen"
                         supportedOrientations={['landscape']}
-                        buttons={
-                            <ButtonBar>
-                                <Button id="connect" label="Connect now" primary onClick={fn()} />
-                                <Button id="continue" label="Continue anyway" onClick={fn()} />
-                            </ButtonBar>
-                        }
+                        buttons={[
+                            { id: 'connect', label: 'Connect now', primary: true, onClick: fn() },
+                            { id: 'continue', label: 'Continue anyway', onClick: fn() },
+                        ]}
                     >
                         <Text style={styles.gateBody}>{startGateProps.body}</Text>
                     </Dialog>

--- a/src/pages/RidePage/Video/VideoRidePage.stories.tsx
+++ b/src/pages/RidePage/Video/VideoRidePage.stories.tsx
@@ -160,8 +160,6 @@ export const WithStartGate: Story = {
                     <Dialog
                         title={startGateProps.title}
                         variant="info"
-                        presentationStyle="overFullScreen"
-                        supportedOrientations={['landscape']}
                         buttons={[
                             { id: 'connect', label: 'Connect now', primary: true, onClick: fn() },
                             { id: 'continue', label: 'Continue anyway', onClick: fn() },


### PR DESCRIPTION
Closes #164

This PR integrates the ride start gate UI into `RidePage.tsx` and wires up the user actions to the service layer. 

Key changes:
- Added a `Dialog` (variant `info`) in `RidePage` that appears when `startGateProps` is present after `initPage()` resolves.
- Implemented `onRefreshSecrets` callback which calls `initSecrets({ timeout: 10000 })` and then notifies the service.
- Implemented `onContinueAnyway` callback which notifies the service directly.
- Ensured the ride page only renders after the gate is dismissed by holding the `rideType` in a ref until the user makes a choice.
- Added a new Storybook story `WithStartGate` to `VideoRidePage.stories.tsx` to visualize the gate overlaying the ride content.