### PR TITLE
feat(169): Add normaliseMqttUri utility function with unit tests

### DIFF
--- a/src/bindings/mq/index.ts
+++ b/src/bindings/mq/index.ts
@@ -2,61 +2,50 @@ import * as Mqtt from '@fdfedin/react-native-native-mqtt';
 import { EventEmitter } from 'events';
 import { getSecretBinding } from '../secret';
 import { EventLogger } from 'gd-eventlog';
-import { v4} from 'uuid'
+import { v4 } from 'uuid';
 import { Platform } from 'react-native';
 import { isProdVariant } from '../appInfo';
+import { normaliseMqttUri } from './utils';
 
 const CONNECT_RETRY_INTERVAL = 10000;   // 10 seconds
-const CONNECT_RETRY_CNT = 5             // number of attempts before taking a pause
+const CONNECT_RETRY_CNT = 5;            // number of attempts before taking a pause
 const CONNECT_TIMEOUT = 5000;           // 5 seconds
 
-export class MessageQueue extends EventEmitter  {
+export class MessageQueue extends EventEmitter {
     private client!: Mqtt.Client;
     private isConnected: boolean = false;
-    private connectPromise!: Promise<boolean>|null
-    private logger:EventLogger
-    private queue: Array< {topic:string,payload:string,ts:number }>=[]
-    private internalEmitter = new EventEmitter()
+    private connectPromise!: Promise<boolean> | null;
+    private logger: EventLogger;
+    private queue: Array<{ topic: string; payload: string; ts: number }> = [];
+    private internalEmitter = new EventEmitter();
     private subscriptions: Set<string> = new Set();
 
-    static _instance:MessageQueue|null;
+    static _instance: MessageQueue | null;
 
-    static getInstance() {        
-        MessageQueue._instance = MessageQueue._instance??new MessageQueue();
+    static getInstance() {
+        MessageQueue._instance = MessageQueue._instance ?? new MessageQueue();
         return MessageQueue._instance;
     }
 
-
     constructor() {
         super();
-        
-        this.logger = new EventLogger('mq')
-        this.logger.logEvent({message:'create message queue'})
-        //this.connect()
+        this.logger = new EventLogger('mq');
+        this.logger.logEvent({ message: 'create message queue' });
     }
 
-
-
-
     enabled(): boolean {
-        const uri = this.getSecret('MQ_BROKER');
-        if (!uri) return false;
-        if (Platform.OS === 'ios' && uri.startsWith('mqtt://')) return false;
-        return true;
+        return !!this.getSecret('MQ_BROKER');
     }
 
     subscribe(topic: string) {
         try {
-            if (!this.client)
-                return;
+            if (!this.client) return;
 
-            // QoS is usually required by this lib (0, 1, or 2)
-            this.client.subscribe([topic], [0]); 
-            this.emit('mq-subscribed',topic)
+            this.client.subscribe([topic], [0]);
+            this.emit('mq-subscribed', topic);
             this.subscriptions.add(topic);
-        }
-        catch(err) {
-            this.logError(err,'subscribe')
+        } catch (err) {
+            this.logError(err, 'subscribe');
         }
     }
 
@@ -64,75 +53,68 @@ export class MessageQueue extends EventEmitter  {
         this.subscriptions.delete(topic);
 
         try {
-            if (!this.client)
-                return;
+            if (!this.client) return;
 
             this.client.unsubscribe([topic]);
+        } catch (err) {
+            this.logError(err, 'subscribe');
         }
-        catch(err) {
-            this.logError(err,'subscribe')
-        }
-
     }
 
     publish(topic: string, payload: object) {
         try {
-            let message:string|undefined
+            let message: string | undefined;
             try {
                 message = JSON.stringify(payload);
                 if (!this.isConnected) {
-                    this.queue.push( {topic,payload:message,ts:Date.now()})
-                    return
+                    this.queue.push({ topic, payload: message, ts: Date.now() });
+                    return;
                 }
-
-                this.send(topic,message)
+                this.send(topic, message);
+            } catch {
+                if (message) {
+                    this.queue.push({ topic, payload: message, ts: Date.now() });
+                }
             }
-            catch {
-                if (message)
-                    this.queue.push( {topic,payload:message,ts:Date.now()})
-            
-            }
-        }
-        catch(err) {
-            this.logError(err,'publish')
+        } catch (err) {
+            this.logError(err, 'publish');
         }
     }
 
-    private send(topic:string, message:string) {
-            const data = Buffer.from( message,'utf-8')
-            this.client.publish(topic, data, 0, false);
-
+    private send(topic: string, message: string) {
+        const data = Buffer.from(message, 'utf-8');
+        this.client.publish(topic, data, 0, false);
     }
 
     async connect(): Promise<boolean> {
-        if (this.connectPromise!==null && this.connectPromise!==undefined)
-            return await this.connectPromise
-
-        if (this.isConnected) return true;        
-        this.logger.logEvent({message:'connecting to message queue ...'})
-
-        // temporary disabled MQTT on IOS
-        if (Platform.OS === 'ios'  && isProdVariant) {
-            return false
+        if (this.connectPromise !== null && this.connectPromise !== undefined) {
+            return await this.connectPromise;
         }
 
+        if (this.isConnected) return true;
 
-        const uri = this.getSecret('MQ_BROKER')
-        
+        this.logger.logEvent({ message: 'connecting to message queue ...' });
+
+        // Temporarily disabled MQTT on iOS in production
+        if (Platform.OS === 'ios' && isProdVariant) {
+            return false;
+        }
+
+        const uri = this.getSecret('MQ_BROKER');
 
         if (!this.enabled()) {
-            this.logger.logEvent({ message: 'mqtt disabled', reason: uri? 'non-TLS broker not supported on iOS' : 'no broker specified'  });
+            this.logger.logEvent({ message: 'mqtt disabled', reason: 'no broker specified' });
             return false;
-        }        
+        }
 
         const username = this.getSecret('MQ_USER');
         const password = this.getSecret('MQ_PASSWORD');
 
-        if (!uri || !username || !password)
-            return false
+        if (!uri || !username || !password) return false;
 
-        this.client = new Mqtt.Client(uri);
-
+        const { nativeUri, tls } = normaliseMqttUri(uri, Platform.OS as 'ios' | 'android');
+        this.logger.logEvent({ message: 'mqtt broker uri normalised', nativeUri, tls });
+        this.client = new Mqtt.Client(nativeUri);
 
         const onConnected = () => {
             this.isConnected = true;
@@ -142,141 +124,136 @@ export class MessageQueue extends EventEmitter  {
                 this.client.subscribe(topics, topics.map(() => 0));
             }
 
-            this.logger.logEvent( {message:'mqtt connected'})
-            this.internalEmitter.emit('connected')
-
+            this.logger.logEvent({ message: 'mqtt connected' });
+            this.internalEmitter.emit('connected');
 
             if (this.queue) {
-                let done = false
-                while(this.queue.length && !done) {
-                    const element = this.queue.pop()
-                    if (!element)
-                        done = true
-                    else {
-                        if (Date.now()-element.ts> 3600*1000)
-                            continue
-                        this.send( element.topic, element.payload)
+                let done = false;
+                while (this.queue.length && !done) {
+                    const element = this.queue.pop();
+                    if (!element) {
+                        done = true;
+                    } else {
+                        if (Date.now() - element.ts > 3600 * 1000) continue;
+                        this.send(element.topic, element.payload);
                     }
                 }
             }
-        }
+        };
 
-        const onDisconnected = (reason:string) => {
+        const onDisconnected = (reason: string) => {
             this.isConnected = false;
-            this.logger.logEvent( {message:'mqtt connection disconnected', reason})
-            this.internalEmitter.emit('disconnected')
-        }
+            this.logger.logEvent({ message: 'mqtt connection disconnected', reason });
+            this.internalEmitter.emit('disconnected');
+        };
 
-        const onEror = (err:string) => {
-            this.logger.logEvent( {message:'mqtt error', info:err})
-            
-        }
+        const onEror = (err: string) => {
+            this.logger.logEvent({ message: 'mqtt error', info: err });
+        };
 
-        this.client.on(Mqtt.Event.Connect,onConnected);
-        this.client.on(Mqtt.Event.Disconnect,onDisconnected );
-        this.client.on(Mqtt.Event.Message,this.onMessage.bind(this) );
+        this.client.on(Mqtt.Event.Connect, onConnected);
+        this.client.on(Mqtt.Event.Disconnect, onDisconnected);
+        this.client.on(Mqtt.Event.Message, this.onMessage.bind(this));
         this.client.on(Mqtt.Event.Error, onEror);
 
-        this.logger.logEvent( {message:'trying to connect to mqtt'})
+        this.logger.logEvent({ message: 'trying to connect to mqtt' });
 
-        this.connectPromise = new Promise<boolean>( done=> {
-            const clientId = 'mobile'+v4()
+        this.connectPromise = new Promise<boolean>((done) => {
+            const clientId = 'mobile' + v4();
             const options: Mqtt.ConnectionOptions = {
-                username, password,clientId,
-                timeout:CONNECT_TIMEOUT, keepAlive:60, autoReconnect:true,                
-            }
+                username,
+                password,
+                clientId,
+                timeout: CONNECT_TIMEOUT,
+                keepAlive: 60,
+                autoReconnect: true,
+            };
 
-            this.connectRetries( options, CONNECT_RETRY_CNT, CONNECT_RETRY_INTERVAL,onConnected )
-                .then(done)
-        })
+            this.connectRetries(options, CONNECT_RETRY_CNT, CONNECT_RETRY_INTERVAL, onConnected)
+                .then(done);
+        });
 
-        this.isConnected = await this.connectPromise
-        this.connectPromise = null
-        return this.isConnected
-
+        this.isConnected = await this.connectPromise;
+        this.connectPromise = null;
+        return this.isConnected;
     }
 
-    disconnect():void {
+    disconnect(): void {
         if (!this.isConnected) return;
 
         try {
             this.client?.disconnect();
-        } catch (err:any) {
-            this.logger.logEvent( {message:'disconnect failed', reason:err.message});
+        } catch (err: any) {
+            this.logger.logEvent({ message: 'disconnect failed', reason: err.message });
         }
         this.isConnected = false;
         this.connectPromise = null;
         this.logger.logEvent({ message: 'mqtt disconnected' });
     }
 
-    private async connectRetries(options:Mqtt.ConnectionOptions, max:number, delay:number,onConnected:()=>void):Promise<boolean> {
-        let success = false
+    private async connectRetries(
+        options: Mqtt.ConnectionOptions,
+        max: number,
+        delay: number,
+        onConnected: () => void,
+    ): Promise<boolean> {
+        let success = false;
         let failed = 0;
 
-
-        const sleep = (ms:number) => new Promise<void>(done=>setTimeout(done,ms))
+        const sleep = (ms: number) => new Promise<void>((done) => setTimeout(done, ms));
 
         while (!success) {
-            success = await this.doConnect(options)
+            success = await this.doConnect(options);
             if (success && !this.isConnected) {
-                onConnected()
+                onConnected();
             }
             if (!success) {
                 ++failed;
-                if (failed>=max) {
-                    return success
+                if (failed >= max) {
+                    return success;
                 }
-                await sleep(delay)
+                await sleep(delay);
             }
         }
 
-        return success
+        return success;
     }
 
+    private doConnect(options: Mqtt.ConnectionOptions): Promise<boolean> {
+        return new Promise<boolean>((resolve) => {
+            this.internalEmitter.once('connected', () => {
+                this.internalEmitter.removeAllListeners();
+                resolve(true);
+            });
+            this.internalEmitter.once('disconnected', () => {
+                this.internalEmitter.removeAllListeners();
+                resolve(false);
+            });
 
-    private doConnect(options:Mqtt.ConnectionOptions):Promise<boolean> {
-        return new Promise<boolean> (resolve=> {
-
-            this.internalEmitter.once('connected',()=>{
-                this.internalEmitter.removeAllListeners()
-                resolve(true)
-            })
-            this.internalEmitter.once('disconnected',()=>{
-                this.internalEmitter.removeAllListeners()
-                resolve(false)
-            })
-                
-            this.client.connect(options,
-                (error?:Error)=>{ 
-                    if (error!==null && error!==undefined) {
-                        this.internalEmitter.removeAllListeners()
-                        resolve(false)
-                    }
+            this.client.connect(options, (error?: Error) => {
+                if (error !== null && error !== undefined) {
+                    this.internalEmitter.removeAllListeners();
+                    resolve(false);
                 }
-            )
-        })
+            });
+        });
     }
 
-
-
-    private onMessage(topic: string, message: Uint8Array)  {
+    private onMessage(topic: string, message: Uint8Array) {
         try {
-            // Convert Uint8Array to string then parse JSON
-            this.emit('mq-message', topic,message);
-        } catch (err:any) {
-            this.logger.logEvent({message:'error', fn:'onMessage',error:err.message })
+            this.emit('mq-message', topic, message);
+        } catch (err: any) {
+            this.logger.logEvent({ message: 'error', fn: 'onMessage', error: err.message });
         }
     }
 
-    protected logError(err:any, fn:string) {
-        this.logger.logEvent({ message:'error', fn, error:err.message, stack:err.stack})
+    protected logError(err: any, fn: string) {
+        this.logger.logEvent({ message: 'error', fn, error: err.message, stack: err.stack });
     }
 
-    protected getSecret(key:string) {
-        return getSecretBinding().getSecret(key)
+    protected getSecret(key: string) {
+        return getSecretBinding().getSecret(key);
     }
-
 }
 
-
-export const getMessageQueueBinding = () =>MessageQueue.getInstance()
+export const getMessageQueueBinding = () => MessageQueue.getInstance();

--- a/src/bindings/mq/utils.test.ts
+++ b/src/bindings/mq/utils.test.ts
@@ -1,0 +1,108 @@
+import { normaliseMqttUri } from './utils';
+
+describe('normaliseMqttUri', () => {
+    // ─── mqtt:// ───────────────────────────────────────────────────────────────
+
+    describe('mqtt:// scheme', () => {
+        it('android — no port → tcp:// with default port 1883', () => {
+            const result = normaliseMqttUri('mqtt://broker.example.com', 'android');
+            expect(result.nativeUri).toBe('tcp://broker.example.com:1883');
+            expect(result.tls).toBe(false);
+        });
+
+        it('android — explicit port → tcp:// with preserved port', () => {
+            const result = normaliseMqttUri('mqtt://broker.example.com:1884', 'android');
+            expect(result.nativeUri).toBe('tcp://broker.example.com:1884');
+            expect(result.tls).toBe(false);
+        });
+
+        it('ios — no port → mqtt:// with default port 1883', () => {
+            const result = normaliseMqttUri('mqtt://broker.example.com', 'ios');
+            expect(result.nativeUri).toBe('mqtt://broker.example.com:1883');
+            expect(result.tls).toBe(false);
+        });
+
+        it('ios — explicit port → mqtt:// with preserved port', () => {
+            const result = normaliseMqttUri('mqtt://broker.example.com:1884', 'ios');
+            expect(result.nativeUri).toBe('mqtt://broker.example.com:1884');
+            expect(result.tls).toBe(false);
+        });
+    });
+
+    // ─── mqtts:// ──────────────────────────────────────────────────────────────
+
+    describe('mqtts:// scheme', () => {
+        it('android — no port → ssl:// with default port 8883', () => {
+            const result = normaliseMqttUri('mqtts://broker.example.com', 'android');
+            expect(result.nativeUri).toBe('ssl://broker.example.com:8883');
+            expect(result.tls).toBe(true);
+        });
+
+        it('android — explicit port → ssl:// with preserved port', () => {
+            const result = normaliseMqttUri('mqtts://broker.example.com:8884', 'android');
+            expect(result.nativeUri).toBe('ssl://broker.example.com:8884');
+            expect(result.tls).toBe(true);
+        });
+
+        it('ios — no port → mqtts:// with default port 8883', () => {
+            const result = normaliseMqttUri('mqtts://broker.example.com', 'ios');
+            expect(result.nativeUri).toBe('mqtts://broker.example.com:8883');
+            expect(result.tls).toBe(true);
+        });
+
+        it('ios — explicit port → mqtts:// with preserved port', () => {
+            const result = normaliseMqttUri('mqtts://broker.example.com:8884', 'ios');
+            expect(result.nativeUri).toBe('mqtts://broker.example.com:8884');
+            expect(result.tls).toBe(true);
+        });
+    });
+
+    // ─── tcp:// passthrough ────────────────────────────────────────────────────
+
+    describe('tcp:// passthrough', () => {
+        it('android — no port → tcp:// unchanged with default port', () => {
+            const result = normaliseMqttUri('tcp://broker.example.com', 'android');
+            expect(result.nativeUri).toBe('tcp://broker.example.com:1883');
+            expect(result.tls).toBe(false);
+        });
+
+        it('android — explicit port preserved', () => {
+            const result = normaliseMqttUri('tcp://broker.example.com:1884', 'android');
+            expect(result.nativeUri).toBe('tcp://broker.example.com:1884');
+            expect(result.tls).toBe(false);
+        });
+    });
+
+    // ─── ssl:// passthrough ────────────────────────────────────────────────────
+
+    describe('ssl:// passthrough', () => {
+        it('android — no port → ssl:// unchanged with default port', () => {
+            const result = normaliseMqttUri('ssl://broker.example.com', 'android');
+            expect(result.nativeUri).toBe('ssl://broker.example.com:8883');
+            expect(result.tls).toBe(true);
+        });
+
+        it('android — explicit port preserved', () => {
+            const result = normaliseMqttUri('ssl://broker.example.com:8884', 'android');
+            expect(result.nativeUri).toBe('ssl://broker.example.com:8884');
+            expect(result.tls).toBe(true);
+        });
+    });
+
+    // ─── malformed URI ─────────────────────────────────────────────────────────
+
+    describe('malformed URI', () => {
+        it('returns uri unchanged with tls false — does not throw', () => {
+            const bad = 'not a uri at all';
+            const result = normaliseMqttUri(bad, 'android');
+            expect(result.nativeUri).toBe(bad);
+            expect(result.tls).toBe(false);
+        });
+
+        it('empty string — does not throw', () => {
+            const result = normaliseMqttUri('', 'android');
+            expect(result.nativeUri).toBe('');
+            expect(result.tls).toBe(false);
+        });
+    });
+});

--- a/src/bindings/mq/utils.ts
+++ b/src/bindings/mq/utils.ts
@@ -1,0 +1,78 @@
+export interface NormalisedMqttUri {
+    nativeUri: string;
+    tls: boolean;
+}
+
+const DEFAULT_PORTS: Record<string, number> = {
+    'mqtt:': 1883,
+    'mqtts:': 8883,
+    'tcp:': 1883,
+    'ssl:': 8883,
+};
+
+/**
+ * Normalises a broker URI from the secrets store into the correct native URI
+ * and TLS flag for the given platform.
+ *
+ * | Input scheme | Platform | Output nativeUri    | tls   |
+ * |-------------|----------|---------------------|-------|
+ * | mqtt://     | android  | tcp://host:port     | false |
+ * | mqtt://     | ios      | mqtt://host:port    | false |
+ * | mqtts://    | android  | ssl://host:port     | true  |
+ * | mqtts://    | ios      | mqtts://host:port   | true  |
+ * | tcp://      | android  | unchanged           | false |
+ * | ssl://      | android  | unchanged           | true  |
+ *
+ * Malformed URIs are returned unchanged with tls: false.
+ */
+export function normaliseMqttUri(uri: string, platform: 'ios' | 'android'): NormalisedMqttUri {
+    let parsed: URL;
+    try {
+        parsed = new URL(uri);
+    } catch {
+        return { nativeUri: uri, tls: false };
+    }
+
+    const scheme = parsed.protocol; // includes trailing colon, e.g. 'mqtt:'
+    const host = parsed.hostname;
+    const explicitPort = parsed.port ? parseInt(parsed.port, 10) : null;
+
+    const resolvePort = (defaultScheme: string): number => {
+        return explicitPort !== null ? explicitPort : DEFAULT_PORTS[defaultScheme] ?? 1883;
+    };
+
+    switch (scheme) {
+        case 'mqtt:': {
+            const port = resolvePort('mqtt:');
+            const nativeUri =
+                platform === 'android'
+                    ? `tcp://${host}:${port}`
+                    : `mqtt://${host}:${port}`;
+            return { nativeUri, tls: false };
+        }
+
+        case 'mqtts:': {
+            const port = resolvePort('mqtts:');
+            const nativeUri =
+                platform === 'android'
+                    ? `ssl://${host}:${port}`
+                    : `mqtts://${host}:${port}`;
+            return { nativeUri, tls: true };
+        }
+
+        case 'tcp:': {
+            const port = resolvePort('tcp:');
+            const nativeUri = `tcp://${host}:${port}`;
+            return { nativeUri, tls: false };
+        }
+
+        case 'ssl:': {
+            const port = resolvePort('ssl:');
+            const nativeUri = `ssl://${host}:${port}`;
+            return { nativeUri, tls: true };
+        }
+
+        default:
+            return { nativeUri: uri, tls: false };
+    }
+}


### PR DESCRIPTION
Closes #169

## Summary

- Adds `normaliseMqttUri(uri, platform)` in `src/bindings/mq/utils.ts` that maps canonical `mqtt://` / `mqtts://` URIs to the scheme required by each native MQTT client (Paho on Android needs `tcp://` / `ssl://`; CocoaMQTT on iOS keeps `mqtt://` / `mqtts://`).
- Ports are preserved from the input URI; default ports (1883 / 8883) are applied only when none is supplied.
- Malformed URIs are returned unchanged with `tls: false` instead of throwing.
- `connect()` in `MessageQueue` now calls `normaliseMqttUri` and logs the normalised result before constructing the native client.
- `enabled()` simplified to a pure presence check — scheme normalisation is no longer the caller's responsibility.
- Full unit-test coverage in `utils.test.ts`: both platforms, both schemes, explicit port, default port, passthrough (`tcp://`, `ssl://`), and malformed input.