### PR TITLE
Add OperationsSelector component

### DIFF
--- a/src/components/OperationsSelector/OperationsSelector.stories.tsx
+++ b/src/components/OperationsSelector/OperationsSelector.stories.tsx
@@ -2,22 +2,20 @@ import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { fn } from 'storybook/test';
 import { OperationsSelector } from './OperationsSelector';
 
-const meta: Meta<typeof OperationsSelector> = {
+export const meta: Meta<typeof OperationsSelector> = {
     title: 'Components/OperationsSelector',
     component: OperationsSelector,
     args: {
         onChanged: fn(),
         operations: [
-            { operation: 'ActivityUpload' as any, enabled: true },
-            { operation: 'WorkoutUpload' as any, enabled: false },
-            { operation: 'WorkoutDownload' as any, enabled: true },
-            { operation: 'RouteDownload' as any, enabled: false },
-            { operation: 'ActivityDownload' as any, enabled: true },
+            { operation: 'ActivityUpload', enabled: true },
+            { operation: 'WorkoutUpload', enabled: false },
+            { operation: 'WorkoutDownload', enabled: true },
+            { operation: 'RouteDownload', enabled: false },
+            { operation: 'ActivityDownload', enabled: true },
         ],
     },
 };
-
-export default meta;
 
 type Story = StoryObj<typeof OperationsSelector>;
 

--- a/src/components/OperationsSelector/OperationsSelector.stories.tsx
+++ b/src/components/OperationsSelector/OperationsSelector.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { OperationsSelector } from './OperationsSelector';
+
+const meta: Meta<typeof OperationsSelector> = {
+    title: 'Components/OperationsSelector',
+    component: OperationsSelector,
+    args: {
+        onChanged: fn(),
+        operations: [
+            { operation: 'ActivityUpload' as any, enabled: true },
+            { operation: 'WorkoutUpload' as any, enabled: false },
+            { operation: 'WorkoutDownload' as any, enabled: true },
+            { operation: 'RouteDownload' as any, enabled: false },
+            { operation: 'ActivityDownload' as any, enabled: true },
+        ],
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof OperationsSelector>;
+
+export const Default: Story = {};
+
+export const Compact: Story = {
+    args: {
+        compact: true,
+    },
+};
+
+export const Empty: Story = {
+    args: {
+        operations: [],
+    },
+};

--- a/src/components/OperationsSelector/OperationsSelector.stories.tsx
+++ b/src/components/OperationsSelector/OperationsSelector.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { fn } from 'storybook/test';
 import { OperationsSelector } from './OperationsSelector';
 
-export const meta: Meta<typeof OperationsSelector> = {
+const meta: Meta<typeof OperationsSelector> = {
     title: 'Components/OperationsSelector',
     component: OperationsSelector,
     args: {
@@ -16,6 +16,8 @@ export const meta: Meta<typeof OperationsSelector> = {
         ],
     },
 };
+
+export default meta;
 
 type Story = StoryObj<typeof OperationsSelector>;
 

--- a/src/components/OperationsSelector/OperationsSelector.test.tsx
+++ b/src/components/OperationsSelector/OperationsSelector.test.tsx
@@ -3,21 +3,17 @@ import { render } from '@testing-library/react-native';
 import { OperationsSelector } from './OperationsSelector';
 import { OperationsSelectorProps } from './types';
 
-jest.mock('../../hooks/useLogging', () => ({
+jest.mock('../../hooks', () => ({
     useLogging: () => ({
         logEvent: jest.fn(),
         logError: jest.fn(),
     }),
 }));
 
-jest.mock('incyclist-services', () => ({
-    AppsOperation: {},
-}));
-
 const MOCK_PROPS: OperationsSelectorProps = {
     operations: [
-        { operation: 'ActivityUpload' as any, enabled: true },
-        { operation: 'RouteDownload' as any, enabled: false },
+        { operation: 'ActivityUpload', enabled: true },
+        { operation: 'RouteDownload', enabled: false },
     ],
     onChanged: jest.fn(),
 };

--- a/src/components/OperationsSelector/OperationsSelector.test.tsx
+++ b/src/components/OperationsSelector/OperationsSelector.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { OperationsSelector } from './OperationsSelector';
+import { OperationsSelectorProps } from './types';
+
+jest.mock('../../hooks/useLogging', () => ({
+    useLogging: () => ({
+        logEvent: jest.fn(),
+        logError: jest.fn(),
+    }),
+}));
+
+jest.mock('incyclist-services', () => ({
+    AppsOperation: {},
+}));
+
+const MOCK_PROPS: OperationsSelectorProps = {
+    operations: [
+        { operation: 'ActivityUpload' as any, enabled: true },
+        { operation: 'RouteDownload' as any, enabled: false },
+    ],
+    onChanged: jest.fn(),
+};
+
+describe('OperationsSelector', () => {
+    it('renders in normal layout', () => {
+        render(<OperationsSelector {...MOCK_PROPS} />);
+    });
+
+    it('renders in compact layout', () => {
+        render(<OperationsSelector {...MOCK_PROPS} compact />);
+    });
+
+    it('renders with operations={undefined} without crashing', () => {
+        render(<OperationsSelector operations={undefined} />);
+    });
+
+    it('renders with empty operations={[]} without crashing', () => {
+        render(<OperationsSelector operations={[]} />);
+    });
+});

--- a/src/components/OperationsSelector/OperationsSelector.tsx
+++ b/src/components/OperationsSelector/OperationsSelector.tsx
@@ -1,44 +1,15 @@
 import React, { useCallback } from 'react';
 import { View, StyleSheet } from 'react-native';
-import { AppsOperation } from 'incyclist-services';
 import { BinarySelect } from '../BinarySelect';
-import { OperationsSelectorProps } from './types';
-import { useLogging } from '../../hooks/useLogging';
+import { OperationsSelectorProps, AppsOperation } from './types';
+import { useLogging } from '../../hooks';
 
-const OPERATION_LABELS: Record<string, string> = {
+const OPERATION_LABELS: Record<AppsOperation, string> = {
     ActivityUpload: 'Upload activities',
     WorkoutUpload: 'Upload workouts',
     WorkoutDownload: 'Download workouts',
     RouteDownload: 'Download routes',
     ActivityDownload: 'Download activities',
-};
-
-/**
- * OperationRow sub-component to handle memoized callbacks for each row
- */
-const OperationRow = ({
-    operation,
-    enabled,
-    onToggle,
-}: {
-    operation: AppsOperation;
-    enabled: boolean;
-    onToggle: (op: AppsOperation, val: boolean) => void;
-}) => {
-    const handleValueChange = useCallback(
-        (val: boolean) => {
-            onToggle(operation, val);
-        },
-        [operation, onToggle]
-    );
-
-    const label = OPERATION_LABELS[operation as string] || (operation as string);
-
-    return (
-        <View style={styles.row}>
-            <BinarySelect label={label} value={enabled} onValueChange={handleValueChange} />
-        </View>
-    );
 };
 
 /**
@@ -66,13 +37,14 @@ export const OperationsSelector = ({ operations = [], onChanged, compact }: Oper
 
     return (
         <View style={containerStyle}>
-            {operations.map((config) => (
-                <OperationRow
-                    key={config.operation}
-                    operation={config.operation}
-                    enabled={config.enabled}
-                    onToggle={handleToggle}
-                />
+            {(operations ?? []).map((config) => (
+                <View key={config.operation} style={styles.row}>
+                    <BinarySelect
+                        label={OPERATION_LABELS[config.operation] ?? config.operation}
+                        value={config.enabled}
+                        onValueChange={(val) => handleToggle(config.operation, val)}
+                    />
+                </View>
             ))}
         </View>
     );

--- a/src/components/OperationsSelector/OperationsSelector.tsx
+++ b/src/components/OperationsSelector/OperationsSelector.tsx
@@ -1,0 +1,94 @@
+import React, { useCallback } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { AppsOperation } from 'incyclist-services';
+import { BinarySelect } from '../BinarySelect';
+import { OperationsSelectorProps } from './types';
+import { useLogging } from '../../hooks/useLogging';
+
+const OPERATION_LABELS: Record<string, string> = {
+    ActivityUpload: 'Upload activities',
+    WorkoutUpload: 'Upload workouts',
+    WorkoutDownload: 'Download workouts',
+    RouteDownload: 'Download routes',
+    ActivityDownload: 'Download activities',
+};
+
+/**
+ * OperationRow sub-component to handle memoized callbacks for each row
+ */
+const OperationRow = ({
+    operation,
+    enabled,
+    onToggle,
+}: {
+    operation: AppsOperation;
+    enabled: boolean;
+    onToggle: (op: AppsOperation, val: boolean) => void;
+}) => {
+    const handleValueChange = useCallback(
+        (val: boolean) => {
+            onToggle(operation, val);
+        },
+        [operation, onToggle]
+    );
+
+    const label = OPERATION_LABELS[operation as string] || (operation as string);
+
+    return (
+        <View style={styles.row}>
+            <BinarySelect label={label} value={enabled} onValueChange={handleValueChange} />
+        </View>
+    );
+};
+
+/**
+ * OperationsSelector component
+ *
+ * Renders a list of BinarySelect toggles for various app operations.
+ */
+export const OperationsSelector = ({ operations = [], onChanged, compact }: OperationsSelectorProps) => {
+    const { logEvent } = useLogging('OperationsSelector');
+
+    const handleToggle = useCallback(
+        (operation: AppsOperation, enabled: boolean) => {
+            logEvent({
+                message: 'operation toggled',
+                operation,
+                enabled,
+                eventSource: 'user',
+            });
+            onChanged?.(operation, enabled);
+        },
+        [logEvent, onChanged]
+    );
+
+    const containerStyle = compact ? styles.compactContainer : styles.container;
+
+    return (
+        <View style={containerStyle}>
+            {operations.map((config) => (
+                <OperationRow
+                    key={config.operation}
+                    operation={config.operation}
+                    enabled={config.enabled}
+                    onToggle={handleToggle}
+                />
+            ))}
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        paddingVertical: 8,
+        width: '100%',
+    },
+    compactContainer: {
+        paddingVertical: 4,
+        width: '100%',
+    },
+    row: {
+        marginVertical: 4,
+        width: '100%',
+    },
+});

--- a/src/components/OperationsSelector/index.ts
+++ b/src/components/OperationsSelector/index.ts
@@ -1,0 +1,2 @@
+export * from './OperationsSelector';
+export * from './types';

--- a/src/components/OperationsSelector/types.ts
+++ b/src/components/OperationsSelector/types.ts
@@ -1,4 +1,9 @@
-import { AppsOperation } from 'incyclist-services';
+export type AppsOperation =
+    | 'ActivityUpload'
+    | 'WorkoutUpload'
+    | 'WorkoutDownload'
+    | 'RouteDownload'
+    | 'ActivityDownload';
 
 export interface OperationConfig {
     operation: AppsOperation;

--- a/src/components/OperationsSelector/types.ts
+++ b/src/components/OperationsSelector/types.ts
@@ -1,0 +1,12 @@
+import { AppsOperation } from 'incyclist-services';
+
+export interface OperationConfig {
+    operation: AppsOperation;
+    enabled: boolean;
+}
+
+export interface OperationsSelectorProps {
+    operations?: OperationConfig[];
+    onChanged?: (operation: AppsOperation, enabled: boolean) => void;
+    compact?: boolean;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -29,3 +29,4 @@ export * from './ChipSelect';
 export * from './BinarySelect';
 export * from './ActivitySummaryDialog';
 export * from './ErrorBoundary'
+export * from './OperationsSelector'


### PR DESCRIPTION
Closes #177

This PR introduces the `OperationsSelector` component, a pure UI component used across settings screens to toggle various app operations (uploads/downloads for activities, workouts, and routes).

Key features:
- Maps `AppsOperation` types to human-readable labels.
- Uses `BinarySelect` for a consistent toggle UI.
- Integrated logging for operation toggles.
- Full Storybook coverage and render tests.