### PR TITLE
Wrap per-app settings content in Dialog

### DIFF
--- a/src/components/AppSettingsView/AppSettingsView.test.tsx
+++ b/src/components/AppSettingsView/AppSettingsView.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Text } from 'react-native';
 import { render } from '@testing-library/react-native';
 import { AppSettingsView } from './AppSettingsView';
 import { AppSettingsViewProps } from './types';
@@ -12,14 +11,17 @@ jest.mock('incyclist-services', () => ({
     },
 }));
 
-jest.mock('../Dialog', () => ({
-    Dialog: ({ children, title }: { children: React.ReactNode, title: string }) => (
-        <>
-            <Text>{title}</Text>
-            {children}
-        </>
-    ),
-}));
+jest.mock('../Dialog', () => {
+    const { Text } = require('react-native');
+    return {
+        Dialog: ({ children, title }: { children: React.ReactNode; title: string }) => (
+            <>
+                <Text>{title}</Text>
+                {children}
+            </>
+        ),
+    };
+});
 
 const MOCK_CONNECT_BUTTON = () => <Button label="Connect" onClick={jest.fn()} />;
 

--- a/src/components/AppSettingsView/AppSettingsView.test.tsx
+++ b/src/components/AppSettingsView/AppSettingsView.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Text } from 'react-native';
 import { render } from '@testing-library/react-native';
 import { AppSettingsView } from './AppSettingsView';
 import { AppSettingsViewProps } from './types';
@@ -14,7 +15,7 @@ jest.mock('incyclist-services', () => ({
 jest.mock('../Dialog', () => ({
     Dialog: ({ children, title }: { children: React.ReactNode, title: string }) => (
         <>
-            {title}
+            <Text>{title}</Text>
             {children}
         </>
     ),

--- a/src/components/AppSettingsView/AppSettingsView.test.tsx
+++ b/src/components/AppSettingsView/AppSettingsView.test.tsx
@@ -11,6 +11,15 @@ jest.mock('incyclist-services', () => ({
     },
 }));
 
+jest.mock('../Dialog', () => ({
+    Dialog: ({ children, title }: { children: React.ReactNode, title: string }) => (
+        <>
+            {title}
+            {children}
+        </>
+    ),
+}));
+
 const MOCK_CONNECT_BUTTON = () => <Button label="Connect" onClick={jest.fn()} />;
 
 const MOCK_PROPS: AppSettingsViewProps = {

--- a/src/components/AppSettingsView/AppSettingsView.tsx
+++ b/src/components/AppSettingsView/AppSettingsView.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator } from 'react-native';
-import { colors, textSizes } from '../../theme';
+import { View, StyleSheet, ActivityIndicator } from 'react-native';
+import { colors } from '../../theme';
 import { AppSettingsViewProps } from './types';
 import { Button } from '../ButtonBar/ButtonBar';
 import { OperationsSelector } from '../OperationsSelector';
+import { Dialog } from '../Dialog';
 
 export const AppSettingsView = ({
     title,
@@ -14,7 +15,6 @@ export const AppSettingsView = ({
     onDisconnect,
     onOperationsChanged,
     onBack,
-    compact = false,
 }: AppSettingsViewProps) => {
     const handleDisconnect = useCallback(() => {
         if (onDisconnect) {
@@ -22,26 +22,12 @@ export const AppSettingsView = ({
         }
     }, [onDisconnect]);
 
-    const handleBack = useCallback(() => {
-        if (onBack) {
-            onBack();
-        }
-    }, [onBack]);
-
-    const titleStyle = [
-        styles.title,
-        compact && styles.titleCompact
-    ];
-
     return (
-        <View style={styles.container}>
-            <View style={styles.header}>
-                <Text style={titleStyle}>{title}</Text>
-                <TouchableOpacity onPress={handleBack} style={styles.backButton}>
-                    <Text style={styles.backText}>←</Text>
-                </TouchableOpacity>
-            </View>
-
+        <Dialog
+            title={title}
+            variant="details"
+            onOutsideClick={onBack}
+        >
             <View style={styles.content}>
                 <View style={styles.connectArea}>
                     {!isConnected && !isConnecting && connectButton()}
@@ -69,37 +55,11 @@ export const AppSettingsView = ({
                     </View>
                 )}
             </View>
-        </View>
+        </Dialog>
     );
 };
 
 const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        padding: 16,
-        backgroundColor: colors.background,
-    },
-    header: {
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        marginBottom: 24,
-    },
-    title: {
-        fontSize: textSizes.pageTitle,
-        color: colors.text,
-        fontWeight: '700',
-    },
-    titleCompact: {
-        fontSize: textSizes.dialogTitle,
-    },
-    backButton: {
-        padding: 8,
-    },
-    backText: {
-        fontSize: 32,
-        color: colors.text,
-    },
     content: {
         flex: 1,
     },


### PR DESCRIPTION
Closes #200

This PR updates the `AppSettingsView` component to use the standard `Dialog` pattern used throughout the application for settings screens. 

### Key Changes:
- Wrapped `AppSettingsView` root content in a `Dialog` with `variant="details"`.
- Removed manual title and back button rendering as these are now handled by the `Dialog` component.
- Mapped the `onBack` prop to the `Dialog`'s `onOutsideClick` handler to enable dismissal via backdrop tap.
- Updated unit tests to include a mock for the `Dialog` component.