### PR TITLE
Add AppsSettings list and navigation component

### DIFF
--- a/src/components/AppsSettings/AppsSettings.stories.tsx
+++ b/src/components/AppsSettings/AppsSettings.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { AppsSettingsView } from './AppsSettingsView';
+
+const meta: Meta<typeof AppsSettingsView> = {
+    title: 'Components/AppsSettings',
+    component: AppsSettingsView,
+    args: {
+        onSelect: fn(),
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof AppsSettingsView>;
+
+export const Default: Story = {
+    args: {
+        apps: [
+            { name: 'Strava', key: 'strava', iconUrl: 'https://example.com/strava.svg', isConnected: true },
+            { name: 'Komoot', key: 'komoot', iconUrl: 'https://example.com/komoot.svg', isConnected: false },
+            { name: 'Intervals.icu', key: 'intervals', iconUrl: 'https://example.com/intervals.png', isConnected: true },
+        ],
+    },
+};
+
+export const Empty: Story = {
+    args: {
+        apps: [],
+    },
+};
+
+export const Compact: Story = {
+    args: {
+        apps: [
+            { name: 'Strava', key: 'strava', iconUrl: 'https://example.com/strava.svg', isConnected: true },
+        ],
+        compact: true,
+    },
+};

--- a/src/components/AppsSettings/AppsSettings.test.tsx
+++ b/src/components/AppsSettings/AppsSettings.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { AppsSettings } from './AppsSettings';
+
+const mockOpenSettings = jest.fn();
+jest.mock('incyclist-services', () => ({
+    useAppsService: () => ({
+        openSettings: mockOpenSettings,
+    }),
+}));
+
+describe('AppsSettings', () => {
+    beforeEach(() => {
+        mockOpenSettings.mockReturnValue([
+            { name: 'Strava', key: 'strava', iconUrl: 'strava.svg', isConnected: false },
+        ]);
+    });
+
+    it('renders without crashing', () => {
+        expect(() => render(<AppsSettings />)).not.toThrow();
+    });
+
+    it('null service response does not crash', () => {
+        mockOpenSettings.mockReturnValue(null);
+        expect(() => render(<AppsSettings />)).not.toThrow();
+    });
+});

--- a/src/components/AppsSettings/AppsSettings.tsx
+++ b/src/components/AppsSettings/AppsSettings.tsx
@@ -1,0 +1,50 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { useAppsService } from 'incyclist-services';
+import { useLogging } from '../../hooks/logging';
+import { AppsSettingsView } from './AppsSettingsView';
+import { AppsSettingsProps, AppDisplayProps } from './types';
+import { OAuthAppSettings } from '../OAuthAppSettings';
+import { KomootSettings } from '../KomootSettings';
+
+export const AppsSettings = ({ onBack }: AppsSettingsProps) => {
+    const [selectedKey, setSelectedKey] = useState<string | null>(null);
+    const [apps, setApps] = useState<AppDisplayProps[]>([]);
+    const refInitialized = useRef(false);
+    
+    const service = useAppsService();
+    const { logEvent } = useLogging('AppsSettings');
+
+    useEffect(() => {
+        if (refInitialized.current) return;
+        
+        const list = service.openSettings();
+        if (list) {
+            setApps(list);
+        }
+        logEvent({ message: 'apps settings opened' });
+        refInitialized.current = true;
+    }, [service, logEvent]);
+
+    const handleSelect = useCallback((key: string) => {
+        setSelectedKey(key);
+        logEvent({ message: 'app selected', key, eventSource: 'user' });
+    }, [logEvent]);
+
+    const handleAppBack = useCallback(() => {
+        setSelectedKey(null);
+    }, []);
+
+    if (selectedKey === 'strava' || selectedKey === 'intervals') {
+        return <OAuthAppSettings appKey={selectedKey} onBack={handleAppBack} />;
+    }
+
+    if (selectedKey === 'komoot') {
+        return <KomootSettings onBack={handleAppBack} />;
+    }
+
+    if (selectedKey === 'velohero') {
+        return null;
+    }
+
+    return <AppsSettingsView apps={apps} onSelect={handleSelect} />;
+};

--- a/src/components/AppsSettings/AppsSettingsView.test.tsx
+++ b/src/components/AppsSettings/AppsSettingsView.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { AppsSettingsView } from './AppsSettingsView';
+import { AppDisplayProps } from './types';
+
+const MOCK_APPS: AppDisplayProps[] = [
+    { name: 'Strava', key: 'strava', iconUrl: 'strava.svg', isConnected: true },
+    { name: 'Komoot', key: 'komoot', iconUrl: 'komoot.svg', isConnected: false },
+];
+
+describe('AppsSettingsView', () => {
+    it('renders in normal layout with apps list', () => {
+        expect(() => render(<AppsSettingsView apps={MOCK_APPS} onSelect={jest.fn()} />)).not.toThrow();
+    });
+
+    it('renders in compact layout', () => {
+        expect(() => render(<AppsSettingsView apps={MOCK_APPS} onSelect={jest.fn()} compact={true} />)).not.toThrow();
+    });
+
+    it('renders with empty apps list without crashing', () => {
+        expect(() => render(<AppsSettingsView apps={[]} />)).not.toThrow();
+    });
+
+    it('renders with apps={undefined} without crashing', () => {
+        expect(() => render(<AppsSettingsView apps={undefined} />)).not.toThrow();
+    });
+});

--- a/src/components/AppsSettings/AppsSettingsView.tsx
+++ b/src/components/AppsSettings/AppsSettingsView.tsx
@@ -1,0 +1,89 @@
+import React, { useCallback } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView, Image } from 'react-native';
+import { SvgUri } from 'react-native-svg';
+import { colors } from '../../theme/colors';
+import { textSizes } from '../../theme/textSizes';
+import { Icon } from '../Icon';
+import { AppDisplayProps, AppsSettingsViewProps } from './types';
+
+const AppRow = ({ 
+    app, 
+    onSelect 
+}: { 
+    app: AppDisplayProps; 
+    onSelect?: (key: string) => void; 
+    compact?: boolean 
+}) => {
+    const handlePress = useCallback(() => onSelect?.(app.key), [app.key, onSelect]);
+    const isSvg = app.iconUrl.toLowerCase().endsWith('.svg');
+    const dotStyle = [
+        styles.dot, 
+        { backgroundColor: app.isConnected ? colors.success : colors.disabled }
+    ];
+
+    return (
+        <TouchableOpacity style={styles.row} onPress={handlePress}>
+            <View style={styles.iconContainer}>
+                {isSvg ? (
+                    <SvgUri uri={app.iconUrl} width="100%" height="100%" />
+                ) : (
+                    <Image source={{ uri: app.iconUrl }} style={styles.image} />
+                )}
+            </View>
+            <Text style={styles.name}>{app.name}</Text>
+            <View style={dotStyle} />
+            <Icon name="chevron-right" size={20} color={colors.text} />
+        </TouchableOpacity>
+    );
+};
+
+export const AppsSettingsView = ({ apps = [], onSelect, compact }: AppsSettingsViewProps) => {
+    return (
+        <ScrollView style={styles.container}>
+            {apps.map((app) => (
+                <AppRow 
+                    key={app.key} 
+                    app={app} 
+                    onSelect={onSelect} 
+                    compact={compact} 
+                />
+            ))}
+        </ScrollView>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+    },
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        padding: 16,
+        borderBottomWidth: 1,
+        borderBottomColor: colors.listSeparator,
+    },
+    iconContainer: {
+        width: 32,
+        height: 32,
+        marginRight: 16,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    image: {
+        width: '100%',
+        height: '100%',
+        resizeMode: 'contain',
+    },
+    name: {
+        flex: 1,
+        color: colors.text,
+        fontSize: textSizes.listEntry,
+    },
+    dot: {
+        width: 10,
+        height: 10,
+        borderRadius: 5,
+        marginHorizontal: 16,
+    },
+});

--- a/src/components/AppsSettings/index.ts
+++ b/src/components/AppsSettings/index.ts
@@ -1,0 +1,3 @@
+export * from './AppsSettings';
+export * from './AppsSettingsView';
+export * from './types';

--- a/src/components/AppsSettings/types.ts
+++ b/src/components/AppsSettings/types.ts
@@ -1,0 +1,16 @@
+export interface AppDisplayProps {
+    name: string;
+    key: string;
+    iconUrl: string;
+    isConnected: boolean;
+}
+
+export interface AppsSettingsViewProps {
+    apps?: AppDisplayProps[];
+    onSelect?: (key: string) => void;
+    compact?: boolean;
+}
+
+export interface AppsSettingsProps {
+    onBack?: () => void;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -28,4 +28,5 @@ export * from './SingleSelect';
 export * from './ChipSelect';
 export * from './BinarySelect';
 export * from './ActivitySummaryDialog';
-export * from './ErrorBoundary'
+export * from './ErrorBoundary';
+export * from './AppsSettings';


### PR DESCRIPTION
Closes #182

Implemented the `AppsSettings` component following the smart/view split pattern. This component serves as the entry point for third-party app integrations.

### Changes:
- Created `AppsSettingsView` (pure) to render a scrollable list of apps with connection status indicators.
- Created `AppsSettings` (smart) to manage service connection via `useAppsService` and handle navigation between the list and per-app settings screens.
- Integrated with `OAuthAppSettings` (Strava/Intervals) and `KomootSettings`.
- Added Storybook stories and unit tests for both components.
- Supported both SVG (via `SvgUri`) and standard image formats for app icons.