### PR TITLE
Add PasswordEdit component

### DIFF
--- a/src/components/PasswordEdit/PasswordEdit.stories.tsx
+++ b/src/components/PasswordEdit/PasswordEdit.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { fn } from 'storybook/test';
 import { PasswordEdit } from './PasswordEdit';
 
-const meta: Meta<typeof PasswordEdit> = {
+export const meta: Meta<typeof PasswordEdit> = {
     title: 'Components/PasswordEdit',
     component: PasswordEdit,
     args: {
@@ -12,7 +12,6 @@ const meta: Meta<typeof PasswordEdit> = {
     },
 };
 
-export default meta;
 type Story = StoryObj<typeof PasswordEdit>;
 
 export const Default: Story = {};

--- a/src/components/PasswordEdit/PasswordEdit.stories.tsx
+++ b/src/components/PasswordEdit/PasswordEdit.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { PasswordEdit } from './PasswordEdit';
+
+const meta: Meta<typeof PasswordEdit> = {
+    title: 'Components/PasswordEdit',
+    component: PasswordEdit,
+    args: {
+        label: 'Password',
+        value: 'secret123',
+        onChangeText: fn(),
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof PasswordEdit>;
+
+export const Default: Story = {};
+
+export const Compact: Story = {
+    args: {
+        compact: true,
+    },
+};
+
+export const WithError: Story = {
+    args: {
+        hasError: true,
+    },
+};
+
+export const Disabled: Story = {
+    args: {
+        disabled: true,
+    },
+};

--- a/src/components/PasswordEdit/PasswordEdit.stories.tsx
+++ b/src/components/PasswordEdit/PasswordEdit.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { fn } from 'storybook/test';
 import { PasswordEdit } from './PasswordEdit';
 
-export const meta: Meta<typeof PasswordEdit> = {
+const meta: Meta<typeof PasswordEdit> = {
     title: 'Components/PasswordEdit',
     component: PasswordEdit,
     args: {
@@ -11,6 +11,8 @@ export const meta: Meta<typeof PasswordEdit> = {
         onChangeText: fn(),
     },
 };
+
+export default meta;
 
 type Story = StoryObj<typeof PasswordEdit>;
 

--- a/src/components/PasswordEdit/PasswordEdit.test.tsx
+++ b/src/components/PasswordEdit/PasswordEdit.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { PasswordEdit } from './PasswordEdit';
+import { PasswordEditProps } from './types';
+
+const MOCK_PROPS: PasswordEditProps = {
+    label: 'Password',
+    value: 'secret',
+    onChangeText: jest.fn(),
+};
+
+describe('PasswordEdit', () => {
+    it('renders in normal layout', () => {
+        render(<PasswordEdit {...MOCK_PROPS} />);
+    });
+
+    it('renders in compact layout', () => {
+        render(<PasswordEdit {...MOCK_PROPS} compact={true} />);
+    });
+
+    it('renders with all optional props undefined', () => {
+        render(<PasswordEdit />);
+    });
+
+    it('renders with disabled={true}', () => {
+        render(<PasswordEdit {...MOCK_PROPS} disabled={true} />);
+    });
+
+    it('renders with hasError={true}', () => {
+        render(<PasswordEdit {...MOCK_PROPS} hasError={true} />);
+    });
+});

--- a/src/components/PasswordEdit/PasswordEdit.tsx
+++ b/src/components/PasswordEdit/PasswordEdit.tsx
@@ -7,6 +7,7 @@ import { PasswordEditProps } from './types';
 
 export const PasswordEdit = ({
     label,
+    labelWidth = 100,
     value = '',
     onChangeText,
     placeholder,
@@ -33,14 +34,15 @@ export const PasswordEdit = ({
         disabled && styles.disabledBorder,
         hasError && styles.errorBorder,
     ];
-    const labelStyle = [styles.label, disabled && styles.disabledText];
+    const labelWidthStyle = { width: labelWidth };
+    const labelStyle = [styles.label, labelWidthStyle, disabled && styles.disabledText];
     const inputStyle = [styles.input, disabled && styles.disabledText];
     const toggleTextStyle = [styles.toggleText, disabled && styles.disabledText];
 
     return (
         <View style={containerStyle}>
             <View style={styles.row}>
-                <Text style={labelStyle}>{label || ''}</Text>
+                <Text style={labelStyle}>{label}</Text>
                 <View style={inputWrapperStyle}>
                     <TextInput
                         style={inputStyle}
@@ -83,7 +85,6 @@ const styles = StyleSheet.create({
     label: {
         color: colors.text,
         fontSize: textSizes.normalText,
-        width: 100,
         marginRight: 8,
     },
     inputWrapper: {

--- a/src/components/PasswordEdit/PasswordEdit.tsx
+++ b/src/components/PasswordEdit/PasswordEdit.tsx
@@ -1,0 +1,138 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
+import { colors } from '../../theme/colors';
+import { textSizes } from '../../theme/textSizes';
+import { useLogging } from '../../hooks';
+import { PasswordEditProps } from './types';
+
+export const PasswordEdit = ({
+    label,
+    value = '',
+    onChangeText,
+    placeholder,
+    disabled = false,
+    hasError = false,
+    compact = false,
+}: PasswordEditProps) => {
+    const [isVisible, setIsVisible] = useState(false);
+    const [internalValue, setInternalValue] = useState(value);
+    const refLastValue = useRef(value);
+    const { logEvent } = useLogging('PasswordEdit');
+
+    useEffect(() => {
+        setInternalValue(value);
+        refLastValue.current = value;
+    }, [value]);
+
+    const handleToggle = useCallback(() => {
+        const nextVisible = !isVisible;
+        setIsVisible(nextVisible);
+        logEvent({
+            message: 'password visibility toggled',
+            visible: nextVisible,
+            eventSource: 'user',
+        });
+    }, [isVisible, logEvent]);
+
+    const handleCommit = useCallback(() => {
+        if (internalValue === refLastValue.current) {
+            return;
+        }
+        refLastValue.current = internalValue;
+        onChangeText?.(internalValue);
+    }, [internalValue, onChangeText]);
+
+    const containerStyle = [styles.container, compact && styles.containerCompact];
+    const inputWrapperStyle = [
+        styles.inputWrapper,
+        disabled && styles.disabledBorder,
+        hasError && styles.errorBorder,
+    ];
+    const labelStyle = [styles.label, disabled && styles.disabledText];
+    const inputStyle = [styles.input, disabled && styles.disabledText];
+    const toggleTextStyle = [styles.toggleText, disabled && styles.disabledText];
+
+    return (
+        <View style={containerStyle}>
+            <View style={styles.row}>
+                <Text style={labelStyle}>{label || ''}</Text>
+                <View style={inputWrapperStyle}>
+                    <TextInput
+                        style={inputStyle}
+                        value={internalValue}
+                        onChangeText={setInternalValue}
+                        onBlur={handleCommit}
+                        onEndEditing={handleCommit}
+                        placeholder={placeholder}
+                        placeholderTextColor={colors.disabled}
+                        secureTextEntry={!isVisible}
+                        autoCorrect={false}
+                        spellCheck={false}
+                        editable={!disabled}
+                    />
+                    <TouchableOpacity
+                        onPress={handleToggle}
+                        style={styles.toggle}
+                        disabled={disabled}
+                    >
+                        <Text style={toggleTextStyle}>
+                            {isVisible ? '○' : '●'}
+                        </Text>
+                    </TouchableOpacity>
+                </View>
+            </View>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        marginVertical: 8,
+        width: '100%',
+    },
+    containerCompact: {
+        marginVertical: 4,
+    },
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
+    },
+    label: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        width: 100,
+        marginRight: 8,
+    },
+    inputWrapper: {
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
+        borderBottomWidth: 1,
+        borderBottomColor: colors.listSeparator,
+    },
+    input: {
+        flex: 1,
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        paddingVertical: 4,
+        paddingHorizontal: 4,
+    },
+    toggle: {
+        paddingHorizontal: 8,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    toggleText: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+    },
+    errorBorder: {
+        borderBottomColor: colors.error,
+    },
+    disabledBorder: {
+        borderBottomColor: 'transparent',
+    },
+    disabledText: {
+        color: colors.disabled,
+    },
+});

--- a/src/components/PasswordEdit/PasswordEdit.tsx
+++ b/src/components/PasswordEdit/PasswordEdit.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import { View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
 import { colors } from '../../theme/colors';
 import { textSizes } from '../../theme/textSizes';
@@ -15,14 +15,7 @@ export const PasswordEdit = ({
     compact = false,
 }: PasswordEditProps) => {
     const [isVisible, setIsVisible] = useState(false);
-    const [internalValue, setInternalValue] = useState(value);
-    const refLastValue = useRef(value);
     const { logEvent } = useLogging('PasswordEdit');
-
-    useEffect(() => {
-        setInternalValue(value);
-        refLastValue.current = value;
-    }, [value]);
 
     const handleToggle = useCallback(() => {
         const nextVisible = !isVisible;
@@ -33,14 +26,6 @@ export const PasswordEdit = ({
             eventSource: 'user',
         });
     }, [isVisible, logEvent]);
-
-    const handleCommit = useCallback(() => {
-        if (internalValue === refLastValue.current) {
-            return;
-        }
-        refLastValue.current = internalValue;
-        onChangeText?.(internalValue);
-    }, [internalValue, onChangeText]);
 
     const containerStyle = [styles.container, compact && styles.containerCompact];
     const inputWrapperStyle = [
@@ -59,10 +44,8 @@ export const PasswordEdit = ({
                 <View style={inputWrapperStyle}>
                     <TextInput
                         style={inputStyle}
-                        value={internalValue}
-                        onChangeText={setInternalValue}
-                        onBlur={handleCommit}
-                        onEndEditing={handleCommit}
+                        value={value ?? ''}
+                        onChangeText={onChangeText}
                         placeholder={placeholder}
                         placeholderTextColor={colors.disabled}
                         secureTextEntry={!isVisible}

--- a/src/components/PasswordEdit/PasswordEdit.tsx
+++ b/src/components/PasswordEdit/PasswordEdit.tsx
@@ -7,7 +7,6 @@ import { PasswordEditProps } from './types';
 
 export const PasswordEdit = ({
     label,
-    labelWidth = 100,
     value = '',
     onChangeText,
     placeholder,
@@ -34,15 +33,16 @@ export const PasswordEdit = ({
         disabled && styles.disabledBorder,
         hasError && styles.errorBorder,
     ];
-    const labelWidthStyle = { width: labelWidth };
-    const labelStyle = [styles.label, labelWidthStyle, disabled && styles.disabledText];
+    const labelStyle = [styles.label, disabled && styles.disabledText];
     const inputStyle = [styles.input, disabled && styles.disabledText];
     const toggleTextStyle = [styles.toggleText, disabled && styles.disabledText];
 
     return (
         <View style={containerStyle}>
             <View style={styles.row}>
-                <Text style={labelStyle}>{label}</Text>
+                {label !== undefined && (
+                    <Text style={labelStyle}>{label}</Text>
+                )}
                 <View style={inputWrapperStyle}>
                     <TextInput
                         style={inputStyle}
@@ -86,6 +86,7 @@ const styles = StyleSheet.create({
         color: colors.text,
         fontSize: textSizes.normalText,
         marginRight: 8,
+        width: 100,
     },
     inputWrapper: {
         flex: 1,

--- a/src/components/PasswordEdit/index.ts
+++ b/src/components/PasswordEdit/index.ts
@@ -1,0 +1,2 @@
+export * from './PasswordEdit';
+export * from './types';

--- a/src/components/PasswordEdit/types.ts
+++ b/src/components/PasswordEdit/types.ts
@@ -1,5 +1,6 @@
 export interface PasswordEditProps {
-    label?: string;
+    label: string;
+    labelWidth?: number;
     value?: string;
     onChangeText?: (value: string) => void;
     placeholder?: string;

--- a/src/components/PasswordEdit/types.ts
+++ b/src/components/PasswordEdit/types.ts
@@ -1,0 +1,9 @@
+export interface PasswordEditProps {
+    label?: string;
+    value?: string;
+    onChangeText?: (value: string) => void;
+    placeholder?: string;
+    disabled?: boolean;
+    hasError?: boolean;
+    compact?: boolean;
+}

--- a/src/components/PasswordEdit/types.ts
+++ b/src/components/PasswordEdit/types.ts
@@ -1,6 +1,5 @@
 export interface PasswordEditProps {
-    label: string;
-    labelWidth?: number;
+    label?: string;
     value?: string;
     onChangeText?: (value: string) => void;
     placeholder?: string;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -23,6 +23,7 @@ export * from './InfoText'
 export * from './RideMenu'
 export * from './Dialog';
 export * from './EditText';
+export * from './PasswordEdit';
 export * from './EditNumber';
 export * from './SingleSelect';
 export * from './ChipSelect';


### PR DESCRIPTION
Closes #176

This PR implements the `PasswordEdit` component, providing a secure text input field with a visibility toggle. 

### Changes:
- Created `PasswordEdit` component mirroring `EditText` structure.
- Added `secureTextEntry` support with a show/hide toggle (using `●` and `○` symbols).
- Implemented visibility toggle logging.
- Disabled autocorrect and spellcheck for the password field.
- Added Storybook stories and render tests.