### PR TITLE
feat(181): Add KomootSettings smart component

### DIFF
--- a/src/components/KomootSettings/KomootSettings.stories.tsx
+++ b/src/components/KomootSettings/KomootSettings.stories.tsx
@@ -1,18 +1,44 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { fn } from 'storybook/test';
-import { KomootSettings } from './KomootSettings';
+import { KomootSettingsView } from './KomootSettingsView';
 
-const meta: Meta<typeof KomootSettings> = {
+const meta: Meta<typeof KomootSettingsView> = {
     title: 'Components/KomootSettings',
-    component: KomootSettings,
+    component: KomootSettingsView,
     args: {
+        isConnected: false,
+        isConnecting: false,
+        operations: [],
+        showLoginDialog: false,
+        onConnect: fn(),
+        onDisconnect: fn(),
+        onOperationsChanged: fn(),
+        onLoginSuccess: fn(),
+        onLoginCancel: fn(),
         onBack: fn(),
     },
 };
 
 export default meta;
 
-type Story = StoryObj<typeof KomootSettings>;
+type Story = StoryObj<typeof KomootSettingsView>;
 
 export const Default: Story = {};
+
+export const Connected: Story = {
+    args: {
+        isConnected: true,
+        operations: [
+            { operation: 'import', label: 'Import Routes', enabled: true },
+            { operation: 'export', label: 'Export Activities', enabled: false },
+        ],
+    },
+};
+
+export const Connecting: Story = {
+    args: {
+        isConnecting: true,
+        showLoginDialog: true,
+    },
+};

--- a/src/components/KomootSettings/KomootSettings.stories.tsx
+++ b/src/components/KomootSettings/KomootSettings.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { fn } from 'storybook/test';
 import { KomootSettingsView } from './KomootSettingsView';
@@ -30,8 +29,8 @@ export const Connected: Story = {
     args: {
         isConnected: true,
         operations: [
-            { operation: 'import', label: 'Import Routes', enabled: true },
-            { operation: 'export', label: 'Export Activities', enabled: false },
+            { operation: 'ActivityUpload', enabled: true },
+            { operation: 'RouteDownload', enabled: false },
         ],
     },
 };

--- a/src/components/KomootSettings/KomootSettings.stories.tsx
+++ b/src/components/KomootSettings/KomootSettings.stories.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { KomootSettings } from './KomootSettings';
+
+const meta: Meta<typeof KomootSettings> = {
+    title: 'Components/KomootSettings',
+    component: KomootSettings,
+    args: {
+        onBack: fn(),
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof KomootSettings>;
+
+export const Default: Story = {};

--- a/src/components/KomootSettings/KomootSettings.test.tsx
+++ b/src/components/KomootSettings/KomootSettings.test.tsx
@@ -2,12 +2,16 @@ import React from 'react';
 import { render } from '@testing-library/react-native';
 import { KomootSettings } from './KomootSettings';
 
+const mockService = {
+    openAppSettings: jest.fn().mockReturnValue({ isConnected: false, operations: [] }),
+    closeAppSettings: jest.fn(),
+    disconnect: jest.fn(),
+    enableOperation: jest.fn().mockReturnValue([]),
+};
+
 jest.mock('incyclist-services', () => ({
-    useAppsService: () => ({
-        openAppSettings: jest.fn().mockReturnValue({ isConnected: false, operations: [] }),
-        disconnect: jest.fn(),
-        enableOperation: jest.fn().mockReturnValue([]),
-    }),
+    useAppsService: () => mockService,
+    AppsOperation: {},
 }));
 
 jest.mock('../../assets/apps/komoot.svg', () => ({
@@ -23,17 +27,17 @@ jest.mock('../KomootLoginDialog', () => ({
 }));
 
 describe('KomootSettings', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockService.openAppSettings.mockReturnValue({ isConnected: false, operations: [] });
+    });
+
     it('renders disconnected state without crashing', () => {
         expect(() => render(<KomootSettings />)).not.toThrow();
     });
 
     it('renders connected state without crashing', () => {
-        const { useAppsService } = require('incyclist-services');
-        (useAppsService as jest.Mock).mockReturnValue({
-            openAppSettings: jest.fn().mockReturnValue({ isConnected: true, operations: [] }),
-            disconnect: jest.fn(),
-            enableOperation: jest.fn().mockReturnValue([]),
-        });
+        mockService.openAppSettings.mockReturnValue({ isConnected: true, operations: [] });
         expect(() => render(<KomootSettings />)).not.toThrow();
     });
 });

--- a/src/components/KomootSettings/KomootSettings.test.tsx
+++ b/src/components/KomootSettings/KomootSettings.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { KomootSettings } from './KomootSettings';
+
+jest.mock('incyclist-services', () => ({
+    useAppsService: () => ({
+        openAppSettings: jest.fn().mockReturnValue({ isConnected: false, operations: [] }),
+        disconnect: jest.fn(),
+        enableOperation: jest.fn().mockReturnValue([]),
+    }),
+}));
+
+jest.mock('../../assets/apps/komoot.svg', () => ({
+    default: () => null,
+}));
+
+jest.mock('../AppSettingsView', () => ({
+    AppSettingsView: () => null,
+}));
+
+jest.mock('../KomootLoginDialog', () => ({
+    KomootLoginDialog: () => null,
+}));
+
+describe('KomootSettings', () => {
+    it('renders disconnected state without crashing', () => {
+        expect(() => render(<KomootSettings />)).not.toThrow();
+    });
+
+    it('renders connected state without crashing', () => {
+        const { useAppsService } = require('incyclist-services');
+        (useAppsService as jest.Mock).mockReturnValue({
+            openAppSettings: jest.fn().mockReturnValue({ isConnected: true, operations: [] }),
+            disconnect: jest.fn(),
+            enableOperation: jest.fn().mockReturnValue([]),
+        });
+        expect(() => render(<KomootSettings />)).not.toThrow();
+    });
+});

--- a/src/components/KomootSettings/KomootSettings.tsx
+++ b/src/components/KomootSettings/KomootSettings.tsx
@@ -4,7 +4,6 @@ import { KomootSettingsProps } from './types';
 import { KomootSettingsView } from './KomootSettingsView';
 import { OperationConfig } from '../OperationsSelector/types';
 import { useLogging } from '../../hooks/logging';
-import { useUnmountEffect } from '../../hooks/unmount';
 
 export const KomootSettings = ({ onBack }: KomootSettingsProps) => {
     const service = useAppsService();
@@ -28,10 +27,6 @@ export const KomootSettings = ({ onBack }: KomootSettingsProps) => {
         }
         logEvent({ message: 'komoot settings opened' });
     }, [service, logEvent]);
-
-    useUnmountEffect(() => {
-        service.closeAppSettings('komoot');
-    });
 
     const handleConnect = useCallback(() => {
         setIsConnecting(true);

--- a/src/components/KomootSettings/KomootSettings.tsx
+++ b/src/components/KomootSettings/KomootSettings.tsx
@@ -1,20 +1,10 @@
-import React, { useCallback, useRef, useState } from 'react';
-import {
-    TouchableOpacity,
-    Text,
-    View,
-    StyleSheet,
-} from 'react-native';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { AppsOperation, useAppsService } from 'incyclist-services';
 import { KomootSettingsProps } from './types';
-import { AppSettingsView } from '../AppSettingsView';
-import { KomootLoginDialog } from '../KomootLoginDialog';
+import { KomootSettingsView } from './KomootSettingsView';
 import { OperationConfig } from '../OperationsSelector/types';
 import { useLogging } from '../../hooks/logging';
 import { useUnmountEffect } from '../../hooks/unmount';
-import { colors, textSizes } from '../../theme';
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const KomootLogo = require('../../assets/apps/komoot.svg').default;
 
 export const KomootSettings = ({ onBack }: KomootSettingsProps) => {
     const service = useAppsService();
@@ -27,18 +17,20 @@ export const KomootSettings = ({ onBack }: KomootSettingsProps) => {
     const [showLoginDialog, setShowLoginDialog] = useState<boolean>(false);
     const [operations, setOperations] = useState<OperationConfig[]>([]);
 
-    if (!refInitialized.current) {
+    useEffect(() => {
+        if (refInitialized.current) return;
         refInitialized.current = true;
+
         const initial = service.openAppSettings('komoot');
         if (initial) {
             setIsConnected(initial.isConnected ?? false);
             setOperations((initial.operations as OperationConfig[]) ?? []);
         }
         logEvent({ message: 'komoot settings opened' });
-    }
+    }, [service, logEvent]);
 
     useUnmountEffect(() => {
-        // no explicit closePage call needed; cleanup if required
+        service.closeAppSettings('komoot');
     });
 
     const handleConnect = useCallback(() => {
@@ -76,55 +68,18 @@ export const KomootSettings = ({ onBack }: KomootSettingsProps) => {
         [service],
     );
 
-    const renderConnectButton = useCallback((): React.ReactElement => {
-        return (
-            <TouchableOpacity style={styles.connectButton} onPress={handleConnect}>
-                <View style={styles.connectButtonContent}>
-                    <KomootLogo width={24} height={24} />
-                    <Text style={styles.connectButtonText}>Connect with Komoot</Text>
-                </View>
-            </TouchableOpacity>
-        );
-    }, [handleConnect]);
-
     return (
-        <>
-            <AppSettingsView
-                title="Komoot"
-                isConnected={isConnected}
-                isConnecting={isConnecting}
-                connectButton={renderConnectButton}
-                operations={operations}
-                onDisconnect={handleDisconnect}
-                onOperationsChanged={handleOperationsChanged}
-                onBack={onBack}
-            />
-            {showLoginDialog && (
-                <KomootLoginDialog
-                    onSuccess={handleLoginSuccess}
-                    onCancel={handleLoginCancel}
-                />
-            )}
-        </>
+        <KomootSettingsView
+            isConnected={isConnected}
+            isConnecting={isConnecting}
+            operations={operations}
+            showLoginDialog={showLoginDialog}
+            onConnect={handleConnect}
+            onDisconnect={handleDisconnect}
+            onOperationsChanged={handleOperationsChanged}
+            onLoginSuccess={handleLoginSuccess}
+            onLoginCancel={handleLoginCancel}
+            onBack={onBack}
+        />
     );
 };
-
-const styles = StyleSheet.create({
-    connectButton: {
-        paddingVertical: 10,
-        paddingHorizontal: 16,
-        borderRadius: 6,
-        backgroundColor: colors.buttonPrimary,
-        alignSelf: 'flex-start',
-    },
-    connectButtonContent: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: 8,
-    },
-    connectButtonText: {
-        color: colors.text,
-        fontSize: textSizes.normalText,
-        fontWeight: '600',
-    },
-});

--- a/src/components/KomootSettings/KomootSettings.tsx
+++ b/src/components/KomootSettings/KomootSettings.tsx
@@ -1,0 +1,130 @@
+import React, { useCallback, useRef, useState } from 'react';
+import {
+    TouchableOpacity,
+    Text,
+    View,
+    StyleSheet,
+} from 'react-native';
+import { AppsOperation, useAppsService } from 'incyclist-services';
+import { KomootSettingsProps } from './types';
+import { AppSettingsView } from '../AppSettingsView';
+import { KomootLoginDialog } from '../KomootLoginDialog';
+import { OperationConfig } from '../OperationsSelector/types';
+import { useLogging } from '../../hooks/logging';
+import { useUnmountEffect } from '../../hooks/unmount';
+import { colors, textSizes } from '../../theme';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const KomootLogo = require('../../assets/apps/komoot.svg').default;
+
+export const KomootSettings = ({ onBack }: KomootSettingsProps) => {
+    const service = useAppsService();
+    const { logEvent } = useLogging('KomootSettings');
+
+    const refInitialized = useRef<boolean>(false);
+
+    const [isConnected, setIsConnected] = useState<boolean>(false);
+    const [isConnecting, setIsConnecting] = useState<boolean>(false);
+    const [showLoginDialog, setShowLoginDialog] = useState<boolean>(false);
+    const [operations, setOperations] = useState<OperationConfig[]>([]);
+
+    if (!refInitialized.current) {
+        refInitialized.current = true;
+        const initial = service.openAppSettings('komoot');
+        if (initial) {
+            setIsConnected(initial.isConnected ?? false);
+            setOperations((initial.operations as OperationConfig[]) ?? []);
+        }
+        logEvent({ message: 'komoot settings opened' });
+    }
+
+    useUnmountEffect(() => {
+        // no explicit closePage call needed; cleanup if required
+    });
+
+    const handleConnect = useCallback(() => {
+        setIsConnecting(true);
+        setShowLoginDialog(true);
+    }, []);
+
+    const handleLoginSuccess = useCallback(() => {
+        setShowLoginDialog(false);
+        const updated = service.openAppSettings('komoot');
+        if (updated) {
+            setIsConnected(updated.isConnected ?? false);
+            setOperations((updated.operations as OperationConfig[]) ?? []);
+        }
+        setIsConnecting(false);
+    }, [service]);
+
+    const handleLoginCancel = useCallback(() => {
+        setShowLoginDialog(false);
+        setIsConnecting(false);
+    }, []);
+
+    const handleDisconnect = useCallback(() => {
+        service.disconnect('komoot');
+        setIsConnected(false);
+        setOperations([]);
+        setIsConnecting(false);
+    }, [service]);
+
+    const handleOperationsChanged = useCallback(
+        (operation: AppsOperation, enabled: boolean) => {
+            const updated = service.enableOperation('komoot', operation, enabled);
+            setOperations((updated as OperationConfig[]) ?? []);
+        },
+        [service],
+    );
+
+    const renderConnectButton = useCallback((): React.ReactElement => {
+        return (
+            <TouchableOpacity style={styles.connectButton} onPress={handleConnect}>
+                <View style={styles.connectButtonContent}>
+                    <KomootLogo width={24} height={24} />
+                    <Text style={styles.connectButtonText}>Connect with Komoot</Text>
+                </View>
+            </TouchableOpacity>
+        );
+    }, [handleConnect]);
+
+    return (
+        <>
+            <AppSettingsView
+                title="Komoot"
+                isConnected={isConnected}
+                isConnecting={isConnecting}
+                connectButton={renderConnectButton}
+                operations={operations}
+                onDisconnect={handleDisconnect}
+                onOperationsChanged={handleOperationsChanged}
+                onBack={onBack}
+            />
+            {showLoginDialog && (
+                <KomootLoginDialog
+                    onSuccess={handleLoginSuccess}
+                    onCancel={handleLoginCancel}
+                />
+            )}
+        </>
+    );
+};
+
+const styles = StyleSheet.create({
+    connectButton: {
+        paddingVertical: 10,
+        paddingHorizontal: 16,
+        borderRadius: 6,
+        backgroundColor: colors.buttonPrimary,
+        alignSelf: 'flex-start',
+    },
+    connectButtonContent: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+    },
+    connectButtonText: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        fontWeight: '600',
+    },
+});

--- a/src/components/KomootSettings/KomootSettingsView.tsx
+++ b/src/components/KomootSettings/KomootSettingsView.tsx
@@ -11,8 +11,7 @@ import { AppSettingsView } from '../AppSettingsView';
 import { KomootLoginDialog } from '../KomootLoginDialog';
 import { OperationConfig } from '../OperationsSelector/types';
 import { colors, textSizes } from '../../theme';
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const KomootLogo = require('../../assets/apps/komoot.svg').default;
+import KomootLogo from '../../assets/apps/komoot.svg';
 
 export const KomootSettingsView = ({
     isConnected,

--- a/src/components/KomootSettings/KomootSettingsView.tsx
+++ b/src/components/KomootSettings/KomootSettingsView.tsx
@@ -1,0 +1,88 @@
+import React, { useCallback } from 'react';
+import {
+    TouchableOpacity,
+    Text,
+    View,
+    StyleSheet,
+} from 'react-native';
+import { AppsOperation } from 'incyclist-services';
+import { KomootSettingsViewProps } from './types';
+import { AppSettingsView } from '../AppSettingsView';
+import { KomootLoginDialog } from '../KomootLoginDialog';
+import { OperationConfig } from '../OperationsSelector/types';
+import { colors, textSizes } from '../../theme';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const KomootLogo = require('../../assets/apps/komoot.svg').default;
+
+export const KomootSettingsView = ({
+    isConnected,
+    isConnecting,
+    operations,
+    showLoginDialog,
+    onConnect,
+    onDisconnect,
+    onOperationsChanged,
+    onLoginSuccess,
+    onLoginCancel,
+    onBack,
+}: KomootSettingsViewProps) => {
+
+    const renderConnectButton = useCallback((): React.ReactElement => {
+        return (
+            <TouchableOpacity style={styles.connectButton} onPress={onConnect}>
+                <View style={styles.connectButtonContent}>
+                    <KomootLogo width={24} height={24} />
+                    <Text style={styles.connectButtonText}>Connect with Komoot</Text>
+                </View>
+            </TouchableOpacity>
+        );
+    }, [onConnect]);
+
+    const handleOperationsChanged = useCallback(
+        (operation: AppsOperation, enabled: boolean) => {
+            onOperationsChanged?.(operation, enabled);
+        },
+        [onOperationsChanged],
+    );
+
+    return (
+        <>
+            <AppSettingsView
+                title="Komoot"
+                isConnected={isConnected}
+                isConnecting={isConnecting}
+                connectButton={renderConnectButton}
+                operations={operations as OperationConfig[]}
+                onDisconnect={onDisconnect}
+                onOperationsChanged={handleOperationsChanged}
+                onBack={onBack}
+            />
+            {showLoginDialog && (
+                <KomootLoginDialog
+                    onSuccess={onLoginSuccess}
+                    onCancel={onLoginCancel}
+                />
+            )}
+        </>
+    );
+};
+
+const styles = StyleSheet.create({
+    connectButton: {
+        paddingVertical: 10,
+        paddingHorizontal: 16,
+        borderRadius: 6,
+        backgroundColor: colors.buttonPrimary,
+        alignSelf: 'flex-start',
+    },
+    connectButtonContent: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+    },
+    connectButtonText: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        fontWeight: '600',
+    },
+});

--- a/src/components/KomootSettings/index.ts
+++ b/src/components/KomootSettings/index.ts
@@ -1,0 +1,2 @@
+export * from './KomootSettings';
+export * from './types';

--- a/src/components/KomootSettings/index.ts
+++ b/src/components/KomootSettings/index.ts
@@ -1,2 +1,3 @@
 export * from './KomootSettings';
+export * from './KomootSettingsView';
 export * from './types';

--- a/src/components/KomootSettings/types.ts
+++ b/src/components/KomootSettings/types.ts
@@ -1,0 +1,3 @@
+export interface KomootSettingsProps {
+    onBack?: () => void
+}

--- a/src/components/KomootSettings/types.ts
+++ b/src/components/KomootSettings/types.ts
@@ -1,3 +1,19 @@
+import { OperationConfig } from '../OperationsSelector/types';
+import { AppsOperation } from 'incyclist-services';
+
 export interface KomootSettingsProps {
+    onBack?: () => void
+}
+
+export interface KomootSettingsViewProps {
+    isConnected: boolean
+    isConnecting: boolean
+    operations: OperationConfig[]
+    showLoginDialog: boolean
+    onConnect?: () => void
+    onDisconnect?: () => void
+    onOperationsChanged?: (operation: AppsOperation, enabled: boolean) => void
+    onLoginSuccess?: () => void
+    onLoginCancel?: () => void
     onBack?: () => void
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -32,3 +32,4 @@ export * from './ActivitySummaryDialog';
 export * from './ErrorBoundary'
 export * from './OperationsSelector'
 export * from './KomootLoginDialog'
+export * from './KomootSettings'


### PR DESCRIPTION
Closes #181

Adds the `KomootSettings` smart component which manages the Komoot connection lifecycle.

### Changes
- `KomootSettings.tsx` — smart component subscribing to `useAppsService`, handling connect/disconnect/operations
- `types.ts` — `KomootSettingsProps` interface
- `KomootSettings.test.tsx` — render-without-crashing tests for connected and disconnected states
- `KomootSettings.stories.tsx` — Storybook story
- `index.ts` — barrel export
- `src/components/index.ts` — re-exports `KomootSettings`