### PR TITLE
feat(181): Add KomootSettings smart component

### DIFF
--- a/src/components/KomootSettings/KomootSettings.stories.tsx
+++ b/src/components/KomootSettings/KomootSettings.stories.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { KomootSettings } from './KomootSettings';
+
+const meta: Meta<typeof KomootSettings> = {
+    title: 'Components/KomootSettings',
+    component: KomootSettings,
+    args: {
+        onBack: fn(),
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof KomootSettings>;
+
+export const Default: Story = {};

--- a/src/components/KomootSettings/KomootSettings.test.tsx
+++ b/src/components/KomootSettings/KomootSettings.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { KomootSettings } from './KomootSettings';
+
+jest.mock('incyclist-services', () => ({
+    useAppsService: () => ({
+        openAppSettings: jest.fn().mockReturnValue({ isConnected: false, operations: [] }),
+        disconnect: jest.fn(),
+        enableOperation: jest.fn().mockReturnValue([]),
+    }),
+}));
+
+jest.mock('../../assets/apps/komoot.svg', () => {
+    const React = require('react');
+    const { View } = require('react-native');
+    return (props: object) => React.createElement(View, props);
+});
+
+jest.mock('../AppSettingsView', () => ({
+    AppSettingsView: () => null,
+}));
+
+jest.mock('../KomootLoginDialog', () => ({
+    KomootLoginDialog: () => null,
+}));
+
+jest.mock('../Dialog', () => ({
+    Dialog: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+describe('KomootSettings', () => {
+    it('renders disconnected state without crashing', () => {
+        expect(() => render(<KomootSettings />)).not.toThrow();
+    });
+
+    it('renders connected state without crashing', () => {
+        const { useAppsService } = require('incyclist-services');
+        (useAppsService as jest.Mock).mockReturnValue({
+            openAppSettings: jest.fn().mockReturnValue({ isConnected: true, operations: [] }),
+            disconnect: jest.fn(),
+            enableOperation: jest.fn().mockReturnValue([]),
+        });
+        expect(() => render(<KomootSettings />)).not.toThrow();
+    });
+});

--- a/src/components/KomootSettings/KomootSettings.tsx
+++ b/src/components/KomootSettings/KomootSettings.tsx
@@ -1,0 +1,128 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+    View,
+} from 'react-native';
+import { AppsOperation, useAppsService } from 'incyclist-services';
+import KomootLogo from '../../assets/apps/komoot.svg';
+import { AppSettingsView } from '../AppSettingsView';
+import { KomootLoginDialog } from '../KomootLoginDialog';
+import { Dialog } from '../Dialog';
+import { useLogging } from '../../hooks/logging';
+import { useUnmountEffect } from '../../hooks/unmount';
+import { colors, textSizes } from '../../theme';
+import { KomootSettingsProps } from './types';
+
+export const KomootSettings = ({ onBack }: KomootSettingsProps) => {
+    const service = useAppsService();
+    const { logEvent } = useLogging('KomootSettings');
+
+    const refInitialized = useRef<boolean>(false);
+
+    const [isConnected, setIsConnected] = useState<boolean>(false);
+    const [isConnecting, setIsConnecting] = useState<boolean>(false);
+    const [showLoginDialog, setShowLoginDialog] = useState<boolean>(false);
+    const [operations, setOperations] = useState<AppsOperation[]>([]);
+
+    const loadSettings = useCallback(() => {
+        if (!service) return;
+        const result = service.openAppSettings('komoot');
+        if (result) {
+            setIsConnected(result.isConnected ?? false);
+            setOperations(result.operations ?? []);
+        }
+    }, [service]);
+
+    useEffect(() => {
+        if (!service || refInitialized.current) return;
+        refInitialized.current = true;
+        logEvent({ message: 'komoot settings opened' });
+        loadSettings();
+    }, [service, logEvent, loadSettings]);
+
+    useUnmountEffect(() => {
+        refInitialized.current = false;
+    });
+
+    const onConnect = useCallback(() => {
+        setIsConnecting(true);
+        setShowLoginDialog(true);
+    }, []);
+
+    const onLoginSuccess = useCallback(() => {
+        setShowLoginDialog(false);
+        setIsConnecting(false);
+        loadSettings();
+    }, [loadSettings]);
+
+    const onLoginCancel = useCallback(() => {
+        setShowLoginDialog(false);
+        setIsConnecting(false);
+    }, []);
+
+    const onDisconnect = useCallback(() => {
+        if (!service) return;
+        service.disconnect('komoot');
+        setIsConnected(false);
+        setIsConnecting(false);
+        setOperations([]);
+    }, [service]);
+
+    const onOperationsChanged = useCallback((operation: AppsOperation, enabled: boolean) => {
+        if (!service) return;
+        const updated = service.enableOperation('komoot', operation, enabled);
+        setOperations(updated ?? []);
+    }, [service]);
+
+    const connectButton = (
+        <TouchableOpacity style={styles.connectButton} onPress={onConnect}>
+            <KomootLogo width={32} height={32} />
+            <Text style={styles.connectText}>Connect with Komoot</Text>
+        </TouchableOpacity>
+    );
+
+    return (
+        <View style={styles.root}>
+            <AppSettingsView
+                isConnected={isConnected}
+                isConnecting={isConnecting}
+                operations={operations}
+                connectButton={connectButton}
+                onBack={onBack}
+                onDisconnect={onDisconnect}
+                onOperationsChanged={onOperationsChanged}
+            />
+
+            {showLoginDialog && (
+                <Dialog title="Komoot Login" variant="details">
+                    <KomootLoginDialog
+                        onSuccess={onLoginSuccess}
+                        onCancel={onLoginCancel}
+                    />
+                </Dialog>
+            )}
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    root: {
+        flex: 1,
+    },
+    connectButton: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        backgroundColor: colors.buttonPrimary,
+        paddingVertical: 10,
+        paddingHorizontal: 16,
+        borderRadius: 6,
+    },
+    connectText: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        marginLeft: 10,
+        fontWeight: '600',
+    },
+});

--- a/src/components/KomootSettings/index.ts
+++ b/src/components/KomootSettings/index.ts
@@ -1,0 +1,2 @@
+export * from './KomootSettings';
+export * from './types';

--- a/src/components/KomootSettings/types.ts
+++ b/src/components/KomootSettings/types.ts
@@ -1,0 +1,3 @@
+export interface KomootSettingsProps {
+    onBack?: () => void
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -29,3 +29,4 @@ export * from './ChipSelect';
 export * from './BinarySelect';
 export * from './ActivitySummaryDialog';
 export * from './ErrorBoundary'
+export * from './KomootSettings'


### PR DESCRIPTION
Closes #181

## Summary

Adds the `KomootSettings` smart component which manages the Komoot connection lifecycle and renders `AppSettingsView` with a Komoot-specific connect button.

### Behaviour
- On mount calls `service.openAppSettings('komoot')` for initial state (guarded by `refInitialized` to prevent double-init in StrictMode).
- **Connect**: sets `isConnecting=true` and conditionally renders `KomootLoginDialog`.
- **Login success**: closes dialog, refreshes state via `service.openAppSettings('komoot')`.
- **Login cancel**: closes dialog, resets `isConnecting=false`.
- **Disconnect**: calls `service.disconnect('komoot')` and resets state.
- **Operations changed**: calls `service.enableOperation('komoot', operation, enabled)` and updates local `operations` state.

### Files changed
- `src/components/KomootSettings/types.ts` — `KomootSettingsProps` interface
- `src/components/KomootSettings/KomootSettings.tsx` — smart component
- `src/components/KomootSettings/KomootSettings.test.tsx` — render-without-crashing tests
- `src/components/KomootSettings/KomootSettings.stories.tsx` — Storybook story
- `src/components/KomootSettings/index.ts` — barrel export
- `src/components/index.ts` — re-exports `KomootSettings`