### PR TITLE
feat(182): Add AppsSettings list and navigation component

### DIFF
--- a/src/components/AppsSettings/AppsSettings.stories.tsx
+++ b/src/components/AppsSettings/AppsSettings.stories.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite'
+import { fn } from 'storybook/test'
+import { AppsSettingsView } from './AppsSettingsView'
+import type { AppsSettingsViewProps } from './types'
+
+const meta: Meta<typeof AppsSettingsView> = {
+    title: 'Components/AppsSettings',
+    component: AppsSettingsView,
+    args: {
+        onSelect: fn(),
+    },
+}
+
+export default meta
+
+type Story = StoryObj<typeof AppsSettingsView>
+
+const STRAVA_APP = {
+    name: 'Strava',
+    key: 'strava',
+    iconUrl: 'https://upload.wikimedia.org/wikipedia/commons/c/cb/Strava_Logo.svg',
+    isConnected: true,
+}
+
+const KOMOOT_APP = {
+    name: 'Komoot',
+    key: 'komoot',
+    iconUrl: 'https://upload.wikimedia.org/wikipedia/commons/6/6f/Komoot_logo.svg',
+    isConnected: false,
+}
+
+const INTERVALS_APP = {
+    name: 'Intervals.icu',
+    key: 'intervals',
+    iconUrl: 'https://example.com/intervals.png',
+    isConnected: true,
+}
+
+const VELOHERO_APP = {
+    name: 'Velohero',
+    key: 'velohero',
+    iconUrl: 'https://example.com/velohero.png',
+    isConnected: false,
+}
+
+const defaultArgs: AppsSettingsViewProps = {
+    apps: [STRAVA_APP, KOMOOT_APP, INTERVALS_APP, VELOHERO_APP],
+    onSelect: fn(),
+    compact: false,
+}
+
+export const Default: Story = {
+    args: defaultArgs,
+}
+
+export const Compact: Story = {
+    args: {
+        ...defaultArgs,
+        compact: true,
+    },
+}
+
+export const AllConnected: Story = {
+    args: {
+        apps: [
+            { ...STRAVA_APP, isConnected: true },
+            { ...KOMOOT_APP, isConnected: true },
+            { ...INTERVALS_APP, isConnected: true },
+            { ...VELOHERO_APP, isConnected: true },
+        ],
+        onSelect: fn(),
+    },
+}
+
+export const Empty: Story = {
+    args: {
+        apps: [],
+        onSelect: fn(),
+    },
+}

--- a/src/components/AppsSettings/AppsSettings.test.tsx
+++ b/src/components/AppsSettings/AppsSettings.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import { AppsSettings } from './AppsSettings'
+
+jest.mock('react-native-svg', () => ({
+    SvgUri: 'SvgUri',
+}))
+
+jest.mock('incyclist-services', () => ({
+    useAppsService: () => ({
+        openSettings: jest.fn().mockReturnValue([
+            {
+                name: 'Strava',
+                key: 'strava',
+                iconUrl: 'strava.svg',
+                isConnected: false,
+            },
+        ]),
+    }),
+}))
+
+jest.mock('../OAuthAppSettings', () => ({
+    OAuthAppSettings: 'OAuthAppSettings',
+}))
+
+jest.mock('../KomootSettings', () => ({
+    KomootSettings: 'KomootSettings',
+}))
+
+describe('AppsSettings', () => {
+    it('renders without crashing', () => {
+        expect(() => render(<AppsSettings />)).not.toThrow()
+    })
+
+    it('null service response does not crash', () => {
+        const { useAppsService } =
+            require('incyclist-services') as {
+                useAppsService: () => { openSettings: jest.Mock }
+            }
+        ;(useAppsService as jest.Mock).mockReturnValueOnce({
+            openSettings: jest.fn().mockReturnValue(null),
+        })
+        expect(() => render(<AppsSettings />)).not.toThrow()
+    })
+})

--- a/src/components/AppsSettings/AppsSettings.tsx
+++ b/src/components/AppsSettings/AppsSettings.tsx
@@ -1,0 +1,73 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { useAppsService } from 'incyclist-services'
+import { useLogging } from '../../hooks/logging'
+import { OAuthAppSettings } from '../OAuthAppSettings'
+import { KomootSettings } from '../KomootSettings'
+import { AppsSettingsView } from './AppsSettingsView'
+import type { AppDisplayProps, AppsSettingsProps } from './types'
+
+export const AppsSettings = ({ onBack }: AppsSettingsProps) => {
+    const [apps, setApps] = useState<AppDisplayProps[]>([])
+    const [selectedKey, setSelectedKey] = useState<string | null>(null)
+    const refInitialized = useRef(false)
+    const { logEvent, logError } = useLogging('AppsSettings')
+    const service = useAppsService()
+
+    useEffect(() => {
+        if (refInitialized.current) return
+        refInitialized.current = true
+
+        try {
+            const result = service?.openSettings()
+            if (result) {
+                setApps(result)
+            }
+            logEvent({ message: 'apps settings opened' })
+        } catch (err) {
+            logError(err, 'openSettings')
+        }
+    }, [service, logEvent, logError])
+
+    const handleSelect = useCallback(
+        (key: string) => {
+            logEvent({ message: 'app selected', key, eventSource: 'user' })
+            setSelectedKey(key)
+        },
+        [logEvent],
+    )
+
+    const handleBack = useCallback(() => {
+        setSelectedKey(null)
+        onBack?.()
+    }, [onBack])
+
+    const handleBackToList = useCallback(() => {
+        setSelectedKey(null)
+    }, [])
+
+    if (selectedKey) {
+        if (selectedKey === 'strava' || selectedKey === 'intervals') {
+            return (
+                <OAuthAppSettings
+                    appKey={selectedKey as 'strava' | 'intervals'}
+                    onBack={handleBackToList}
+                />
+            )
+        }
+        if (selectedKey === 'komoot') {
+            return <KomootSettings onBack={handleBackToList} />
+        }
+        // velohero — placeholder until #175 is resolved
+        if (selectedKey === 'velohero') {
+            return null
+        }
+        // Unknown key — fall through to list
+    }
+
+    return (
+        <AppsSettingsView
+            apps={apps}
+            onSelect={handleSelect}
+        />
+    )
+}

--- a/src/components/AppsSettings/AppsSettingsView.test.tsx
+++ b/src/components/AppsSettings/AppsSettingsView.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import { AppsSettingsView } from './AppsSettingsView'
+import type { AppDisplayProps, AppsSettingsViewProps } from './types'
+
+jest.mock('react-native-svg', () => ({
+    SvgUri: 'SvgUri',
+}))
+
+const MOCK_APPS: AppDisplayProps[] = [
+    { name: 'Strava', key: 'strava', iconUrl: 'strava.svg', isConnected: true },
+    { name: 'Komoot', key: 'komoot', iconUrl: 'komoot.svg', isConnected: false },
+]
+
+const MOCK_PROPS: AppsSettingsViewProps = {
+    apps: MOCK_APPS,
+    onSelect: jest.fn(),
+}
+
+describe('AppsSettingsView', () => {
+    it('renders in normal layout with apps list', () => {
+        expect(() => render(<AppsSettingsView {...MOCK_PROPS} />)).not.toThrow()
+    })
+
+    it('renders in compact layout', () => {
+        expect(() =>
+            render(<AppsSettingsView {...MOCK_PROPS} compact={true} />),
+        ).not.toThrow()
+    })
+
+    it('renders with empty apps list without crashing', () => {
+        expect(() =>
+            render(<AppsSettingsView apps={[]} onSelect={jest.fn()} />),
+        ).not.toThrow()
+    })
+
+    it('renders with apps={undefined} without crashing', () => {
+        expect(() =>
+            render(<AppsSettingsView apps={undefined} onSelect={jest.fn()} />),
+        ).not.toThrow()
+    })
+})

--- a/src/components/AppsSettings/AppsSettingsView.tsx
+++ b/src/components/AppsSettings/AppsSettingsView.tsx
@@ -1,0 +1,175 @@
+import React, { useCallback } from 'react'
+import {
+    Image,
+    ScrollView,
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+    View,
+} from 'react-native'
+import { SvgUri } from 'react-native-svg'
+import { colors } from '../../theme/colors'
+import { textSizes } from '../../theme/textSizes'
+import type { AppDisplayProps, AppsSettingsViewProps } from './types'
+
+// ---------------------------------------------------------------------------
+// Sub-components (defined outside to avoid react/no-unstable-nested-components)
+// ---------------------------------------------------------------------------
+
+interface AppIconProps {
+    iconUrl: string
+}
+
+const AppIcon = ({ iconUrl }: AppIconProps) => {
+    const isSvg = iconUrl.endsWith('.svg')
+    if (isSvg) {
+        return (
+            <View style={styles.iconWrapper}>
+                <SvgUri uri={iconUrl} width={32} height={32} />
+            </View>
+        )
+    }
+    return (
+        <View style={styles.iconWrapper}>
+            <Image source={{ uri: iconUrl }} style={styles.iconImage} />
+        </View>
+    )
+}
+
+interface ConnectedBadgeProps {
+    isConnected: boolean
+}
+
+const ConnectedBadge = ({ isConnected }: ConnectedBadgeProps) => (
+    <View
+        style={[
+            styles.badge,
+            isConnected ? styles.badgeConnected : styles.badgeDisconnected,
+        ]}
+    />
+)
+
+interface AppRowProps {
+    app: AppDisplayProps
+    compact: boolean
+    onPress: (key: string) => void
+}
+
+const AppRow = ({ app, compact, onPress }: AppRowProps) => {
+    const handlePress = useCallback(() => {
+        onPress(app.key)
+    }, [onPress, app.key])
+
+    return (
+        <TouchableOpacity
+            style={[styles.row, compact && styles.rowCompact]}
+            onPress={handlePress}
+            activeOpacity={0.7}
+        >
+            <AppIcon iconUrl={app.iconUrl} />
+            <Text style={[styles.appName, compact && styles.appNameCompact]}>
+                {app.name}
+            </Text>
+            <View style={styles.trailingGroup}>
+                <ConnectedBadge isConnected={app.isConnected} />
+                <Text style={styles.chevron}>{'›'}</Text>
+            </View>
+        </TouchableOpacity>
+    )
+}
+
+// ---------------------------------------------------------------------------
+// View
+// ---------------------------------------------------------------------------
+
+export const AppsSettingsView = ({
+    apps,
+    onSelect,
+    compact = false,
+}: AppsSettingsViewProps) => {
+    const handleSelect = useCallback(
+        (key: string) => {
+            onSelect?.(key)
+        },
+        [onSelect],
+    )
+
+    return (
+        <ScrollView
+            style={styles.container}
+            contentContainerStyle={styles.contentContainer}
+        >
+            {(apps ?? []).map((app) => (
+                <AppRow
+                    key={app.key}
+                    app={app}
+                    compact={compact}
+                    onPress={handleSelect}
+                />
+            ))}
+        </ScrollView>
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        backgroundColor: colors.background,
+    },
+    contentContainer: {
+        paddingVertical: 8,
+    },
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingHorizontal: 16,
+        paddingVertical: 14,
+        borderBottomWidth: StyleSheet.hairlineWidth,
+        borderBottomColor: colors.disabled,
+    },
+    rowCompact: {
+        paddingVertical: 8,
+    },
+    iconWrapper: {
+        width: 32,
+        height: 32,
+        marginRight: 14,
+        overflow: 'hidden',
+    },
+    iconImage: {
+        width: 32,
+        height: 32,
+    },
+    appName: {
+        flex: 1,
+        color: colors.text,
+        fontSize: textSizes.listEntry,
+    },
+    appNameCompact: {
+        fontSize: textSizes.normalText,
+    },
+    trailingGroup: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 10,
+    },
+    badge: {
+        width: 10,
+        height: 10,
+        borderRadius: 5,
+    },
+    badgeConnected: {
+        backgroundColor: '#4CAF50',
+    },
+    badgeDisconnected: {
+        backgroundColor: colors.disabled,
+    },
+    chevron: {
+        color: colors.text,
+        fontSize: textSizes.listEntry,
+    },
+})

--- a/src/components/AppsSettings/index.ts
+++ b/src/components/AppsSettings/index.ts
@@ -1,0 +1,3 @@
+export { AppsSettings } from './AppsSettings'
+export { AppsSettingsView } from './AppsSettingsView'
+export type { AppsSettingsProps, AppsSettingsViewProps, AppDisplayProps } from './types'

--- a/src/components/AppsSettings/types.ts
+++ b/src/components/AppsSettings/types.ts
@@ -1,0 +1,16 @@
+export interface AppDisplayProps {
+    name: string
+    key: string
+    iconUrl: string
+    isConnected: boolean
+}
+
+export interface AppsSettingsViewProps {
+    apps?: AppDisplayProps[]
+    onSelect?: (key: string) => void
+    compact?: boolean
+}
+
+export interface AppsSettingsProps {
+    onBack?: () => void
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,10 +11,10 @@ export * from './FreeMap'
 export * from './FilterPanel';
 export * from './RoutesTable'
 export * from './RouteDetailsDialog'
+export * from './RouteImportDialog'
 export type * from './NavigationBar/types'
 export * from './Icon';
 export * from './Dynamic'
-export * from './RouteImportDialog'
 export * from './ElevationGraph'
 export * from './RideDashboard'
 export * from './Video'
@@ -32,3 +32,4 @@ export * from './ActivitySummaryDialog';
 export * from './ErrorBoundary'
 export * from './OperationsSelector'
 export * from './KomootLoginDialog'
+export * from './AppsSettings'


### PR DESCRIPTION
Closes #182

## Summary

Adds the `AppsSettings` component as the top-level entry point for app integration settings (story #171).

### Changes
- **`types.ts`** — `AppDisplayProps`, `AppsSettingsViewProps`, `AppsSettingsProps`
- **`AppsSettingsView`** — pure view rendering a scrollable list of app tiles with icon (SVG via `SvgUri` or PNG/JPG via `Image`), name, connected badge, and chevron; calls `onSelect(key)` on row tap
- **`AppsSettings`** — smart component; uses `useAppsService` + `refInitialized` pattern; maps `selectedKey` to per-app settings components (`OAuthAppSettings`, `KomootSettings`); logs open and select events
- **Tests** — render-without-crashing tests for both view and smart component
- **Stories** — Storybook story targeting `AppsSettingsView`
- **Barrel exports** — `index.ts` + update to `src/components/index.ts`