### PR TITLE
Add Storybook mock for @kesha-antonov/react-native-background-downloader

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -109,6 +109,7 @@ const config: StorybookConfig = {
                     'react-native-device-info': path.resolve(dirname, 'mocks/react-native-device-info.ts'),
                     '@zoontek/react-native-navigation-bar': path.resolve(dirname, 'mocks/react-native-navigation-bar.tsx'),
                     'react-native-permissions': path.resolve(dirname, 'mocks/react-native-permissions.ts'),
+                    '@kesha-antonov/react-native-background-downloader': path.resolve(dirname, 'mocks/react-native-background-downloader.ts'),
                     //'react-native-fs':               'react-native-web/dist/exports/View',
                     'react-native-fs': path.resolve(dirname, './emptyStub.ts'),
                     '@settings':                     'react-native-web/dist/exports/View',

--- a/.storybook/mocks/react-native-background-downloader.ts
+++ b/.storybook/mocks/react-native-background-downloader.ts
@@ -1,0 +1,21 @@
+const createDownloadTask = (_opts: unknown) => ({
+    begin: function (this: any, _cb: unknown) {
+        return this;
+    },
+    progress: function (this: any, _cb: unknown) {
+        return this;
+    },
+    done: function (this: any, _cb: unknown) {
+        return this;
+    },
+    error: function (this: any, _cb: unknown) {
+        return this;
+    },
+    stop: () => {},
+});
+
+const getExistingDownloadTasks = () => [];
+
+const directories = { documents: '/mock/documents' };
+
+export { createDownloadTask, getExistingDownloadTasks, directories };


### PR DESCRIPTION
Closes #242

This PR adds a Storybook mock for `@kesha-antonov/react-native-background-downloader` and registers it in the Storybook Vite configuration aliases. This prevents crashes when rendering components that depend on the background downloader binding in the Storybook environment.