### PR TITLE
Refactor ActivityListItem into smart/view split with caching

### DIFF
--- a/src/components/ActivityListItem/ActivityListItem.stories.tsx
+++ b/src/components/ActivityListItem/ActivityListItem.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { fn } from 'storybook/test';
-import { ActivityListItem } from './ActivityListItem';
+import { ActivityListItemView } from './ActivityListItemView';
 
-const meta: Meta<typeof ActivityListItem> = {
+const meta: Meta<typeof ActivityListItemView> = {
     title: 'Components/ActivityListItem',
-    component: ActivityListItem,
+    component: ActivityListItemView,
     args: {
         onPress: fn(),
     },
@@ -12,58 +12,60 @@ const meta: Meta<typeof ActivityListItem> = {
 
 export default meta;
 
-type Story = StoryObj<typeof ActivityListItem>;
+type Story = StoryObj<typeof ActivityListItemView>;
 
 export const Default: Story = {
     args: {
-        activityInfo: {
-            summary: {
-                id: '1',
-                title: 'Morning Ride',
-                startTime: 1744444800000,
-                rideTime: 3660,
-                distance: { value: 25.5, unit: 'km' },
-            } as any,
-            details: undefined,
-        },
+        title: 'Morning Ride',
+        dateStr: '12.04.2025',
+        timeStr: '08:00',
+        durationStr: '1h 1min',
+        distanceValue: '25.5',
+        distanceUnit: 'km',
+        elevationValue: '',
+        elevationUnit: '',
+        details: undefined,
+        compact: false,
+        outsideFold: false,
     },
 };
 
 export const IncyclistRide: Story = {
     args: {
-        activityInfo: {
-            summary: {
-                id: '2',
-                title: 'Incyclist Ride',
-                startTime: 1744444800000,
-                rideTime: 1800,
-                distance: 12500,
-            } as any,
-            details: {
-                route: {
-                    title: 'Mont Ventoux',
-                },
-                logs: [
-                    { distance: 0, power: 100 },
-                    { distance: 100, power: 150 },
-                ],
-            } as any,
-        },
+        title: 'Mont Ventoux',
+        dateStr: '12.04.2025',
+        timeStr: '10:00',
+        durationStr: '30min',
+        distanceValue: '12.5',
+        distanceUnit: 'km',
+        elevationValue: '0',
+        elevationUnit: 'm',
+        details: {
+            route: {
+                title: 'Mont Ventoux',
+            },
+            logs: [
+                { distance: 0, power: 100 },
+                { distance: 100, power: 150 },
+            ],
+        } as any,
+        compact: false,
+        outsideFold: false,
     },
 };
 
 export const WithElevation: Story = {
     args: {
-        activityInfo: {
-            summary: {
-                id: '4',
-                title: 'Mountain Stage',
-                startTime: 1744444800000,
-                rideTime: 7200,
-                distance: { value: 45.2, unit: 'km' },
-                totalElevation: { value: 1250, unit: 'm' },
-            } as any,
-            details: undefined,
-        },
+        title: 'Mountain Stage',
+        dateStr: '12.04.2025',
+        timeStr: '11:00',
+        durationStr: '2h 0min',
+        distanceValue: '45.2',
+        distanceUnit: 'km',
+        elevationValue: '1250',
+        elevationUnit: 'm',
+        details: undefined,
+        compact: false,
+        outsideFold: false,
     },
 };

--- a/src/components/ActivityListItem/ActivityListItem.test.tsx
+++ b/src/components/ActivityListItem/ActivityListItem.test.tsx
@@ -9,7 +9,11 @@ jest.mock('incyclist-services', () => ({
         return '';
     }),
     useActivityList: jest.fn(() => ({
-        getActivityDetails: jest.fn(() => ({ on: jest.fn() })),
+        getActivityDetails: jest.fn(() => ({ 
+            on: jest.fn(),
+            once: jest.fn(),
+            stop: jest.fn(),
+        })),
     })),
 }))
 

--- a/src/components/ActivityListItem/ActivityListItem.tsx
+++ b/src/components/ActivityListItem/ActivityListItem.tsx
@@ -1,5 +1,5 @@
-import React, { memo, useCallback, useState, useEffect } from 'react';
-import { formatDateTime, useActivityList, ActivityDetails } from 'incyclist-services';
+import React, { memo, useCallback, useState, useEffect, useRef } from 'react';
+import { formatDateTime, useActivityList, ActivityDetails  } from 'incyclist-services';
 import { ActivityListItemProps } from './types';
 import { ActivityListItemView } from './ActivityListItemView';
 
@@ -11,7 +11,8 @@ export const ActivityListItem = memo((props: ActivityListItemProps) => {
     const { id, startTime, rideTime, distance } = summary;
 
     const service = useActivityList();
-    const [details, setDetails] = useState<ActivityDetails | undefined>(initialDetails);
+    const [details, setDetails] = useState<ActivityDetails | undefined>(undefined);
+    const refInitialized = useRef(false);
 
     // Sync from cache on ID change (FlashList recycling)
     useEffect(() => {
@@ -20,31 +21,30 @@ export const ActivityListItem = memo((props: ActivityListItemProps) => {
         if (cached) {
             setDetails(cached);
         } else {
-            setDetails(initialDetails);
+            setDetails(undefined);
         }
     }, [id, initialDetails]);
 
     useEffect(() => {
-        // Sharp edge: check outsideFold first
         if (outsideFold) return;
-        if (details?.logs?.length || !id) return;
-        if (detailsCache.has(id)) {
-            setDetails(detailsCache.get(id));
+        if (refInitialized.current) return;
+        refInitialized.current = true;
+        if (!id) return;
+        const cached = detailsCache.get(id);
+        if (cached) {
+            setDetails(cached);
             return;
         }
-
         const observer = service.getActivityDetails(id);
         const onLoaded = (data: ActivityDetails) => {
             detailsCache.set(id, data);
             setDetails(data);
-            observer.stop()
+            observer.stop();
         };
         observer.once('loaded', onLoaded);
+        return () => { observer.stop(); };
+    }, [id, service, outsideFold]);
 
-        return () => {
-            observer.stop()
-        };
-    }, [id, service, outsideFold, details]);
 
     const handlePress = useCallback(() => {
         onPress(id);

--- a/src/components/ActivityListItem/ActivityListItem.tsx
+++ b/src/components/ActivityListItem/ActivityListItem.tsx
@@ -1,40 +1,55 @@
-import React, { memo, useCallback, useState, useEffect, useRef } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Image } from 'react-native';
-import { formatDateTime, useActivityList } from 'incyclist-services';
-import { ActivityListItemProps, ACTIVITY_LIST_ITEM_HEIGHT } from './types';
-import { ActivityGraphPreview } from '../ActivityGraphPreview';
-import { colors, textSizes } from '../../theme';
+import React, { memo, useCallback, useState, useEffect } from 'react';
+import { formatDateTime, useActivityList, ActivityDetails } from 'incyclist-services';
+import { ActivityListItemProps } from './types';
+import { ActivityListItemView } from './ActivityListItemView';
+
+const detailsCache = new Map<string, ActivityDetails>();
 
 export const ActivityListItem = memo((props: ActivityListItemProps) => {
-    const { activityInfo, onPress, outsideFold } = props;
+    const { activityInfo, onPress, outsideFold = false } = props;
     const { summary, details: initialDetails } = activityInfo;
-    const { id, title, startTime, rideTime, distance } = summary;
+    const { id, startTime, rideTime, distance } = summary;
 
     const service = useActivityList();
-    const refInitialized = useRef(false);
-    const [details, setDetails] = useState(initialDetails);
+    const [details, setDetails] = useState<ActivityDetails | undefined>(initialDetails);
+
+    // Sync from cache on ID change (FlashList recycling)
+    useEffect(() => {
+        if (!id) return;
+        const cached = detailsCache.get(id);
+        if (cached) {
+            setDetails(cached);
+        } else {
+            setDetails(initialDetails);
+        }
+    }, [id, initialDetails]);
 
     useEffect(() => {
-        if (refInitialized.current) return;
-        refInitialized.current = true;
+        // Sharp edge: check outsideFold first
+        if (outsideFold) return;
         if (details?.logs?.length || !id) return;
+        if (detailsCache.has(id)) {
+            setDetails(detailsCache.get(id));
+            return;
+        }
+
         const observer = service.getActivityDetails(id);
-        observer.on('loaded', (d: any) => setDetails(d));
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+        const onLoaded = (data: ActivityDetails) => {
+            detailsCache.set(id, data);
+            setDetails(data);
+        };
+        observer.on('loaded', onLoaded);
+    }, [id, service, outsideFold, details]);
 
     const handlePress = useCallback(() => {
         onPress(id);
     }, [id, onPress]);
 
-    if (outsideFold) {
-        return <View style={styles.outsideFold} />;
-    }
-
+    // Data processing
     const displayTitle =
-        title === 'Incyclist Ride'
+        summary.title === 'Incyclist Ride'
             ? details?.route?.title ?? details?.route?.name ?? 'Incyclist Ride'
-            : title;
+            : summary.title;
 
     const dateStr = formatDateTime(new Date(startTime), '%d.%m.%Y');
     const timeStr = formatDateTime(new Date(startTime), '%H:%M');
@@ -64,119 +79,22 @@ export const ActivityListItem = memo((props: ActivityListItemProps) => {
         elevationUnit = 'm';
     }
 
-    const hasLogs = details?.logs && details.logs.length > 0;
-
     return (
-        <TouchableOpacity style={styles.container} onPress={handlePress} activeOpacity={0.7}>
-            <View style={styles.leftSection}>
-                {hasLogs ? (
-                    <ActivityGraphPreview width={80} height={64} activity={details} ftp={200} />
-                ) : (
-                    <View style={styles.placeholder} />
-                )}
-            </View>
-
-            <View style={styles.centerSection}>
-                <Text style={styles.title} numberOfLines={1}>
-                    {displayTitle}
-                </Text>
-                <Text style={styles.dateTime}>
-                    {dateStr}{'  '}{timeStr}{'  '}{durationStr}
-                </Text>
-            </View>
-
-            <View style={styles.metricsSection}>
-                <View style={styles.metricColumn}>
-                    <Image source={require('../../assets/icons/length.gif')} style={styles.metricIcon} />
-                    <Text style={styles.metricValue}>{distanceValue}</Text>
-                    <Text style={styles.metricUnit}>{distanceUnit}</Text>
-                </View>
-                {elevationValue !== '' && (
-                    <View style={styles.metricColumn}>
-                        <Image source={require('../../assets/icons/up.gif')} style={styles.metricIcon} />
-                        <Text style={styles.metricValue}>{elevationValue}</Text>
-                        <Text style={styles.metricUnit}>{elevationUnit}</Text>
-                    </View>
-                )}
-            </View>
-        </TouchableOpacity>
+        <ActivityListItemView
+            title={displayTitle}
+            dateStr={dateStr}
+            timeStr={timeStr}
+            durationStr={durationStr}
+            distanceValue={distanceValue}
+            distanceUnit={distanceUnit}
+            elevationValue={elevationValue}
+            elevationUnit={elevationUnit}
+            details={details}
+            compact={false}
+            outsideFold={outsideFold}
+            onPress={handlePress}
+        />
     );
 });
 
 ActivityListItem.displayName = 'ActivityListItem';
-
-const styles = StyleSheet.create({
-    container: {
-        height: ACTIVITY_LIST_ITEM_HEIGHT,
-        flexDirection: 'row',
-        alignItems: 'center',
-        backgroundColor: colors.listItemBackground,
-        paddingHorizontal: 12,
-        marginVertical: 4,
-        marginHorizontal: 12,
-        borderRadius: 8,
-    },
-    outsideFold: {
-        height: ACTIVITY_LIST_ITEM_HEIGHT,
-        marginVertical: 4,
-        marginHorizontal: 12,
-    },
-    leftSection: {
-        width: 80,
-        height: 64,
-        justifyContent: 'center',
-        alignItems: 'center',
-        borderRadius: 4,
-        overflow: 'hidden',
-    },
-    placeholder: {
-        width: 80,
-        height: 64,
-        backgroundColor: 'rgba(255, 255, 255, 0.05)',
-        borderRadius: 4,
-    },
-    centerSection: {
-        flex: 1,
-        paddingHorizontal: 12,
-        justifyContent: 'center',
-    },
-    title: {
-        color: colors.text,
-        fontSize: textSizes.normalText,
-        fontWeight: '600',
-    },
-    dateTime: {
-        color: colors.text,
-        fontSize: textSizes.smallText,
-        marginTop: 4,
-    },
-    metricsSection: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'flex-end',
-        gap: 12,
-        paddingRight: 8,
-    },
-    metricColumn: {
-        alignItems: 'center',
-        minWidth: 56,
-    },
-    metricIcon: {
-        width: 16,
-        height: 16,
-        tintColor: colors.text,
-    },
-    metricValue: {
-        color: colors.text,
-        fontSize: textSizes.normalText,
-        fontWeight: '600',
-        textAlign: 'center',
-        marginTop: 6,
-        marginBottom: 3,
-    },
-    metricUnit: {
-        color: colors.disabled,
-        fontSize: textSizes.smallText,
-        textAlign: 'center',
-    },
-});

--- a/src/components/ActivityListItem/ActivityListItem.tsx
+++ b/src/components/ActivityListItem/ActivityListItem.tsx
@@ -39,6 +39,10 @@ export const ActivityListItem = memo((props: ActivityListItemProps) => {
             setDetails(data);
         };
         observer.on('loaded', onLoaded);
+
+        return () => {
+            observer.off('loaded', onLoaded);
+        };
     }, [id, service, outsideFold, details]);
 
     const handlePress = useCallback(() => {

--- a/src/components/ActivityListItem/ActivityListItem.tsx
+++ b/src/components/ActivityListItem/ActivityListItem.tsx
@@ -37,11 +37,12 @@ export const ActivityListItem = memo((props: ActivityListItemProps) => {
         const onLoaded = (data: ActivityDetails) => {
             detailsCache.set(id, data);
             setDetails(data);
+            observer.stop()
         };
-        observer.on('loaded', onLoaded);
+        observer.once('loaded', onLoaded);
 
         return () => {
-            observer.off('loaded', onLoaded);
+            observer.stop()
         };
     }, [id, service, outsideFold, details]);
 

--- a/src/components/ActivityListItem/ActivityListItemView.test.tsx
+++ b/src/components/ActivityListItem/ActivityListItemView.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { ActivityListItemView } from './ActivityListItemView';
+import { ActivityListItemViewProps } from './types';
+
+const MOCK_PROPS: ActivityListItemViewProps = {
+    title: 'LaonParis',
+    dateStr: '31.03.2026',
+    timeStr: '12:32',
+    durationStr: '45min',
+    distanceValue: '32.4',
+    distanceUnit: 'km',
+    elevationValue: '420',
+    elevationUnit: 'm',
+    details: undefined,
+    compact: false,
+    outsideFold: false,
+    onPress: () => {},
+};
+
+describe('ActivityListItemView', () => {
+    it('renders normal layout', () => {
+        render(<ActivityListItemView {...MOCK_PROPS} />);
+    });
+
+    it('renders compact layout', () => {
+        render(<ActivityListItemView {...MOCK_PROPS} compact={true} />);
+    });
+
+    it('renders with details undefined', () => {
+        render(<ActivityListItemView {...MOCK_PROPS} details={undefined} />);
+    });
+
+    it('renders when outside fold', () => {
+        render(<ActivityListItemView {...MOCK_PROPS} outsideFold={true} />);
+    });
+});

--- a/src/components/ActivityListItem/ActivityListItemView.tsx
+++ b/src/components/ActivityListItem/ActivityListItemView.tsx
@@ -1,0 +1,150 @@
+import React, { memo } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Image } from 'react-native';
+import { ActivityListItemViewProps, ACTIVITY_LIST_ITEM_HEIGHT } from './types';
+import { ActivityGraphPreview } from '../ActivityGraphPreview';
+import { colors, textSizes } from '../../theme';
+
+export const ActivityListItemView = memo((props: ActivityListItemViewProps) => {
+    const {
+        title,
+        dateStr,
+        timeStr,
+        durationStr,
+        distanceValue,
+        distanceUnit,
+        elevationValue,
+        elevationUnit,
+        details,
+        compact,
+        outsideFold,
+        onPress,
+    } = props;
+
+    if (outsideFold) {
+        return <View style={styles.outsideFold} />;
+    }
+
+    const hasLogs = details?.logs && details.logs.length > 0;
+    const containerStyle = [
+        styles.container,
+        compact && styles.compactContainer
+    ];
+
+    return (
+        <TouchableOpacity style={containerStyle} onPress={onPress} activeOpacity={0.7}>
+            <View style={styles.leftSection}>
+                {hasLogs ? (
+                    <ActivityGraphPreview width={80} height={64} activity={details} ftp={200} />
+                ) : (
+                    <View style={styles.placeholder} />
+                )}
+            </View>
+
+            <View style={styles.centerSection}>
+                <Text style={styles.title} numberOfLines={1}>
+                    {title}
+                </Text>
+                <Text style={styles.dateTime}>
+                    {dateStr}{'  '}{timeStr}{'  '}{durationStr}
+                </Text>
+            </View>
+
+            <View style={styles.metricsSection}>
+                <View style={styles.metricColumn}>
+                    <Image source={require('../../assets/icons/length.gif')} style={styles.metricIcon} />
+                    <Text style={styles.metricValue}>{distanceValue}</Text>
+                    <Text style={styles.metricUnit}>{distanceUnit}</Text>
+                </View>
+                {elevationValue !== '' && (
+                    <View style={styles.metricColumn}>
+                        <Image source={require('../../assets/icons/up.gif')} style={styles.metricIcon} />
+                        <Text style={styles.metricValue}>{elevationValue}</Text>
+                        <Text style={styles.metricUnit}>{elevationUnit}</Text>
+                    </View>
+                )}
+            </View>
+        </TouchableOpacity>
+    );
+});
+
+ActivityListItemView.displayName = 'ActivityListItemView';
+
+const styles = StyleSheet.create({
+    container: {
+        height: ACTIVITY_LIST_ITEM_HEIGHT,
+        flexDirection: 'row',
+        alignItems: 'center',
+        backgroundColor: colors.listItemBackground,
+        paddingHorizontal: 12,
+        marginVertical: 4,
+        marginHorizontal: 12,
+        borderRadius: 8,
+    },
+    compactContainer: {
+        height: 64,
+        marginVertical: 2,
+    },
+    outsideFold: {
+        height: ACTIVITY_LIST_ITEM_HEIGHT,
+        marginVertical: 4,
+        marginHorizontal: 12,
+    },
+    leftSection: {
+        width: 80,
+        height: 64,
+        justifyContent: 'center',
+        alignItems: 'center',
+        borderRadius: 4,
+        overflow: 'hidden',
+    },
+    placeholder: {
+        width: 80,
+        height: 64,
+        backgroundColor: 'rgba(255, 255, 255, 0.05)',
+        borderRadius: 4,
+    },
+    centerSection: {
+        flex: 1,
+        paddingHorizontal: 12,
+        justifyContent: 'center',
+    },
+    title: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        fontWeight: '600',
+    },
+    dateTime: {
+        color: colors.text,
+        fontSize: textSizes.smallText,
+        marginTop: 4,
+    },
+    metricsSection: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'flex-end',
+        gap: 12,
+        paddingRight: 8,
+    },
+    metricColumn: {
+        alignItems: 'center',
+        minWidth: 56,
+    },
+    metricIcon: {
+        width: 16,
+        height: 16,
+        tintColor: colors.text,
+    },
+    metricValue: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        fontWeight: '600',
+        textAlign: 'center',
+        marginTop: 6,
+        marginBottom: 3,
+    },
+    metricUnit: {
+        color: colors.disabled,
+        fontSize: textSizes.smallText,
+        textAlign: 'center',
+    },
+});

--- a/src/components/ActivityListItem/index.ts
+++ b/src/components/ActivityListItem/index.ts
@@ -1,2 +1,3 @@
 export * from './ActivityListItem';
 export * from './types';
+export * from './ActivityListItemView';

--- a/src/components/ActivityListItem/types.ts
+++ b/src/components/ActivityListItem/types.ts
@@ -1,9 +1,24 @@
-import { ActivityInfoUI } from 'incyclist-services';
+import { ActivityInfoUI, ActivityDetails } from 'incyclist-services';
 
 export interface ActivityListItemProps {
     activityInfo: ActivityInfoUI;
     onPress: (id: string) => void;
     outsideFold?: boolean;
+}
+
+export interface ActivityListItemViewProps {
+    title: string;
+    dateStr: string;
+    timeStr: string;
+    durationStr: string;
+    distanceValue: string;
+    distanceUnit: string;
+    elevationValue: string;
+    elevationUnit: string;
+    details: ActivityDetails | undefined;
+    compact: boolean;
+    outsideFold: boolean;
+    onPress: () => void;
 }
 
 export const ACTIVITY_LIST_ITEM_HEIGHT = 72;

--- a/src/pages/ActivitiesPage/ActivitiesPage.test.tsx
+++ b/src/pages/ActivitiesPage/ActivitiesPage.test.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { render } from '@testing-library/react-native';
 import { ActivitiesPage } from './ActivitiesPage';
 
-jest.mock('../../components/ActivityDetailsDialog', () => ({
-    ActivityDetailsDialog: () => null,
-}))
-
 jest.mock('../../services', () => ({
     navigate: jest.fn(),
-}))
+}));
+
+jest.mock('../../components/ActivityDetailsDialog', () => ({
+    ActivityDetailsDialog: () => null,
+}));
 
 jest.mock('incyclist-services', () => ({
     getActivitiesPageService: () => ({
@@ -28,7 +28,7 @@ jest.mock('../../components', () => ({
     MainBackground: ({ children }: any) => children,
     NavigationBar: () => null,
     ActivitiesTable: () => null,
-}))
+}));
 
 describe('ActivitiesPage', () => {
     it('renders without crashing when observer is null', () => {


### PR DESCRIPTION
Closes #248

Refactors `ActivityListItem` to follow the smart/view component pattern.

### Changes:
- Created `ActivityListItemView` as a pure functional component focusing on UI.
- Rewrote `ActivityListItem` (smart component) to handle data orchestration, service interaction, and caching.
- Implemented a module-level `detailsCache` to persist activity details across remounts and list recycling.
- Added an `outsideFold` guard to prevent triggering expensive details fetching for off-screen items.
- Added `ActivityListItemView.test.tsx` for render-only testing of the view component.
- Updated Storybook stories to target `ActivityListItemView` with appropriate exploded props.