### PR TITLE
Fix ActivityListItem layout and remove compact prop

### DIFF
--- a/src/components/ActivityListItem/ActivityListItem.stories.tsx
+++ b/src/components/ActivityListItem/ActivityListItem.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { ActivityListItem } from './ActivityListItem';
+import { ActivityInfoUI } from 'incyclist-services';
+
+const mockActivity: ActivityInfoUI = {
+    id: '1',
+    name: 'Evening Commute',
+    startTime: new Date().toISOString(),
+    summary: {
+        duration: 2450,
+        totalDistance: 12400,
+    }
+} as any;
+
+const meta: Meta<typeof ActivityListItem> = {
+    title: 'Components/ActivityListItem',
+    component: ActivityListItem,
+    args: {
+        onPress: fn(),
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof ActivityListItem>;
+
+export const Default: Story = {
+    args: {
+        activityInfo: mockActivity,
+    },
+};
+
+export const WithElevation: Story = {
+    args: {
+        activityInfo: {
+            ...mockActivity,
+            name: 'Mountain Climb',
+            summary: {
+                ...mockActivity.summary,
+                totalElevation: { value: 1250, unit: 'm' } as any
+            }
+        },
+    },
+};
+
+export const LongTitle: Story = {
+    args: {
+        activityInfo: {
+            ...mockActivity,
+            name: 'A Very Long Activity Name That Should Be Truncated Properly In The UI',
+        },
+    },
+};

--- a/src/components/ActivityListItem/ActivityListItem.test.tsx
+++ b/src/components/ActivityListItem/ActivityListItem.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { ActivityListItem } from './ActivityListItem';
+import { ActivityInfoUI } from 'incyclist-services';
+
+const mockActivity: ActivityInfoUI = {
+    id: '123',
+    name: 'Morning Ride',
+    startTime: '2024-01-01T08:00:00Z',
+    summary: {
+        duration: 3600,
+        totalDistance: 25000,
+        totalElevation: 150,
+    }
+} as any;
+
+describe('ActivityListItem', () => {
+    it('renders correctly', () => {
+        const { getByText } = render(
+            <ActivityListItem 
+                activityInfo={mockActivity} 
+                onPress={jest.fn()} 
+            />
+        );
+        expect(getByText('Morning Ride')).toBeTruthy();
+        expect(getByText(/25.0/)).toBeTruthy();
+        expect(getByText('km')).toBeTruthy();
+    });
+
+    it('calls onPress when clicked', () => {
+        const onPress = jest.fn();
+        const { getByText } = render(
+            <ActivityListItem 
+                activityInfo={mockActivity} 
+                onPress={onPress} 
+            />
+        );
+        
+        fireEvent.press(getByText('Morning Ride'));
+        expect(onPress).toHaveBeenCalledWith('123');
+    });
+
+    it('renders duration in the second line', () => {
+        const { getByText } = render(
+            <ActivityListItem 
+                activityInfo={mockActivity} 
+                onPress={jest.fn()} 
+            />
+        );
+        // 3600 seconds = 1:00:00
+        expect(getByText(/1:00:00/)).toBeTruthy();
+    });
+});

--- a/src/components/ActivityListItem/ActivityListItem.tsx
+++ b/src/components/ActivityListItem/ActivityListItem.tsx
@@ -1,0 +1,152 @@
+import React, { useMemo, useCallback } from 'react';
+import { View, Text, StyleSheet, Image, TouchableOpacity } from 'react-native';
+import { ActivityListItemProps } from './types';
+import { colors, textSizes } from '../../theme';
+
+export const ActivityListItem = ({ activityInfo, onPress }: ActivityListItemProps) => {
+    const handlePress = useCallback(() => {
+        onPress(activityInfo.id);
+    }, [activityInfo.id, onPress]);
+
+    const dateStr = useMemo(() => {
+        if (!activityInfo.startTime) return '';
+        return new Date(activityInfo.startTime).toLocaleDateString();
+    }, [activityInfo.startTime]);
+
+    const timeStr = useMemo(() => {
+        if (!activityInfo.startTime) return '';
+        return new Date(activityInfo.startTime).toLocaleTimeString([], { 
+            hour: '2-digit', 
+            minute: '2-digit' 
+        });
+    }, [activityInfo.startTime]);
+
+    const durationStr = useMemo(() => {
+        const seconds = activityInfo.summary?.duration ?? 0;
+        const h = Math.floor(seconds / 3600);
+        const m = Math.floor((seconds % 3600) / 60);
+        const s = Math.floor(seconds % 60);
+        
+        if (h > 0) {
+            return `${h}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
+        }
+        return `${m}:${s.toString().padStart(2, '0')}`;
+    }, [activityInfo.summary?.duration]);
+
+    const getMetricParts = (val: any, type: 'distance' | 'elevation') => {
+        if (val === undefined || val === null) return null;
+        
+        if (typeof val === 'object' && val.value !== undefined) {
+            return { value: val.value.toString(), unit: val.unit };
+        }
+        
+        if (type === 'distance') {
+            return { value: (val / 1000).toFixed(1), unit: 'km' };
+        }
+        
+        return { value: Math.round(val).toString(), unit: 'm' };
+    };
+
+    const distance = useMemo(() => 
+        getMetricParts(activityInfo.summary?.totalDistance, 'distance'), 
+        [activityInfo.summary?.totalDistance]
+    );
+    
+    const elevation = useMemo(() => 
+        getMetricParts(activityInfo.summary?.totalElevation, 'elevation'), 
+        [activityInfo.summary?.totalElevation]
+    );
+
+    return (
+        <TouchableOpacity 
+            style={styles.container} 
+            onPress={handlePress} 
+            activeOpacity={0.7}
+        >
+            <View style={styles.centerSection}>
+                <Text style={styles.title} numberOfLines={1}>
+                    {activityInfo.name || 'Activity'}
+                </Text>
+                <Text style={styles.subText}>
+                    {`${dateStr}  ${timeStr}  ${durationStr}`}
+                </Text>
+            </View>
+
+            <View style={styles.metricsContainer}>
+                {distance && (
+                    <View style={styles.metricColumn}>
+                        <Image 
+                            source={require('../../assets/icons/length.gif')} 
+                            style={styles.metricIcon} 
+                        />
+                        <Text style={styles.metricValue}>{distance.value}</Text>
+                        <Text style={styles.metricUnit}>{distance.unit}</Text>
+                    </View>
+                )}
+                {elevation && (
+                    <View style={styles.metricColumn}>
+                        <Image 
+                            source={require('../../assets/icons/elevation.gif')} 
+                            style={styles.metricIcon} 
+                        />
+                        <Text style={styles.metricValue}>{elevation.value}</Text>
+                        <Text style={styles.metricUnit}>{elevation.unit}</Text>
+                    </View>
+                )}
+            </View>
+        </TouchableOpacity>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        height: 72,
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingHorizontal: 16,
+        backgroundColor: colors.listItemBackground,
+        borderBottomWidth: 1,
+        borderBottomColor: 'rgba(255, 255, 255, 0.1)',
+    },
+    centerSection: {
+        flex: 1,
+        justifyContent: 'center',
+    },
+    title: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        fontWeight: 'bold',
+    },
+    subText: {
+        color: colors.disabled,
+        fontSize: textSizes.smallText,
+        marginTop: 2,
+    },
+    metricsContainer: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+    },
+    metricColumn: {
+        width: 64,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    metricIcon: {
+        width: 20,
+        height: 20,
+        marginBottom: 2,
+        resizeMode: 'contain',
+    },
+    metricValue: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        fontWeight: '600',
+        textAlign: 'center',
+    },
+    metricUnit: {
+        color: colors.disabled,
+        fontSize: textSizes.smallText,
+        textAlign: 'center',
+    },
+});

--- a/src/components/ActivityListItem/types.ts
+++ b/src/components/ActivityListItem/types.ts
@@ -1,0 +1,8 @@
+import { ActivityInfoUI } from 'incyclist-services';
+
+export interface ActivityListItemProps {
+    activityInfo: ActivityInfoUI;
+    onPress: (id: string) => void;
+}
+
+export const ACTIVITY_LIST_ITEM_HEIGHT = 72;


### PR DESCRIPTION
Closes #229

This PR updates the `ActivityListItem` component to follow the new UI requirements:
- Removed the `compact` prop as the component height is now fixed at 72px.
- Moved the duration string to the second line of the center section, alongside date and time.
- Refactored the metric columns to show an icon, a bold value, and a dimmed unit, removing the redundant label text.
- Implemented robust parsing for distance and elevation metrics, supporting both raw numbers and `FormattedNumber` objects.
- Updated tests and stories to reflect these changes.