### PR TITLE
Fix ActivityListItem layout and remove compact prop

### DIFF
--- a/src/components/ActivityListItem/ActivityListItem.stories.tsx
+++ b/src/components/ActivityListItem/ActivityListItem.stories.tsx
@@ -52,22 +52,6 @@ export const IncyclistRide: Story = {
     },
 };
 
-export const Compact: Story = {
-    args: {
-        compact: true,
-        activityInfo: {
-            summary: {
-                id: '3',
-                title: 'Quick Sprint',
-                startTime: 1744444800000,
-                rideTime: 600,
-                distance: 5000,
-            } as any,
-            details: undefined,
-        },
-    },
-};
-
 export const WithElevation: Story = {
     args: {
         activityInfo: {

--- a/src/components/ActivityListItem/ActivityListItem.test.tsx
+++ b/src/components/ActivityListItem/ActivityListItem.test.tsx
@@ -31,7 +31,7 @@ const MOCK_RAW_DISTANCE: ActivityListItemProps = {
             id: 'act-2',
             title: 'Incyclist Ride',
             startTime: 1744444800000,
-            rideTime: 720,
+            rideTime: 7200,
             distance: 24500,
         } as any,
         details: undefined,
@@ -61,10 +61,6 @@ describe('ActivityListItem', () => {
 
     it('renders without crashing with raw distance', () => {
         render(<ActivityListItem {...MOCK_RAW_DISTANCE} />);
-    });
-
-    it('renders in compact mode without crashing', () => {
-        render(<ActivityListItem {...MOCK_FORMATTED} compact />);
     });
 
     it('renders without crashing with no elevation', () => {

--- a/src/components/ActivityListItem/ActivityListItem.tsx
+++ b/src/components/ActivityListItem/ActivityListItem.tsx
@@ -149,6 +149,8 @@ const styles = StyleSheet.create({
         fontSize: textSizes.normalText,
         fontWeight: '600',
         textAlign: 'center',
+        marginTop: 6,
+        marginBottom: 3
     },
     metricUnit: {
         color: colors.disabled,

--- a/src/components/ActivityListItem/ActivityListItem.tsx
+++ b/src/components/ActivityListItem/ActivityListItem.tsx
@@ -6,7 +6,7 @@ import { ActivityGraphPreview } from '../ActivityGraphPreview';
 import { colors, textSizes } from '../../theme';
 
 export const ActivityListItem = memo((props: ActivityListItemProps) => {
-    const { activityInfo, onPress, compact } = props;
+    const { activityInfo, onPress } = props;
     const { summary, details } = activityInfo;
     const { id, title, startTime, rideTime, distance } = summary;
 
@@ -26,19 +26,25 @@ export const ActivityListItem = memo((props: ActivityListItemProps) => {
     const minutes = Math.floor((rideTime % 3600) / 60);
     const durationStr = hours > 0 ? `${hours}h ${minutes}min` : `${minutes}min`;
 
-    let distanceStr = '';
+    let distanceValue = '';
+    let distanceUnit = '';
     if (typeof distance === 'object' && distance !== null && 'value' in distance && 'unit' in distance) {
-        distanceStr = `${distance.value.toFixed(1)} ${distance.unit}`;
+        distanceValue = distance.value.toFixed(1);
+        distanceUnit = distance.unit;
     } else if (typeof distance === 'number') {
-        distanceStr = `${(distance / 1000).toFixed(1)} km`;
+        distanceValue = (distance / 1000).toFixed(1);
+        distanceUnit = 'km';
     }
 
     const elevation = (summary as any).totalElevation;
-    let elevationStr = '';
+    let elevationValue = '';
+    let elevationUnit = '';
     if (typeof elevation === 'object' && elevation !== null && 'value' in elevation && 'unit' in elevation) {
-        elevationStr = `${Math.round(elevation.value)} ${elevation.unit}`;
+        elevationValue = Math.round(elevation.value).toString();
+        elevationUnit = elevation.unit;
     } else if (typeof elevation === 'number' && !isNaN(elevation)) {
-        elevationStr = `${Math.round(elevation)}m`;
+        elevationValue = Math.round(elevation).toString();
+        elevationUnit = 'm';
     }
 
     const hasLogs = details?.logs && details.logs.length > 0;
@@ -56,26 +62,23 @@ export const ActivityListItem = memo((props: ActivityListItemProps) => {
             <View style={styles.centerSection}>
                 <Text style={styles.title} numberOfLines={1}>
                     {displayTitle}
-                    {compact && <Text style={styles.dateCompact}> - {dateStr}</Text>}
                 </Text>
-                {!compact && (
-                    <Text style={styles.dateTime}>
-                        {dateStr}{'  '}{timeStr}{'  '}{durationStr}
-                    </Text>
-                )}
+                <Text style={styles.dateTime}>
+                    {dateStr}{'  '}{timeStr}{'  '}{durationStr}
+                </Text>
             </View>
 
             <View style={styles.metricsSection}>
                 <View style={styles.metricColumn}>
                     <Image source={require('../../assets/icons/length.gif')} style={styles.metricIcon} />
-                    <Text style={styles.metricLabel}>Distance</Text>
-                    <Text style={styles.metricValue}>{distanceStr}</Text>
+                    <Text style={styles.metricValue}>{distanceValue}</Text>
+                    <Text style={styles.metricUnit}>{distanceUnit}</Text>
                 </View>
-                {elevationStr !== '' && (
+                {elevationValue !== '' && (
                     <View style={styles.metricColumn}>
                         <Image source={require('../../assets/icons/up.gif')} style={styles.metricIcon} />
-                        <Text style={styles.metricLabel}>Elevation</Text>
-                        <Text style={styles.metricValue}>{elevationStr}</Text>
+                        <Text style={styles.metricValue}>{elevationValue}</Text>
+                        <Text style={styles.metricUnit}>{elevationUnit}</Text>
                     </View>
                 )}
             </View>
@@ -120,11 +123,6 @@ const styles = StyleSheet.create({
         fontSize: textSizes.normalText,
         fontWeight: '600',
     },
-    dateCompact: {
-        fontSize: textSizes.smallText,
-        fontWeight: 'normal',
-        color: colors.text,
-    },
     dateTime: {
         color: colors.text,
         fontSize: textSizes.smallText,
@@ -146,13 +144,15 @@ const styles = StyleSheet.create({
         height: 16,
         tintColor: colors.text,
     },
-    metricLabel: {
-        color: colors.text,
-        fontSize: textSizes.smallText,
-    },
     metricValue: {
         color: colors.text,
+        fontSize: textSizes.normalText,
+        fontWeight: '600',
+        textAlign: 'center',
+    },
+    metricUnit: {
+        color: colors.disabled,
         fontSize: textSizes.smallText,
-        fontWeight: '500',
+        textAlign: 'center',
     },
 });

--- a/src/components/ActivityListItem/types.ts
+++ b/src/components/ActivityListItem/types.ts
@@ -3,7 +3,6 @@ import { ActivityInfoUI } from 'incyclist-services';
 export interface ActivityListItemProps {
     activityInfo: ActivityInfoUI;
     onPress: (id: string) => void;
-    compact?: boolean;
 }
 
 export const ACTIVITY_LIST_ITEM_HEIGHT = 72;


### PR DESCRIPTION
Closes #229

This PR updates the `ActivityListItem` component to match the established UI patterns:
- Removed the `compact` prop and related logic/styles.
- Moved `durationStr` to the second line of the center section, alongside date and time.
- Refactored metric columns to use icon + value + unit (removing label text).
- Split metric values and units into separate `Text` nodes with distinct styles.
- Elevation column is now conditionally rendered based on presence of data.