### PR TITLE
feat(179): Add OAuthAppSettings smart component (Strava + Intervals.icu)

### DIFF
--- a/src/components/OAuthAppSettings/OAuthAppSettings.stories.tsx
+++ b/src/components/OAuthAppSettings/OAuthAppSettings.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { OAuthAppSettings } from './OAuthAppSettings';
+
+const meta: Meta<typeof OAuthAppSettings> = {
+    title: 'Components/OAuthAppSettings',
+    component: OAuthAppSettings,
+    args: {
+        onBack: fn(),
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof OAuthAppSettings>;
+
+export const StravaDisconnected: Story = {
+    args: {
+        appKey: 'strava',
+    },
+};
+
+export const IntervalsDisconnected: Story = {
+    args: {
+        appKey: 'intervals',
+    },
+};

--- a/src/components/OAuthAppSettings/OAuthAppSettings.stories.tsx
+++ b/src/components/OAuthAppSettings/OAuthAppSettings.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { fn } from 'storybook/test';
 import { OAuthAppSettings } from './OAuthAppSettings';

--- a/src/components/OAuthAppSettings/OAuthAppSettings.test.tsx
+++ b/src/components/OAuthAppSettings/OAuthAppSettings.test.tsx
@@ -4,12 +4,12 @@ import { Linking } from 'react-native';
 import { OAuthAppSettings } from './OAuthAppSettings';
 
 jest.mock('incyclist-services', () => ({
-    useAppsService: () => ({
+    useAppsService: jest.fn(() => ({
         openAppSettings: jest.fn().mockReturnValue({ isConnected: false, operations: [] }),
         connect: jest.fn().mockResolvedValue(true),
         disconnect: jest.fn(),
         enableOperation: jest.fn().mockReturnValue([]),
-    }),
+    })),
 }));
 
 jest.mock('../AppSettingsView', () => ({

--- a/src/components/OAuthAppSettings/OAuthAppSettings.test.tsx
+++ b/src/components/OAuthAppSettings/OAuthAppSettings.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { OAuthAppSettings } from './OAuthAppSettings';
+
+jest.mock('incyclist-services', () => ({
+    useAppsService: () => ({
+        openAppSettings: jest.fn().mockReturnValue({ isConnected: false, operations: [] }),
+        connect: jest.fn().mockResolvedValue(true),
+        disconnect: jest.fn(),
+        enableOperation: jest.fn().mockReturnValue([]),
+    }),
+}));
+
+jest.mock('react-native', () => ({
+    ...jest.requireActual('react-native'),
+    Linking: {
+        openURL: jest.fn(),
+        addEventListener: jest.fn().mockReturnValue({ remove: jest.fn() }),
+    },
+}));
+
+jest.mock('../AppSettingsView', () => ({
+    AppSettingsView: () => null,
+}));
+
+jest.mock('../../assets/apps/strava-connect.svg', () => ({
+    default: () => null,
+}));
+
+describe('OAuthAppSettings', () => {
+    it('renders disconnected state for appKey="strava" without crashing', () => {
+        expect(() => render(<OAuthAppSettings appKey='strava' />)).not.toThrow();
+    });
+
+    it('renders disconnected state for appKey="intervals" without crashing', () => {
+        expect(() => render(<OAuthAppSettings appKey='intervals' />)).not.toThrow();
+    });
+
+    it('renders connected state with operations without crashing', () => {
+        const { useAppsService } = require('incyclist-services');
+        (useAppsService as jest.Mock).mockReturnValue({
+            openAppSettings: jest.fn().mockReturnValue({
+                isConnected: true,
+                operations: [
+                    { operation: 'sync', enabled: true },
+                    { operation: 'upload', enabled: false },
+                ],
+            }),
+            connect: jest.fn().mockResolvedValue(true),
+            disconnect: jest.fn(),
+            enableOperation: jest.fn().mockReturnValue([]),
+        });
+
+        expect(() => render(<OAuthAppSettings appKey='strava' />)).not.toThrow();
+    });
+
+    it('renders without crashing when service returns null', () => {
+        const { useAppsService } = require('incyclist-services');
+        (useAppsService as jest.Mock).mockReturnValue({
+            openAppSettings: jest.fn().mockReturnValue(null),
+            connect: jest.fn().mockResolvedValue(true),
+            disconnect: jest.fn(),
+            enableOperation: jest.fn().mockReturnValue([]),
+        });
+
+        expect(() => render(<OAuthAppSettings appKey='intervals' />)).not.toThrow();
+    });
+});

--- a/src/components/OAuthAppSettings/OAuthAppSettings.test.tsx
+++ b/src/components/OAuthAppSettings/OAuthAppSettings.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
+import { Linking } from 'react-native';
 import { OAuthAppSettings } from './OAuthAppSettings';
 
 jest.mock('incyclist-services', () => ({
@@ -11,21 +12,25 @@ jest.mock('incyclist-services', () => ({
     }),
 }));
 
-jest.mock('react-native', () => ({
-    ...jest.requireActual('react-native'),
-    Linking: {
-        openURL: jest.fn(),
-        addEventListener: jest.fn().mockReturnValue({ remove: jest.fn() }),
-    },
-}));
-
 jest.mock('../AppSettingsView', () => ({
     AppSettingsView: () => null,
 }));
 
-jest.mock('../../assets/apps/strava-connect.svg', () => ({
+jest.mock('../../assets/apps/btn_strava_connectwith_orange.svg', () => ({
     default: () => null,
 }));
+
+const mockOpenURL = jest.fn().mockResolvedValue(undefined);
+const mockAddEventListener = jest.fn().mockReturnValue({ remove: jest.fn() });
+
+beforeEach(() => {
+    jest.spyOn(Linking, 'openURL').mockImplementation(mockOpenURL);
+    jest.spyOn(Linking, 'addEventListener').mockImplementation(mockAddEventListener);
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
+});
 
 describe('OAuthAppSettings', () => {
     it('renders disconnected state for appKey="strava" without crashing', () => {

--- a/src/components/OAuthAppSettings/OAuthAppSettings.tsx
+++ b/src/components/OAuthAppSettings/OAuthAppSettings.tsx
@@ -1,11 +1,14 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
-import { Linking, TouchableOpacity } from 'react-native';
+import { Linking, StyleSheet, TouchableOpacity } from 'react-native';
 import { useAppsService } from 'incyclist-services';
 import type { AppsOperation } from 'incyclist-services';
 import { AppSettingsView } from '../AppSettingsView';
 import type { OperationConfig } from '../OperationsSelector/types';
-import { useLogging } from '../../hooks/logging';
-import { useUnmountEffect } from '../../hooks/unmount';
+import { useLogging } from '../../hooks';
+import { useUnmountEffect } from '../../hooks';
+import { colors } from '../../theme/colors';
+import { textSizes } from '../../theme/textSizes';
+import StravaConnectSvg from '../../assets/apps/btn_strava_connectwith_orange.svg';
 import type { OAuthAppSettingsProps } from './types';
 
 const OAUTH_BASE = 'https://auth.incyclist.com';
@@ -115,8 +118,7 @@ const OAuthAppSettings = ({ appKey, onBack }: OAuthAppSettingsProps) => {
     const stravaConnectButton = useCallback(
         () => (
             <TouchableOpacity onPress={onConnect}>
-                {/* eslint-disable-next-line @typescript-eslint/no-var-requires */}
-                {React.createElement(require('../../assets/apps/strava-connect.svg').default)}
+                <StravaConnectSvg />
             </TouchableOpacity>
         ),
         [onConnect],
@@ -125,7 +127,6 @@ const OAuthAppSettings = ({ appKey, onBack }: OAuthAppSettingsProps) => {
     const intervalsConnectButton = useCallback(
         () => (
             <TouchableOpacity onPress={onConnect} style={styles.intervalsButton}>
-                {/* text rendered by AppSettingsView via Button — pass a simple wrapper */}
                 {React.createElement(
                     require('react-native').Text,
                     { style: styles.intervalsButtonText },
@@ -153,10 +154,6 @@ const OAuthAppSettings = ({ appKey, onBack }: OAuthAppSettingsProps) => {
         />
     );
 };
-
-import { StyleSheet } from 'react-native';
-import { colors } from '../../theme/colors';
-import { textSizes } from '../../theme/textSizes';
 
 const styles = StyleSheet.create({
     intervalsButton: {

--- a/src/components/OAuthAppSettings/OAuthAppSettings.tsx
+++ b/src/components/OAuthAppSettings/OAuthAppSettings.tsx
@@ -1,0 +1,176 @@
+import React, { useState, useRef, useCallback, useEffect } from 'react';
+import { Linking, TouchableOpacity } from 'react-native';
+import { useAppsService } from 'incyclist-services';
+import type { AppsOperation } from 'incyclist-services';
+import { AppSettingsView } from '../AppSettingsView';
+import type { OperationConfig } from '../OperationsSelector/types';
+import { useLogging } from '../../hooks/logging';
+import { useUnmountEffect } from '../../hooks/unmount';
+import type { OAuthAppSettingsProps } from './types';
+
+const OAUTH_BASE = 'https://auth.incyclist.com';
+const REDIRECT_URI = 'incyclist://oauth/callback';
+
+const OAuthAppSettings = ({ appKey, onBack }: OAuthAppSettingsProps) => {
+    const service = useAppsService();
+    const { logEvent, logError } = useLogging('OAuthAppSettings');
+
+    const [isConnected, setIsConnected] = useState<boolean>(false);
+    const [isConnecting, setIsConnecting] = useState<boolean>(false);
+    const [operations, setOperations] = useState<OperationConfig[]>([]);
+
+    const refInitialized = useRef<boolean>(false);
+    const refLinkingSubscription = useRef<{ remove: () => void } | null>(null);
+
+    const removeLinkingListener = useCallback(() => {
+        if (refLinkingSubscription.current) {
+            refLinkingSubscription.current.remove();
+            refLinkingSubscription.current = null;
+        }
+    }, []);
+
+    useEffect(() => {
+        if (refInitialized.current || !service) return;
+        refInitialized.current = true;
+
+        const state = service.openAppSettings(appKey);
+        if (state) {
+            setIsConnected(state.isConnected ?? false);
+            setOperations((state.operations as OperationConfig[]) ?? []);
+        }
+    }, [service, appKey]);
+
+    useUnmountEffect(removeLinkingListener);
+
+    const onConnect = useCallback(() => {
+        if (!service) return;
+
+        logEvent({ message: 'oauth connect start', appKey, eventSource: 'user' });
+        setIsConnecting(true);
+
+        const url = `${OAUTH_BASE}/${appKey}?sid=${encodeURIComponent(REDIRECT_URI)}`;
+
+        Linking.openURL(url).catch((err: Error) => {
+            logError(err, 'onConnect');
+            setIsConnecting(false);
+        });
+
+        const subscription = Linking.addEventListener('url', async ({ url: callbackUrl }: { url: string }) => {
+            if (!callbackUrl.startsWith('incyclist://oauth/callback')) return;
+
+            removeLinkingListener();
+
+            try {
+                const parsed = new URL(callbackUrl.replace('incyclist://', 'https://incyclist'));
+                const error = parsed.searchParams.get('error');
+
+                if (error) {
+                    logEvent({ message: 'oauth connect failed', appKey, error });
+                    setIsConnecting(false);
+                    return;
+                }
+
+                const credentials = {
+                    accesstoken: parsed.searchParams.get('accesstoken'),
+                    refreshtoken: parsed.searchParams.get('refreshtoken'),
+                    id: parsed.searchParams.get('id'),
+                };
+
+                await service.connect(appKey, credentials);
+
+                logEvent({ message: 'oauth connect success', appKey });
+
+                const refreshed = service.openAppSettings(appKey);
+                if (refreshed) {
+                    setIsConnected(refreshed.isConnected ?? false);
+                    setOperations((refreshed.operations as OperationConfig[]) ?? []);
+                }
+            } catch (err) {
+                logError(err as Error, 'onConnectCallback');
+                logEvent({ message: 'oauth connect failed', appKey, error: (err as Error).message });
+            } finally {
+                setIsConnecting(false);
+            }
+        });
+
+        refLinkingSubscription.current = subscription;
+    }, [service, appKey, logEvent, logError, removeLinkingListener]);
+
+    const onDisconnect = useCallback(() => {
+        if (!service) return;
+        service.disconnect(appKey);
+        setIsConnected(false);
+        setOperations([]);
+    }, [service, appKey]);
+
+    const onOperationsChanged = useCallback(
+        (operation: AppsOperation, enabled: boolean) => {
+            if (!service) return;
+            const updated = service.enableOperation(appKey, operation, enabled);
+            setOperations((updated as OperationConfig[]) ?? []);
+        },
+        [service, appKey],
+    );
+
+    const stravaConnectButton = useCallback(
+        () => (
+            <TouchableOpacity onPress={onConnect}>
+                {/* eslint-disable-next-line @typescript-eslint/no-var-requires */}
+                {React.createElement(require('../../assets/apps/strava-connect.svg').default)}
+            </TouchableOpacity>
+        ),
+        [onConnect],
+    );
+
+    const intervalsConnectButton = useCallback(
+        () => (
+            <TouchableOpacity onPress={onConnect} style={styles.intervalsButton}>
+                {/* text rendered by AppSettingsView via Button — pass a simple wrapper */}
+                {React.createElement(
+                    require('react-native').Text,
+                    { style: styles.intervalsButtonText },
+                    'Connect with Intervals.icu',
+                )}
+            </TouchableOpacity>
+        ),
+        [onConnect],
+    );
+
+    const connectButton = appKey === 'strava' ? stravaConnectButton : intervalsConnectButton;
+
+    const title = appKey === 'strava' ? 'Strava' : 'Intervals.icu';
+
+    return (
+        <AppSettingsView
+            title={title}
+            isConnected={isConnected}
+            isConnecting={isConnecting}
+            connectButton={connectButton}
+            operations={operations}
+            onDisconnect={onDisconnect}
+            onOperationsChanged={onOperationsChanged}
+            onBack={onBack}
+        />
+    );
+};
+
+import { StyleSheet } from 'react-native';
+import { colors } from '../../theme/colors';
+import { textSizes } from '../../theme/textSizes';
+
+const styles = StyleSheet.create({
+    intervalsButton: {
+        backgroundColor: colors.buttonPrimary,
+        paddingHorizontal: 16,
+        paddingVertical: 10,
+        borderRadius: 4,
+        alignItems: 'center',
+    },
+    intervalsButtonText: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        fontWeight: '600',
+    },
+});
+
+export { OAuthAppSettings };

--- a/src/components/OAuthAppSettings/index.ts
+++ b/src/components/OAuthAppSettings/index.ts
@@ -1,0 +1,2 @@
+export { OAuthAppSettings } from './OAuthAppSettings';
+export type { OAuthAppSettingsProps, OAuthAppKey } from './types';

--- a/src/components/OAuthAppSettings/types.ts
+++ b/src/components/OAuthAppSettings/types.ts
@@ -1,0 +1,10 @@
+import type { AppsOperation } from 'incyclist-services';
+
+export type OAuthAppKey = 'strava' | 'intervals';
+
+export interface OAuthAppSettingsProps {
+    appKey: OAuthAppKey;
+    onBack?: () => void;
+}
+
+export type { AppsOperation };


### PR DESCRIPTION
Closes #179

Adds the `OAuthAppSettings` smart component parameterised by `appKey` (`'strava'` | `'intervals'`). A single component covers both providers against the shared `https://auth.incyclist.com` OAuth gateway.

### What's included
- `OAuthAppSettings.tsx` — smart component with `Linking`-based OAuth flow, `refInitialized` guard, cleanup on unmount via `useUnmountEffect`, and structured logging
- `types.ts` — `OAuthAppKey` + `OAuthAppSettingsProps` interfaces
- `OAuthAppSettings.test.tsx` — four render-without-crashing tests covering disconnected (strava), disconnected (intervals), connected-with-operations, and null-service-response states
- `OAuthAppSettings.stories.tsx` — Storybook story targeting the smart component directly with mocked args
- `index.ts` — barrel export

### Flow summary
1. Mount: `service.openAppSettings(appKey)` seeds `isConnected` + `operations`
2. Connect: opens `https://auth.incyclist.com/{appKey}?sid=incyclist%3A%2F%2Foauth%2Fcallback` via `Linking.openURL`, registers one-time `Linking` listener
3. Callback: parses query params, calls `service.connect`, refreshes state; error param skips connect
4. Disconnect: calls `service.disconnect`, resets state
5. Operations toggle: calls `service.enableOperation`, updates local state
6. Unmount: removes any pending `Linking` listener