### PR TITLE
feat: Use InAppBrowser for OAuth flow with CSRF protection

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -113,6 +113,7 @@ const config: StorybookConfig = {
                     'react-native-fs': path.resolve(dirname, './emptyStub.ts'),
                     '@settings':                     'react-native-web/dist/exports/View',
                     'react-native-maps': path.resolve(dirname, './mocks/react-native-maps.tsx'),
+                    'react-native-inappbrowser-reborn': path.resolve(dirname, './mocks/react-native-inappbrowser-reborn.ts'),
 
                     // ── native TurboModule stubs ──────────────────────────────────
                     '@pagopa/io-react-native-integrity': path.resolve(dirname, 'mocks/io-react-native-integrity.ts'),

--- a/.storybook/mocks/react-native-inappbrowser-reborn.ts
+++ b/.storybook/mocks/react-native-inappbrowser-reborn.ts
@@ -1,0 +1,5 @@
+export default {
+    isAvailable: async () => true,
+    openAuth: async () => ({ type: 'cancel' }),
+    close: () => {},
+};

--- a/__mocks__/react-native-inappbrowser-reborn.ts
+++ b/__mocks__/react-native-inappbrowser-reborn.ts
@@ -1,0 +1,5 @@
+export default {
+    isAvailable: jest.fn().mockResolvedValue(true),
+    openAuth: jest.fn().mockResolvedValue({ type: 'cancel' }),
+    close: jest.fn(),
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
     'react-native-maps': '<rootDir>/__mocks__/react-native-maps.tsx',
     '\\.svg$': '<rootDir>/__mocks__/svgMock.tsx',
     'react-native-safe-area-context': '<rootDir>/__mocks__/react-native-safe-area-context.ts',
+    'react-native-inappbrowser-reborn': '<rootDir>/__mocks__/react-native-inappbrowser-reborn.ts',
     '@react-navigation/native': '<rootDir>/src/__mocks__/@react-navigation/native.ts', // Added for ESM module support
   },
 };

--- a/src/components/OAuthAppSettings/OAuthAppSettings.tsx
+++ b/src/components/OAuthAppSettings/OAuthAppSettings.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { Linking, StyleSheet, TouchableOpacity } from 'react-native';
+import InAppBrowser from 'react-native-inappbrowser-reborn';
 import { useAppsService } from 'incyclist-services';
 import type { AppsOperation } from 'incyclist-services';
 import { AppSettingsView } from '../AppSettingsView';
 import type { OperationConfig } from '../OperationsSelector/types';
 import { useLogging } from '../../hooks';
-import { useUnmountEffect } from '../../hooks';
 import { colors } from '../../theme/colors';
 import { textSizes } from '../../theme/textSizes';
 import StravaConnectSvg from '../../assets/btn_strava_connectwith_orange.svg';
@@ -23,14 +23,7 @@ const OAuthAppSettings = ({ appKey, onBack }: OAuthAppSettingsProps) => {
     const [operations, setOperations] = useState<OperationConfig[]>([]);
 
     const refInitialized = useRef<boolean>(false);
-    const refLinkingSubscription = useRef<{ remove: () => void } | null>(null);
-
-    const removeLinkingListener = useCallback(() => {
-        if (refLinkingSubscription.current) {
-            refLinkingSubscription.current.remove();
-            refLinkingSubscription.current = null;
-        }
-    }, []);
+    const refStateParam = useRef<string>('');
 
     useEffect(() => {
         if (refInitialized.current || !service) return;
@@ -43,61 +36,77 @@ const OAuthAppSettings = ({ appKey, onBack }: OAuthAppSettingsProps) => {
         }
     }, [service, appKey]);
 
-    useUnmountEffect(removeLinkingListener);
-
-    const onConnect = useCallback(() => {
+    const onConnect = useCallback(async () => {
         if (!service) return;
+
+        const stateParam = Math.random().toString(36).substring(2);
+        refStateParam.current = stateParam;
 
         logEvent({ message: 'oauth connect start', appKey, eventSource: 'user' });
         setIsConnecting(true);
 
-        const url = `${OAUTH_BASE}/${appKey}?sid=${encodeURIComponent(REDIRECT_URI)}`;
+        const url = `${OAUTH_BASE}/${appKey}?sid=${encodeURIComponent(REDIRECT_URI)}&state=${stateParam}`;
 
-        Linking.openURL(url).catch((err: Error) => {
-            logError(err, 'onConnect');
-            setIsConnecting(false);
-        });
-
-        const subscription = Linking.addEventListener('url', async ({ url: callbackUrl }: { url: string }) => {
-            if (!callbackUrl.startsWith('incyclist://oauth/callback')) return;
-
-            removeLinkingListener();
-
-            try {
-                const parsed = new URL(callbackUrl.replace('incyclist://', 'https://incyclist'));
-                const error = parsed.searchParams.get('error');
-
-                if (error) {
-                    logEvent({ message: 'oauth connect failed', appKey, error });
-                    setIsConnecting(false);
-                    return;
-                }
-
-                const credentials = {
-                    accesstoken: parsed.searchParams.get('accesstoken'),
-                    refreshtoken: parsed.searchParams.get('refreshtoken'),
-                    id: parsed.searchParams.get('id'),
-                };
-
-                await service.connect(appKey, credentials);
-
-                logEvent({ message: 'oauth connect success', appKey });
-
-                const refreshed = service.openAppSettings(appKey);
-                if (refreshed) {
-                    setIsConnected(refreshed.isConnected ?? false);
-                    setOperations((refreshed.operations as OperationConfig[]) ?? []);
-                }
-            } catch (err) {
-                logError(err as Error, 'onConnectCallback');
-                logEvent({ message: 'oauth connect failed', appKey, error: (err as Error).message });
-            } finally {
+        try {
+            const isAvailable = await InAppBrowser.isAvailable();
+            if (!isAvailable) {
+                // Fallback: open system browser, user must return manually
+                await Linking.openURL(url);
                 setIsConnecting(false);
+                return;
             }
-        });
 
-        refLinkingSubscription.current = subscription;
-    }, [service, appKey, logEvent, logError, removeLinkingListener]);
+            const result = await InAppBrowser.openAuth(url, REDIRECT_URI, {
+                showTitle: false,
+                enableUrlBarHiding: true,
+                enableDefaultShare: false,
+                forceCloseOnRedirection: false,
+                headers: { 'stateKey': stateParam },
+            });
+
+            if (result.type === 'cancel') {
+                return;
+            }
+
+            if (result.type !== 'success' || !result.url) {
+                return;
+            }
+
+            const callbackUrl = result.url;
+            const parsed = new URL(callbackUrl.replace('incyclist://', 'https://incyclist'));
+            const returnedState = parsed.searchParams.get('state');
+
+            if (returnedState !== refStateParam.current) {
+                logEvent({ message: 'oauth state mismatch', appKey });
+                return;
+            }
+
+            const error = parsed.searchParams.get('error');
+            if (error) {
+                logEvent({ message: 'oauth connect failed', appKey, error });
+                return;
+            }
+
+            const credentials = {
+                accesstoken: parsed.searchParams.get('accesstoken'),
+                refreshtoken: parsed.searchParams.get('refreshtoken'),
+                id: parsed.searchParams.get('id'),
+            };
+
+            await service.connect(appKey, credentials);
+            logEvent({ message: 'oauth connect success', appKey });
+
+            const refreshed = service.openAppSettings(appKey);
+            if (refreshed) {
+                setIsConnected(refreshed.isConnected ?? false);
+                setOperations((refreshed.operations as OperationConfig[]) ?? []);
+            }
+        } catch (err) {
+            logError(err as Error, 'onConnect');
+        } finally {
+            setIsConnecting(false);
+        }
+    }, [service, appKey, logEvent, logError]);
 
     const onDisconnect = useCallback(() => {
         if (!service) return;


### PR DESCRIPTION
Closes #207

This PR refactors the OAuth flow in `OAuthAppSettings` to use `react-native-inappbrowser-reborn` instead of the legacy `Linking` event listener pattern. 

Key changes:
- Replaced `Linking.openURL` and `Linking.addEventListener` with `InAppBrowser.openAuth`.
- Implemented CSRF protection using a `state` parameter generated at the start of the flow and verified upon callback.
- Improved error handling and state management by ensuring `isConnecting` is properly reset in all scenarios (cancel, error, success).
- Cleaned up unused refs (`refLinkingSubscription`) and unmount effects related to the old linking listener.