### PR TITLE
Add Storybook mocks for Linking and SVG assets used in app settings

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -76,6 +76,17 @@ const config: StorybookConfig = {
                         }
                         return null;
                     },
+                },
+                {
+                    name: 'mock-svg-apps-assets',
+                    enforce: 'pre' as const,
+                    resolveId(id: string) {
+                        // Redirect SVG imports from assets/apps to a stub component
+                        if (id.includes('assets/apps/') && id.endsWith('.svg')) {
+                            return path.resolve(dirname, './mocks/svg-stub.tsx');
+                        }
+                        return null;
+                    },
                 },                
                 // nodePolyfills() is intentionally omitted.
                 // It pulls in crypto-browserify -> browserify-sign, which vendors
@@ -87,6 +98,7 @@ const config: StorybookConfig = {
             resolve: {
                 alias: {
                     // ── React Native web shims ────────────────────────────────────
+                    'react-native': path.resolve(dirname, './mocks/react-native.ts'),
                     'react-native-safe-area-context': path.resolve(dirname, './mocks/react-native-safe-area-context.ts'),
                     'react-native-share': path.resolve(dirname, './mocks/react-native-share.ts'),
                     'react-native-ble-manager':      'react-native-web/dist/exports/View',

--- a/.storybook/mocks/react-native.ts
+++ b/.storybook/mocks/react-native.ts
@@ -1,0 +1,18 @@
+import * as RNW from 'react-native-web';
+
+/**
+ * Storybook mock for react-native.
+ * Extends react-native-web with specific stubs needed for the app.
+ */
+
+export const Linking = {
+    openURL: () => Promise.resolve(),
+    canOpenURL: () => Promise.resolve(true),
+    addEventListener: () => ({ remove: () => {} }),
+    removeEventListener: () => {},
+    getInitialURL: () => Promise.resolve(null),
+};
+
+// Re-export all standard components and APIs from react-native-web.
+// In ESM, the local 'Linking' export above takes precedence over the one in RNW.
+export * from 'react-native-web';

--- a/.storybook/mocks/svg-stub.tsx
+++ b/.storybook/mocks/svg-stub.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { View } from 'react-native-web';
+
+/**
+ * A generic stub for SVG assets imported as React components.
+ * Renders a plain View to avoid crashes in the Storybook web renderer.
+ */
+const SvgStub = (props: any) => {
+    return React.createElement(View, props);
+};
+
+export default SvgStub;


### PR DESCRIPTION
Closes #183

This PR adds Storybook mocks to prevent the web renderer from crashing when components use native APIs or assets introduced in the app integration feature.

### Changes:
- Created `.storybook/mocks/react-native.ts` to stub the `Linking` API and re-export `react-native-web` components.
- Created `.storybook/mocks/svg-stub.tsx` to provide a lightweight `View` replacement for SVG assets imported as components.
- Updated `.storybook/main.ts` to:
    - Alias `react-native` to our custom mock.
    - Add a Vite plugin to resolve SVG imports from `src/assets/apps/` to the stub component.

### Verified Stories:
- PasswordEdit
- OperationsSelector
- AppSettingsView
- OAuthAppSettings
- KomootLoginDialog
- KomootSettings
- AppsSettings