### PR TITLE
Add Download button and DownloadModal to RouteDetailsDialog

### DIFF
--- a/ios/Incyclist/Info.plist
+++ b/ios/Incyclist/Info.plist
@@ -57,6 +57,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>bluetooth-central</string>
+		<string>fetch</string>
 	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>

--- a/src/bindings/download/index.ts
+++ b/src/bindings/download/index.ts
@@ -1,103 +1,116 @@
 import RNFS from 'react-native-fs';
+import { Platform } from 'react-native'
 import { EventEmitter } from 'events';
 import { createDownloadTask } from '@kesha-antonov/react-native-background-downloader';
 import path from 'path-browserify';
 import { IDownloadManager, IDownloadSession, DownloadProps } from 'incyclist-services';
+import { EventLogger } from 'gd-eventlog';
 
 export class MobileDownloadSession extends EventEmitter implements IDownloadSession {
     private task?: any;
     private lastUpdate: number = 0;
     private lastBytes: number = 0;
     private stopped: boolean = false;
+    private logger = new EventLogger('MobileDownloadSession')
 
     constructor(private url: string, private fileName: string) {
         super();
     }
 
     public start(): void {
+        this.logger.logEvent({message: 'DownloadSession start', url: this.url})
+
         if (this.task) {
             this.attachHandlers();
             return;
         }
 
-        const videoDir = RNFS.DocumentDirectoryPath + '/videos';
+        const videoDir = path.parse(this.fileName).dir
+
+
         RNFS.mkdir(videoDir)
             .then(() => {
-                if (this.stopped) {
-                    return;
-                }
+                if (this.stopped) return;
 
-                // Use the route ID (filename without extension) as the task ID
                 const id = path.parse(this.fileName).name;
-
                 this.task = createDownloadTask({
                     id,
                     url: this.url,
                     destination: this.fileName,
                     metadata: {},
-                });
+                    isAllowedOverRoaming: true,
+                    isAllowedOverMetered: true,
+                })
 
                 this.attachHandlers();
             })
             .catch((err) => {
+                this.logger.logEvent({message: 'DownloadSession mkdir error', error: err.message})
                 this.emit('error', err);
             });
     }
 
     public stop(): void {
+        this.logger.logEvent({message: 'DownloadSession stop', url: this.url})
         this.stopped = true;
         if (this.task) {
             this.task.stop();
         }
+        this.emit('stopped')
     }
 
     private attachHandlers(): void {
-        if (!this.task) {
-            return;
-        }
+        if (!this.task) return;
 
-        this.task.begin(({ expectedBytes: _expectedBytes }: { expectedBytes: number }) => {
-            if (this.stopped) {
-                return;
-            }
-            this.emit('started');
-        })
-        .progress(({ bytesDownloaded, bytesTotal }: { bytesDownloaded: number, bytesTotal: number }) => {
-            if (this.stopped) {
-                return;
-            }
+        let ts=0, prev=0
 
-            const now = Date.now();
-            let speed = '0.0 MB/s';
-            if (this.lastUpdate > 0) {
-                const duration = (now - this.lastUpdate) / 1000;
-                if (duration > 0) {
-                    const bps = (bytesDownloaded - this.lastBytes) / duration;
-                    const mbps = bps / 1024 / 1024;
-                    speed = `${mbps.toFixed(1)} MB/s`;
+        this.task
+            .begin(({ expectedBytes: _expectedBytes }: { expectedBytes: number }) => {
+                this.logger.logEvent({message: 'DownloadSession download has started', url: this.url})
+                if (this.stopped) return;
+                this.emit('started');
+            })
+            .progress(({ bytesDownloaded, bytesTotal }: { bytesDownloaded: number, bytesTotal: number }) => {
+                if (this.stopped) return;
+
+                const now = Date.now();
+                let speed = '0.0 MB/s';
+                if (this.lastUpdate > 0) {
+                    const duration = (now - this.lastUpdate) / 1000;
+                    if (duration > 0) {
+                        const bps = (bytesDownloaded - this.lastBytes) / duration;
+                        speed = `${(bps / 1024 / 1024).toFixed(1)} MB/s`;
+                    }
                 }
-            }
+                this.lastUpdate = now;
+                this.lastBytes = bytesDownloaded;
 
-            this.lastUpdate = now;
-            this.lastBytes = bytesDownloaded;
+                const pct = bytesTotal > 0
+                    ? ((bytesDownloaded / bytesTotal) * 100).toFixed(1)
+                    : '0.0';
 
-            const pct = bytesTotal > 0 ? ((bytesDownloaded / bytesTotal) * 100).toFixed(1) : '0.0';
-            
-            this.emit('progress', pct, speed, bytesDownloaded);
-        })
-        .done(() => {
-            if (this.stopped) {
-                return;
-            }
-            // Prefix with video:/// as expected by RouteCard.onDownloadCompleted
-            this.emit('done', `video:///${this.fileName}`);
-        })
-        .error((error: any) => {
-            if (this.stopped) {
-                return;
-            }
-            this.emit('error', error);
-        });
+                // log progress only every 10 seconds
+                ts = Date.now()
+                if (ts-prev>10000) {                
+                    this.logger.logEvent({message: 'DownloadSession progress', pct, speed, bytesDownloaded})
+                    prev = ts
+                }
+                this.emit('progress', pct, speed, bytesDownloaded);
+            })
+            .done(() => {
+                this.logger.logEvent({message: 'DownloadSession done', url: this.url})
+                if (this.stopped) return;
+                this.emit('done', `video:///${this.fileName}`);
+            })
+            .error(({ error, errorCode }: { error: string, errorCode: number }) => {
+                this.logger.logEvent({message: 'DownloadSession error', url: this.url, error, errorCode})
+                if (this.stopped) return;
+                this.emit('error', new Error(error));
+            })
+
+        this.logger.logEvent({message: 'DownloadSession start download', url: this.url})
+
+        this.task.start()
     }
 }
 
@@ -106,10 +119,14 @@ export class MobileDownloadManager implements IDownloadManager {
         return new MobileDownloadSession(url, fileName);
     }
 
-    /**
-     * Returns the fixed video directory for mobile.
-     */
     public getVideoDir(): string {
-        return RNFS.DocumentDirectoryPath + '/videos';
+        return getDownloadVideoDir()
     }
+}
+
+
+export const getDownloadVideoDir = ():string =>  {
+    return (Platform.OS === 'android'
+        ? RNFS.ExternalDirectoryPath
+        : RNFS.DocumentDirectoryPath) + '/videos'
 }

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -28,6 +28,7 @@ export const Dialog = ({
     buttons,
     children,
     visible = true,
+    nested = false,
     onOutsideClick,
     slideFrom,
 }: PropsWithChildren<DialogProps>) => {
@@ -114,7 +115,7 @@ export const Dialog = ({
         }
     });
 
-    const styles = getStyles({ width, height, minWidth, minHeight, variant, isCompact, stripHeight });
+    const styles = getStyles({ width, height, minWidth, minHeight, variant, isCompact, stripHeight,nested });
 
     const gradientColors = colors.dialogBackground;
 
@@ -226,10 +227,11 @@ type StyleProps = {
     height: number | undefined,
     minWidth: DimensionValue | undefined,
     minHeight: DimensionValue | undefined,
-    variant?: DialogVariant
+    variant?: DialogVariant,
+    nested?: boolean
 }
 
-const getStyles = ({ width, height, minWidth, minHeight, variant = 'details', isCompact, stripHeight }: StyleProps & { isCompact: boolean, stripHeight: number }) => {
+const getStyles = ({ width, height, minWidth, minHeight, variant = 'details', isCompact, stripHeight,nested=false }: StyleProps & { isCompact: boolean, stripHeight: number }) => {
     const isInfoVariant = variant === 'info';
     
     return StyleSheet.create({
@@ -249,15 +251,14 @@ const getStyles = ({ width, height, minWidth, minHeight, variant = 'details', is
             overflow: 'hidden',
             color: colors.text,
             // Shadow and thin white frame for info variant only
-            ...(isInfoVariant && {
+            ...( (isInfoVariant||nested) && {
                 borderWidth: 1,
                 borderColor: 'white',
-                // Subtle shadow to create floating effect
                 shadowColor: '#000',
-                shadowOffset: { width: 4, height: 4 },
+                shadowOffset: { width: 4, height: 8 },
                 shadowOpacity: 0.75,
-                shadowRadius: 12,
-                elevation: 5,
+                shadowRadius: 16,
+                elevation: 24,
             }),
         },
         header: {

--- a/src/components/Dialog/types.ts
+++ b/src/components/Dialog/types.ts
@@ -14,6 +14,7 @@ export interface DialogProps {
     visible?: boolean;
     buttons?: Array<ButtonProps>;
     style?: StyleProp<ViewStyle>;
+    nested?: boolean;
     titleStyle?: StyleProp<TextStyle>;
     slideFrom?: 'left'; // only applies to variant='full'
 }

--- a/src/components/DownloadModal/DownloadModalView.tsx
+++ b/src/components/DownloadModal/DownloadModalView.tsx
@@ -76,6 +76,7 @@ const DownloadRow = memo(({ row, onStop, onRetry, onDelete }: DownloadRowProps) 
 export const DownloadModalView = memo(({
     visible,
     rows,
+    nested,
     onStop,
     onRetry,
     onDelete,
@@ -84,6 +85,7 @@ export const DownloadModalView = memo(({
     return (
         <Dialog
             title="Downloads"
+            nested={nested}
             visible={visible}
             variant="details"
             onOutsideClick={onClose}

--- a/src/components/DownloadModal/DownloadModalView.tsx
+++ b/src/components/DownloadModal/DownloadModalView.tsx
@@ -4,6 +4,7 @@ import { Dialog } from '../Dialog';
 import { colors, textSizes } from '../../theme';
 import { DownloadModalViewProps } from './types';
 import { DownloadRowDisplayProps } from 'incyclist-services';
+import { useLogging } from '../../hooks';
 
 interface DownloadRowProps {
     row: DownloadRowDisplayProps;
@@ -13,11 +14,25 @@ interface DownloadRowProps {
 }
 
 const DownloadRow = memo(({ row, onStop, onRetry, onDelete }: DownloadRowProps) => {
+    const {logEvent} = useLogging('RoutesDownload')
     const { routeId, title, status, pct } = row;
 
-    const handleStop = useCallback(() => onStop(routeId), [onStop, routeId]);
-    const handleRetry = useCallback(() => onRetry(routeId), [onRetry, routeId]);
-    const handleDelete = useCallback(() => onDelete(routeId), [onDelete, routeId]);
+    const handleStop = useCallback(() => {
+        logEvent( {message:'button clicked', button:'stop', routeId, eventSource:'user'  })
+        onStop(routeId)
+    },[logEvent, onStop, routeId]);
+
+    const handleRetry = useCallback(() => { 
+        logEvent( {message:'button clicked', button:'retry',routeId, eventSource:'user'  })
+        onRetry(routeId)
+    },[logEvent, onRetry, routeId]);
+
+    const handleDelete = useCallback(() => {
+        logEvent( {message:'button clicked', button:'delete',routeId,  eventSource:'user'  })
+        onDelete(routeId)
+    },[logEvent, onDelete, routeId]);
+
+    const progressWidth = `${Math.min(100, Math.max(0, pct ?? 0))}%` as `${number}%`;
 
     return (
         <View style={styles.row}>
@@ -26,9 +41,12 @@ const DownloadRow = memo(({ row, onStop, onRetry, onDelete }: DownloadRowProps) 
                     {title}
                 </Text>
                 {status === 'downloading' && (
-                    <View style={styles.progressContainer}>
-                        <View style={[styles.progressBar, { width: `${pct ?? 0}%` }]} />
-                    </View>
+                    <>
+                        <View style={styles.progressContainer}>
+                            <View style={[styles.progressBar, { width: progressWidth }]} />
+                        </View>
+                        <Text style={styles.pctText}>{pct ?? 0}%</Text>
+                    </>
                 )}
                 {status === 'done' && (
                     <Text style={[styles.statusText, { color: colors.success }]}>
@@ -60,7 +78,7 @@ const DownloadRow = memo(({ row, onStop, onRetry, onDelete }: DownloadRowProps) 
                 )}
                 {status === 'failed' && (
                     <TouchableOpacity style={styles.actionButton} onPress={handleRetry}>
-                        <Text style={styles.actionButtonText}>Retry</Text>
+                        <Text style={styles.actionButtonText}>Retry Download</Text>
                     </TouchableOpacity>
                 )}
                 {status === 'required' && (
@@ -145,6 +163,11 @@ const styles = StyleSheet.create({
     },
     statusText: {
         fontSize: textSizes.smallText,
+    },
+    pctText: {
+        color: colors.disabled,
+        fontSize: textSizes.smallText,
+        marginTop: 2,
     },
     progressContainer: {
         height: 4,

--- a/src/components/DownloadModal/types.ts
+++ b/src/components/DownloadModal/types.ts
@@ -3,6 +3,7 @@ import { DownloadRowDisplayProps } from 'incyclist-services';
 export interface DownloadModalViewProps {
     visible: boolean;
     rows: DownloadRowDisplayProps[];
+    nested?:boolean,
     onStop: (routeId: string) => void;
     onRetry: (routeId: string) => void;
     onDelete: (routeId: string) => void;

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.stories.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.stories.tsx
@@ -117,3 +117,65 @@ export const CompactWithMap: Story = {
         ],
     }),
 };
+export const DownloadRequired: Story = {
+    args: mockRouteProps({
+        canStart: false,
+        downloadButtonLabel: 'Download',
+        downloadButtonPrimary: true,
+        downloadButtonDisabled: false,
+        onDownloadPress: fn(),
+        onDownloadModalClose: fn(),
+        downloadRows: [],
+        onDownloadStop: fn(),
+        onDownloadRetry: fn(),
+        onDownloadDelete: fn(),
+    }),
+};
+
+export const WithDownloadButton: Story = {
+    args: mockRouteProps({
+        downloadButtonLabel: 'Download',
+        downloadButtonDisabled: false,
+        onDownloadPress: fn(),
+    }),
+};
+
+export const Downloading: Story = {
+    args: mockRouteProps({
+        downloadButtonLabel: 'Downloading…',
+        downloadButtonDisabled: true,
+        onDownloadPress: fn(),
+    }),
+};
+
+export const Downloaded: Story = {
+    args: mockRouteProps({
+        downloadButtonLabel: 'Downloaded ✓',
+        downloadButtonDisabled: false,
+        onDownloadPress: fn(),
+    }),
+};
+
+export const DownloadFailed: Story = {
+    args: mockRouteProps({
+        downloadButtonLabel: 'Retry Download',
+        downloadButtonDisabled: false,
+        onDownloadPress: fn(),
+    }),
+};
+
+export const DownloadModalOpen: Story = {
+    args: mockRouteProps({
+        downloadButtonLabel: 'Downloading…',
+        downloadButtonDisabled: true,
+        onDownloadPress: fn(),
+        showDownloadModal: true,
+        onDownloadModalClose: fn(),
+        downloadRows: [
+            { routeId: 'r1', title: 'Alblasserwaard (SD)', status: 'downloading', pct: 45 },
+        ],
+        onDownloadStop: fn(),
+        onDownloadRetry: fn(),
+        onDownloadDelete: fn(),
+    }),
+};

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
@@ -1,46 +1,46 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useWindowDimensions } from 'react-native';
-import RNFS from 'react-native-fs';
-import { useRouteList, useActivityList } from 'incyclist-services';
+import { useRouteList, useActivityList  } from 'incyclist-services';
 import type { DownloadRowDisplayProps, UIRouteSettings, UIStartSettings } from 'incyclist-services';
 import { useLogging, useUnmountEffect } from '../../hooks';
 import { RouteDetailsView } from './RouteDetailsView';
 import { RouteDetailsDialogProps } from './types';
 
-export const RouteDetailsDialog = ({ routeId,onStart }:RouteDetailsDialogProps ) => {
+export const RouteDetailsDialog = ({ routeId, onStart }: RouteDetailsDialogProps) => {
     const { height } = useWindowDimensions();
     const compact = height < 420;
-    
+
     const service = useRouteList();
     const activities = useActivityList();
     const card = service.getCard(routeId);
-    
+
     const { logEvent } = useLogging('RouteDetailsDialog');
     const refMounted = useRef(true);
     const refInitialized = useRef(false);
     const refDownloadObserver = useRef<any>(null);
-    
+
     const [cardProps, setCardProps] = useState(() => card?.openSettings());
     const [loading, setLoading] = useState(false);
     const [prevRides, setPrevRides] = useState<any[] | null>(null);
     const [showPrev, setShowPrev] = useState(false);
+    const [showDownloadModal, setShowDownloadModal] = useState(false);
 
     const route = card?.getData();
     const routeDescr = route?.description;
 
-    const [downloadStatus, setDownloadStatus] = useState<'none' | 'downloading' | 'done' | 'failed'>(() => {
-        if (routeDescr?.isDownloaded) return 'done';
-        if (card?.getCurrentDownload()) return 'downloading';
-        return 'none';
+    // Full download row state — carries pct so progress bar updates correctly
+    const [downloadRow, setDownloadRow] = useState<DownloadRowDisplayProps | null>(() => {
+        if (routeDescr?.isDownloaded) return { routeId, title: routeDescr.title ?? '', status: 'done' }
+        if (card?.getCurrentDownload()) return { routeId, title: routeDescr?.title ?? '', status: 'downloading' }
+        return null
     });
-    const [showDownloadModal, setShowDownloadModal] = useState(false);
 
     const refreshPrevRides = useCallback(async (settings: UIRouteSettings) => {
         if (!card) return { prevRides: undefined, showPrev: false };
         const data = card.getData();
         const routeHash = data.description.routeHash;
         const rId = !routeHash ? data.description.id : undefined;
-        
+
         const prev = await activities.getPastActivitiesWithDetails({
             routeHash,
             routeId: rId,
@@ -50,7 +50,7 @@ export const RouteDetailsDialog = ({ routeId,onStart }:RouteDetailsDialogProps )
         });
 
         if (!refMounted.current) return { prevRides: undefined, showPrev: false };
-        
+
         const hasPrev = prev?.length > 0;
         setPrevRides(hasPrev ? prev : null);
         setShowPrev(hasPrev);
@@ -60,12 +60,12 @@ export const RouteDetailsDialog = ({ routeId,onStart }:RouteDetailsDialogProps )
     useEffect(() => {
         if (!card || refInitialized.current) return;
         refInitialized.current = true;
-        
+
         const currentProps = card.openSettings();
         setCardProps(currentProps);
-        
+
         const data = card.getData();
-        
+
         if (!data.details) {
             setLoading(true);
             service.getRouteDetails(routeId)
@@ -74,43 +74,58 @@ export const RouteDetailsDialog = ({ routeId,onStart }:RouteDetailsDialogProps )
         }
 
         refreshPrevRides(currentProps.settings as UIRouteSettings);
-        logEvent({ message: 'dialog shown', title:'select route',route: data.description.title });
+        logEvent({ message: 'dialog shown', title: 'select route', route: data.description.title });
     }, [routeId, card, service, refreshPrevRides, logEvent]);
 
-    useEffect(() => {
-        if (!card) return;
-        
-        const subscribe = (observer: any) => {
-            if (!observer || refDownloadObserver.current === observer) return;
-            refDownloadObserver.current = observer;
+    const subscribeToObserver = useCallback((observer: any) => {
+        if (!observer || refDownloadObserver.current === observer) return;
+        refDownloadObserver.current = observer;
 
-            const onProgress = () => setDownloadStatus('downloading');
-            const onDone = () => {
-                setDownloadStatus('done');
-                refDownloadObserver.current = null;
-            };
-            const onError = () => {
-                setDownloadStatus('failed');
-                refDownloadObserver.current = null;
-            };
+        const title = routeDescr?.title ?? '';
 
-            observer.on('progress', onProgress);
-            observer.on('done', onDone);
-            observer.on('error', onError);
-
-            return () => {
-                observer.off('progress', onProgress);
-                observer.off('done', onDone);
-                observer.off('error', onError);
-                refDownloadObserver.current = null;
-            };
+        const onProgress = (pct: string, _speed: string) => {
+            setDownloadRow({
+                routeId,
+                title,
+                status: 'downloading',
+                pct: parseFloat(pct),                
+            })
+        };
+        const onDone = () => {
+            setDownloadRow({ routeId, title, status: 'done' });
+            refDownloadObserver.current = null;
+        };
+        const onError = () => {
+            setDownloadRow({ routeId, title, status: 'failed' });
+            refDownloadObserver.current = null;
+        };
+        const onStopped = () => {
+            setDownloadRow(null);
+            refDownloadObserver.current = null;
         };
 
+        observer.on('progress', onProgress);
+        observer.on('done', onDone);
+        observer.on('error', onError);
+        observer.on('stopped', onStopped);
+
+        return () => {
+            observer.off('progress', onProgress);
+            observer.off('done', onDone);
+            observer.off('error', onError);
+            observer.off('stopped', onStopped);
+            refDownloadObserver.current = null;
+        };
+    }, [routeId, routeDescr]);
+
+    // Subscribe to any already-active download observer on mount
+    useEffect(() => {
+        if (!card) return;
         const currentObserver = card.getCurrentDownload();
         if (currentObserver) {
-            return subscribe(currentObserver);
+            return subscribeToObserver(currentObserver);
         }
-    }, [card]);
+    }, [card, subscribeToObserver]);
 
     useUnmountEffect(() => {
         refMounted.current = false;
@@ -118,21 +133,22 @@ export const RouteDetailsDialog = ({ routeId,onStart }:RouteDetailsDialogProps )
 
     if (!card || !cardProps || !routeDescr) return null;
 
-    const { 
-        totalDistance, 
-        totalElevation, 
-        showLoopOverwrite, 
-        showNextOverwrite, 
-        hasWorkout, 
-        canStart: cardCanStart, 
-        updateStartPos, 
-        settings 
+    const {
+        totalDistance,
+        totalElevation,
+        showLoopOverwrite,
+        showNextOverwrite,
+        hasWorkout,
+        canStart: cardCanStart,
+        updateStartPos,
+        settings
     } = cardProps;
 
     const { hasVideo, hasGpx, isLoop, videoFormat, previewUrl, segments } = routeDescr;
     const points = route.details?.points ?? route.points;
     const routeType = `${hasVideo ? 'Video' : 'GPX'} - ${isLoop ? 'Loop' : 'Point to Point'}`;
     const isAvi = videoFormat?.toLowerCase() === 'avi';
+    const downloadStatus = downloadRow?.status ?? 'none'
     const canStart = !isAvi && (cardCanStart ?? true) && downloadStatus !== 'downloading';
     const canNotStartReason = isAvi ? 'AVI videos are not supported on mobile' : undefined;
 
@@ -157,48 +173,40 @@ export const RouteDetailsDialog = ({ routeId,onStart }:RouteDetailsDialogProps )
 
     const onDownloadPress = useCallback(() => {
         if (downloadStatus === 'none' || downloadStatus === 'failed') {
-            const videoDir = RNFS.DocumentDirectoryPath + '/videos';
-            card.setVideoDir(videoDir);
-            card.download();
-            logEvent({ 
-                message: 'button clicked', 
-                button: downloadStatus === 'failed' ? 'download-retry' : 'download', 
-                eventSource: 'user' 
-            });
-        } else {
-            logEvent({ message: 'button clicked', button: 'download', eventSource: 'user' });
+            const observer = card.download();
+            setDownloadRow({ routeId, title: routeDescr.title ?? '', status: 'downloading' });
+            subscribeToObserver(observer);
         }
         setShowDownloadModal(true);
-    }, [card, downloadStatus, logEvent]);
+    }, [card, downloadStatus, routeId, routeDescr, subscribeToObserver]);
 
     const onDownloadModalClose = useCallback(() => {
         setShowDownloadModal(false);
     }, []);
 
     const onDownloadStop = useCallback((id: string) => {
-        service.getCard(id)?.stopDownload();
+        const c = service.getCard(id)
+        if (c) {
+            c.stopDownload(true);
+        }
     }, [service]);
 
     const onDownloadRetry = useCallback((id: string) => {
         const c = service.getCard(id);
         if (c) {
-            const videoDir = RNFS.DocumentDirectoryPath + '/videos';
-            c.setVideoDir(videoDir);
-            c.download();
+            const observer = c.download();
+            setDownloadRow({ routeId, title: routeDescr.title ?? '', status: 'downloading' });
+            subscribeToObserver(observer);
         }
-    }, [service]);
+    }, [service, routeId, routeDescr, subscribeToObserver]);
 
     const onDownloadDelete = useCallback((id: string) => {
         service.getCard(id)?.delete();
+        setDownloadRow(null);
     }, [service]);
 
-    const downloadRows: DownloadRowDisplayProps[] = downloadStatus !== 'none' ? [{
-        routeId,
-        title: routeDescr.title ?? '',
-        status: downloadStatus,
-    }] : []
-
-    const downloadButtonPrimary = routeDescr.requiresDownload === true
+    const downloadRows: DownloadRowDisplayProps[] = downloadRow ? [downloadRow] : [];
+    const downloadButtonPrimary = routeDescr.requiresDownload === true;
 
     return (
         <RouteDetailsView

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useWindowDimensions } from 'react-native';
+import RNFS from 'react-native-fs';
 import { useRouteList, useActivityList } from 'incyclist-services';
 import type { UIRouteSettings, UIStartSettings } from 'incyclist-services';
 import { useLogging, useUnmountEffect } from '../../hooks';
@@ -16,18 +17,29 @@ export const RouteDetailsDialog = ({ routeId,onStart }:RouteDetailsDialogProps )
     
     const { logEvent } = useLogging('RouteDetailsDialog');
     const refMounted = useRef(true);
-    const refInitialized = useRef(false)
+    const refInitialized = useRef(false);
+    const refDownloadObserver = useRef<any>(null);
     
     const [cardProps, setCardProps] = useState(() => card?.openSettings());
     const [loading, setLoading] = useState(false);
     const [prevRides, setPrevRides] = useState<any[] | null>(null);
     const [showPrev, setShowPrev] = useState(false);
 
+    const route = card?.getData();
+    const routeDescr = route?.description;
+
+    const [downloadStatus, setDownloadStatus] = useState<'none' | 'downloading' | 'done' | 'failed'>(() => {
+        if (routeDescr?.isDownloaded) return 'done';
+        if (card?.getCurrentDownload()) return 'downloading';
+        return 'none';
+    });
+    const [showDownloadModal, setShowDownloadModal] = useState(false);
+
     const refreshPrevRides = useCallback(async (settings: UIRouteSettings) => {
         if (!card) return { prevRides: undefined, showPrev: false };
-        const route = card.getData();
-        const routeHash = route.description.routeHash;
-        const rId = !routeHash ? route.description.id : undefined;
+        const data = card.getData();
+        const routeHash = data.description.routeHash;
+        const rId = !routeHash ? data.description.id : undefined;
         
         const prev = await activities.getPastActivitiesWithDetails({
             routeHash,
@@ -52,9 +64,9 @@ export const RouteDetailsDialog = ({ routeId,onStart }:RouteDetailsDialogProps )
         const currentProps = card.openSettings();
         setCardProps(currentProps);
         
-        const route = card.getData();
+        const data = card.getData();
         
-        if (!route.details) {
+        if (!data.details) {
             setLoading(true);
             service.getRouteDetails(routeId)
                 .then(() => { if (refMounted.current) setLoading(false); })
@@ -62,14 +74,49 @@ export const RouteDetailsDialog = ({ routeId,onStart }:RouteDetailsDialogProps )
         }
 
         refreshPrevRides(currentProps.settings as UIRouteSettings);
-        logEvent({ message: 'dialog shown', title:'select route',route: route.description.title });
+        logEvent({ message: 'dialog shown', title:'select route',route: data.description.title });
     }, [routeId, card, service, refreshPrevRides, logEvent]);
+
+    useEffect(() => {
+        if (!card) return;
+        
+        const subscribe = (observer: any) => {
+            if (!observer || refDownloadObserver.current === observer) return;
+            refDownloadObserver.current = observer;
+
+            const onProgress = () => setDownloadStatus('downloading');
+            const onDone = () => {
+                setDownloadStatus('done');
+                refDownloadObserver.current = null;
+            };
+            const onError = () => {
+                setDownloadStatus('failed');
+                refDownloadObserver.current = null;
+            };
+
+            observer.on('progress', onProgress);
+            observer.on('done', onDone);
+            observer.on('error', onError);
+
+            return () => {
+                observer.off('progress', onProgress);
+                observer.off('done', onDone);
+                observer.off('error', onError);
+                refDownloadObserver.current = null;
+            };
+        };
+
+        const currentObserver = card.getCurrentDownload();
+        if (currentObserver) {
+            return subscribe(currentObserver);
+        }
+    }, [card]);
 
     useUnmountEffect(() => {
         refMounted.current = false;
     });
 
-    if (!card || !cardProps) return null;
+    if (!card || !cardProps || !routeDescr) return null;
 
     const { 
         totalDistance, 
@@ -82,14 +129,71 @@ export const RouteDetailsDialog = ({ routeId,onStart }:RouteDetailsDialogProps )
         settings 
     } = cardProps;
 
-    const route = card.getData();
-    const routeDescr = route.description;
     const { hasVideo, hasGpx, isLoop, videoFormat, previewUrl, segments } = routeDescr;
     const points = route.details?.points ?? route.points;
     const routeType = `${hasVideo ? 'Video' : 'GPX'} - ${isLoop ? 'Loop' : 'Point to Point'}`;
     const isAvi = videoFormat?.toLowerCase() === 'avi';
-    const canStart = !isAvi && (cardCanStart ?? true);
+    const canStart = !isAvi && (cardCanStart ?? true) && downloadStatus !== 'downloading';
     const canNotStartReason = isAvi ? 'AVI videos are not supported on mobile' : undefined;
+
+    const hasDownloadUrl = !!(routeDescr.downloadUrl || (routeDescr.videoUrl?.startsWith('https://')));
+    const showDownloadButton = hasDownloadUrl || routeDescr.requiresDownload === true;
+
+    let downloadButtonLabel: string | undefined;
+    let downloadButtonDisabled = false;
+
+    if (showDownloadButton) {
+        if (downloadStatus === 'downloading') {
+            downloadButtonLabel = 'Downloading…';
+            downloadButtonDisabled = true;
+        } else if (downloadStatus === 'done') {
+            downloadButtonLabel = 'Downloaded ✓';
+        } else if (downloadStatus === 'failed') {
+            downloadButtonLabel = 'Retry';
+        } else {
+            downloadButtonLabel = 'Download';
+        }
+    }
+
+    const onDownloadPress = useCallback(() => {
+        if (downloadStatus === 'none' || downloadStatus === 'failed') {
+            const videoDir = RNFS.DocumentDirectoryPath + '/videos';
+            card.setVideoDir(videoDir);
+            card.download();
+            logEvent({ 
+                message: 'button clicked', 
+                button: downloadStatus === 'failed' ? 'download-retry' : 'download', 
+                eventSource: 'user' 
+            });
+        } else {
+            logEvent({ message: 'button clicked', button: 'download', eventSource: 'user' });
+        }
+        setShowDownloadModal(true);
+    }, [card, downloadStatus, logEvent]);
+
+    const onDownloadModalClose = useCallback(() => {
+        setShowDownloadModal(false);
+    }, []);
+
+    const onDownloadStop = useCallback((id: string) => {
+        service.getCard(id)?.stopDownload();
+    }, [service]);
+
+    const onDownloadRetry = useCallback((id: string) => {
+        const c = service.getCard(id);
+        if (c) {
+            const videoDir = RNFS.DocumentDirectoryPath + '/videos';
+            c.setVideoDir(videoDir);
+            c.download();
+        }
+    }, [service]);
+
+    const onDownloadDelete = useCallback((id: string) => {
+        service.getCard(id)?.delete();
+    }, [service]);
+
+    // Obtain global download rows from service if possible
+    const downloadRows = (service as any).getPageDisplayProperties?.().downloadRows ?? [];
 
     return (
         <RouteDetailsView
@@ -116,7 +220,7 @@ export const RouteDetailsDialog = ({ routeId,onStart }:RouteDetailsDialogProps )
                 logEvent({ message: 'button clicked', button: 'start', eventSource: 'user' });
                 card.changeSettings(updatedSettings);
                 card.start();
-                onStart()
+                onStart();
             }}
             onCancel={() => {
                 logEvent({ message: 'button clicked', button: 'cancel', eventSource: 'user' });
@@ -137,6 +241,15 @@ export const RouteDetailsDialog = ({ routeId,onStart }:RouteDetailsDialogProps )
                     ...result
                 };
             }}
+            downloadButtonLabel={downloadButtonLabel}
+            downloadButtonDisabled={downloadButtonDisabled}
+            onDownloadPress={onDownloadPress}
+            showDownloadModal={showDownloadModal}
+            onDownloadModalClose={onDownloadModalClose}
+            downloadRows={downloadRows}
+            onDownloadStop={onDownloadStop}
+            onDownloadRetry={onDownloadRetry}
+            onDownloadDelete={onDownloadDelete}
         />
     );
 };

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
@@ -1,54 +1,152 @@
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useWindowDimensions } from 'react-native';
+import RNFS from 'react-native-fs';
+import { useRouteList, useActivityList } from 'incyclist-services';
+import type { UIRouteSettings, UIStartSettings } from 'incyclist-services';
+import { useLogging, useUnmountEffect } from '../../hooks';
 import { RouteDetailsView } from './RouteDetailsView';
 import { RouteDetailsDialogProps } from './types';
-import { useLogging, useUnmountEffect } from '../../hooks';
-import { getRouteListService } from '../../services';
-import { UIStartSettings, UIRouteSettings, DownloadRowDisplayProps } from 'incyclist-services';
-import RNFS from 'react-native-fs';
 
-export const RouteDetailsDialog = ({
-    routeDescr,
-    onClose,
-    onStart,
-    onCancel,
-    onEdit,
-    onDelete,
-    onShare,
-    onExport,
-    onDuplicate,
-    onImport,
-    onImportGpx,
-}: RouteDetailsDialogProps) => {
-    const { logEvent, logError } = useLogging('RouteDetailsDialog');
-    const service = getRouteListService();
-    const card = service?.getCard(routeDescr.id);
-    const routeId = routeDescr.id;
-
-    const [downloadStatus, setDownloadStatus] = useState<'none' | 'downloading' | 'done' | 'failed'>('none');
-    const [showDownloadModal, setShowDownloadModal] = useState(false);
-    const refObserver = useRef<any>(null);
+export const RouteDetailsDialog = ({ routeId,onStart }:RouteDetailsDialogProps ) => {
+    const { height } = useWindowDimensions();
+    const compact = height < 420;
+    
+    const service = useRouteList();
+    const activities = useActivityList();
+    const card = service.getCard(routeId);
+    
+    const { logEvent } = useLogging('RouteDetailsDialog');
+    const refMounted = useRef(true);
     const refInitialized = useRef(false);
+    const refDownloadObserver = useRef<any>(null);
+    
+    const [cardProps, setCardProps] = useState(() => card?.openSettings());
+    const [loading, setLoading] = useState(false);
+    const [prevRides, setPrevRides] = useState<any[] | null>(null);
+    const [showPrev, setShowPrev] = useState(false);
 
-    const canStart = routeDescr.canStart ?? false;
-    const canEdit = routeDescr.canEdit ?? false;
-    const canDelete = routeDescr.canDelete ?? false;
-    const canShare = routeDescr.canShare ?? false;
-    const canExport = routeDescr.canExport ?? false;
-    const canDuplicate = routeDescr.canDuplicate ?? false;
-    const canImport = routeDescr.canImport ?? false;
-    const canImportGpx = routeDescr.canImportGpx ?? false;
+    const route = card?.getData();
+    const routeDescr = route?.description;
 
-    const hasDownloadableVideo = routeDescr.downloadUrl || (routeDescr.videoUrl?.startsWith('https://'));
-    const showDownloadButton = hasDownloadableVideo || routeDescr.requiresDownload === true;
+    const [downloadStatus, setDownloadStatus] = useState<'none' | 'downloading' | 'done' | 'failed'>(() => {
+        if (routeDescr?.isDownloaded) return 'done';
+        if (card?.getCurrentDownload()) return 'downloading';
+        return 'none';
+    });
+    const [showDownloadModal, setShowDownloadModal] = useState(false);
 
-    // Determine download button label and disabled state
+    const refreshPrevRides = useCallback(async (settings: UIRouteSettings) => {
+        if (!card) return { prevRides: undefined, showPrev: false };
+        const data = card.getData();
+        const routeHash = data.description.routeHash;
+        const rId = !routeHash ? data.description.id : undefined;
+        
+        const prev = await activities.getPastActivitiesWithDetails({
+            routeHash,
+            routeId: rId,
+            startPos: settings.startPos?.value,
+            endPos: settings.endPos?.value,
+            realityFactor: settings.realityFactor
+        });
+
+        if (!refMounted.current) return { prevRides: undefined, showPrev: false };
+        
+        const hasPrev = prev?.length > 0;
+        setPrevRides(hasPrev ? prev : null);
+        setShowPrev(hasPrev);
+        return { prevRides: hasPrev ? prev : undefined, showPrev: hasPrev };
+    }, [card, activities]);
+
+    useEffect(() => {
+        if (!card || refInitialized.current) return;
+        refInitialized.current = true;
+        
+        const currentProps = card.openSettings();
+        setCardProps(currentProps);
+        
+        const data = card.getData();
+        
+        if (!data.details) {
+            setLoading(true);
+            service.getRouteDetails(routeId)
+                .then(() => { if (refMounted.current) setLoading(false); })
+                .catch(() => { if (refMounted.current) setLoading(false); });
+        }
+
+        refreshPrevRides(currentProps.settings as UIRouteSettings);
+        logEvent({ message: 'dialog shown', title:'select route',route: data.description.title });
+    }, [routeId, card, service, refreshPrevRides, logEvent]);
+
+    useEffect(() => {
+        if (!card) return;
+        
+        const subscribe = (observer: any) => {
+            if (!observer || refDownloadObserver.current === observer) return;
+            refDownloadObserver.current = observer;
+
+            const onProgress = () => setDownloadStatus('downloading');
+            const onDone = () => {
+                setDownloadStatus('done');
+                refDownloadObserver.current = null;
+            };
+            const onError = () => {
+                setDownloadStatus('failed');
+                refDownloadObserver.current = null;
+            };
+
+            observer.on('progress', onProgress);
+            observer.on('done', onDone);
+            observer.on('error', onError);
+
+            return () => {
+                observer.off('progress', onProgress);
+                observer.off('done', onDone);
+                observer.off('error', onError);
+                refDownloadObserver.current = null;
+            };
+        };
+
+        const currentObserver = card.getCurrentDownload();
+        if (currentObserver) {
+            return subscribe(currentObserver);
+        }
+    }, [card]);
+
+    useUnmountEffect(() => {
+        refMounted.current = false;
+    });
+
+    if (!card || !cardProps || !routeDescr) return null;
+
+    const { 
+        totalDistance, 
+        totalElevation, 
+        showLoopOverwrite, 
+        showNextOverwrite, 
+        hasWorkout, 
+        canStart: cardCanStart, 
+        updateStartPos, 
+        settings 
+    } = cardProps;
+
+    const { hasVideo, hasGpx, isLoop, videoFormat, previewUrl, segments } = routeDescr;
+    const points = route.details?.points ?? route.points;
+    const routeType = `${hasVideo ? 'Video' : 'GPX'} - ${isLoop ? 'Loop' : 'Point to Point'}`;
+    const isAvi = videoFormat?.toLowerCase() === 'avi';
+    const canStart = !isAvi && (cardCanStart ?? true) && downloadStatus !== 'downloading';
+    const canNotStartReason = isAvi ? 'AVI videos are not supported on mobile' : undefined;
+
+    const hasDownloadUrl = !!(routeDescr.downloadUrl || (routeDescr.videoUrl?.startsWith('https://')));
+    const showDownloadButton = hasDownloadUrl || routeDescr.requiresDownload === true;
+
     let downloadButtonLabel: string | undefined;
     let downloadButtonDisabled = false;
+
     if (showDownloadButton) {
         if (downloadStatus === 'downloading') {
             downloadButtonLabel = 'Downloading…';
             downloadButtonDisabled = true;
-        } else if (routeDescr.isDownloaded) {
+        } else if (downloadStatus === 'done') {
             downloadButtonLabel = 'Downloaded ✓';
         } else if (downloadStatus === 'failed') {
             downloadButtonLabel = 'Retry';
@@ -57,132 +155,101 @@ export const RouteDetailsDialog = ({
         }
     }
 
-    const startDisabled = downloadStatus === 'downloading';
-
-    // Subscribe to download observer
-    useEffect(() => {
-        if (!card || refInitialized.current) return;
-        refInitialized.current = true;
-
-        const observer = card.getCurrentDownload();
-        if (observer) {
-            refObserver.current = observer;
-            setDownloadStatus('downloading');
-
-            observer.on('progress', () => {
-                setDownloadStatus('downloading');
-            });
-            observer.on('done', () => {
-                setDownloadStatus('done');
-                refObserver.current = null;
-            });
-            observer.on('error', () => {
-                setDownloadStatus('failed');
-                refObserver.current = null;
-            });
-        } else if (routeDescr.isDownloaded) {
-            setDownloadStatus('done');
-        } else {
-            setDownloadStatus('none');
-        }
-    }, [card, routeDescr.isDownloaded]);
-
-    useUnmountEffect(() => {
-        if (refObserver.current) {
-            refObserver.current.removeAllListeners();
-            refObserver.current = null;
-        }
-    });
-
-    const handleDownloadPress = useCallback(() => {
-        if (!card) return;
-
-        if (downloadStatus === 'failed' || downloadStatus === 'none') {
+    const onDownloadPress = useCallback(() => {
+        if (downloadStatus === 'none' || downloadStatus === 'failed') {
             const videoDir = RNFS.DocumentDirectoryPath + '/videos';
             card.setVideoDir(videoDir);
             card.download();
+            logEvent({ 
+                message: 'button clicked', 
+                button: downloadStatus === 'failed' ? 'download-retry' : 'download', 
+                eventSource: 'user' 
+            });
+        } else {
             logEvent({ message: 'button clicked', button: 'download', eventSource: 'user' });
-        } else if (downloadStatus === 'failed') {
-            card.download();
-            logEvent({ message: 'button clicked', button: 'download-retry', eventSource: 'user' });
         }
-
         setShowDownloadModal(true);
     }, [card, downloadStatus, logEvent]);
 
-    const handleDownloadModalClose = useCallback(() => {
+    const onDownloadModalClose = useCallback(() => {
         setShowDownloadModal(false);
     }, []);
 
-    const handleStart = useCallback((settings: UIStartSettings) => {
-        onStart(settings);
-    }, [onStart]);
+    const onDownloadStop = useCallback((id: string) => {
+        service.getCard(id)?.stopDownload();
+    }, [service]);
 
-    const handleCancel = useCallback(() => {
-        onCancel();
-    }, [onCancel]);
+    const onDownloadRetry = useCallback((id: string) => {
+        const c = service.getCard(id);
+        if (c) {
+            const videoDir = RNFS.DocumentDirectoryPath + '/videos';
+            c.setVideoDir(videoDir);
+            c.download();
+        }
+    }, [service]);
 
-    const handleEdit = useCallback((settings: UIRouteSettings) => {
-        onEdit(settings);
-    }, [onEdit]);
+    const onDownloadDelete = useCallback((id: string) => {
+        service.getCard(id)?.delete();
+    }, [service]);
 
-    const handleDelete = useCallback(() => {
-        onDelete();
-    }, [onDelete]);
-
-    const handleShare = useCallback(() => {
-        onShare();
-    }, [onShare]);
-
-    const handleExport = useCallback(() => {
-        onExport();
-    }, [onExport]);
-
-    const handleDuplicate = useCallback(() => {
-        onDuplicate();
-    }, [onDuplicate]);
-
-    const handleImport = useCallback(() => {
-        onImport();
-    }, [onImport]);
-
-    const handleImportGpx = useCallback(() => {
-        onImportGpx();
-    }, [onImportGpx]);
-
-    const downloadRows: DownloadRowDisplayProps[] = downloadStatus !== 'none' ? [{
-        routeId,
-        title: routeDescr.title ?? '',
-        status: downloadStatus,
-    }] : [];
+    // Obtain global download rows from service if possible
+    const downloadRows = (service as any).getPageDisplayProperties?.().downloadRows ?? [];
 
     return (
         <RouteDetailsView
-            data={routeDescr}
+            title={routeDescr.title ?? ''}
+            compact={compact}
+            hasGpx={hasGpx ?? false}
+            points={points}
+            previewUrl={previewUrl}
+            totalDistance={totalDistance}
+            totalElevation={totalElevation}
+            routeType={routeType}
+            videoFormat={videoFormat}
+            segments={segments}
             canStart={canStart}
-            canEdit={canEdit}
-            canDelete={canDelete}
-            canShare={canShare}
-            canExport={canExport}
-            canDuplicate={canDuplicate}
-            canImport={canImport}
-            canImportGpx={canImportGpx}
-            startDisabled={startDisabled}
-            onStart={handleStart}
-            onCancel={handleCancel}
-            onEdit={handleEdit}
-            onDelete={handleDelete}
-            onShare={handleShare}
-            onExport={handleExport}
-            onDuplicate={handleDuplicate}
-            onImport={handleImport}
-            onImportGpx={handleImportGpx}
+            canNotStartReason={canNotStartReason}
+            showLoopOverwrite={!!showLoopOverwrite}
+            showNextOverwrite={!!showNextOverwrite}
+            showWorkout={!hasWorkout}
+            showPrev={showPrev}
+            loading={loading}
+            initialSettings={settings as UIRouteSettings}
+            prevRides={prevRides ?? undefined}
+            onStart={(updatedSettings) => {
+                logEvent({ message: 'button clicked', button: 'start', eventSource: 'user' });
+                card.changeSettings(updatedSettings);
+                card.start();
+                onStart();
+            }}
+            onCancel={() => {
+                logEvent({ message: 'button clicked', button: 'cancel', eventSource: 'user' });
+                card.cancel();
+            }}
+            onStartWithWorkout={(updatedSettings) => {
+                logEvent({ message: 'button clicked', button: 'start-with-workout', eventSource: 'user' });
+                card.changeSettings(updatedSettings);
+                card.addWorkout();
+            }}
+            onSettingsChanged={refreshPrevRides}
+            onUpdateStartPos={(value) => {
+                if (!updateStartPos) return null;
+                const result = updateStartPos(value);
+                if (!result) return null;
+                return {
+                    ...(cardProps.settings as UIStartSettings),
+                    ...result
+                };
+            }}
             downloadButtonLabel={downloadButtonLabel}
             downloadButtonDisabled={downloadButtonDisabled}
-            onDownloadPress={handleDownloadPress}
+            onDownloadPress={onDownloadPress}
             showDownloadModal={showDownloadModal}
-            onDownloadModalClose={handleDownloadModalClose}
+            onDownloadModalClose={onDownloadModalClose}
             downloadRows={downloadRows}
+            onDownloadStop={onDownloadStop}
+            onDownloadRetry={onDownloadRetry}
+            onDownloadDelete={onDownloadDelete}
         />
     );
 };

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useWindowDimensions } from 'react-native';
 import RNFS from 'react-native-fs';
 import { useRouteList, useActivityList } from 'incyclist-services';
-import type { UIRouteSettings, UIStartSettings } from 'incyclist-services';
+import type { DownloadRowDisplayProps, UIRouteSettings, UIStartSettings } from 'incyclist-services';
 import { useLogging, useUnmountEffect } from '../../hooks';
 import { RouteDetailsView } from './RouteDetailsView';
 import { RouteDetailsDialogProps } from './types';
@@ -149,7 +149,7 @@ export const RouteDetailsDialog = ({ routeId,onStart }:RouteDetailsDialogProps )
         } else if (downloadStatus === 'done') {
             downloadButtonLabel = 'Downloaded ✓';
         } else if (downloadStatus === 'failed') {
-            downloadButtonLabel = 'Retry';
+            downloadButtonLabel = 'Retry Download';
         } else {
             downloadButtonLabel = 'Download';
         }
@@ -192,8 +192,13 @@ export const RouteDetailsDialog = ({ routeId,onStart }:RouteDetailsDialogProps )
         service.getCard(id)?.delete();
     }, [service]);
 
-    // Obtain global download rows from service if possible
-    const downloadRows = (service as any).getPageDisplayProperties?.().downloadRows ?? [];
+    const downloadRows: DownloadRowDisplayProps[] = downloadStatus !== 'none' ? [{
+        routeId,
+        title: routeDescr.title ?? '',
+        status: downloadStatus,
+    }] : []
+
+    const downloadButtonPrimary = routeDescr.requiresDownload === true
 
     return (
         <RouteDetailsView
@@ -211,23 +216,21 @@ export const RouteDetailsDialog = ({ routeId,onStart }:RouteDetailsDialogProps )
             canNotStartReason={canNotStartReason}
             showLoopOverwrite={!!showLoopOverwrite}
             showNextOverwrite={!!showNextOverwrite}
+            downloadButtonPrimary={downloadButtonPrimary}
             showWorkout={!hasWorkout}
             showPrev={showPrev}
             loading={loading}
             initialSettings={settings as UIRouteSettings}
             prevRides={prevRides ?? undefined}
             onStart={(updatedSettings) => {
-                logEvent({ message: 'button clicked', button: 'start', eventSource: 'user' });
                 card.changeSettings(updatedSettings);
                 card.start();
                 onStart();
             }}
             onCancel={() => {
-                logEvent({ message: 'button clicked', button: 'cancel', eventSource: 'user' });
                 card.cancel();
             }}
             onStartWithWorkout={(updatedSettings) => {
-                logEvent({ message: 'button clicked', button: 'start-with-workout', eventSource: 'user' });
                 card.changeSettings(updatedSettings);
                 card.addWorkout();
             }}

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
@@ -1,152 +1,54 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useWindowDimensions } from 'react-native';
-import RNFS from 'react-native-fs';
-import { useRouteList, useActivityList } from 'incyclist-services';
-import type { UIRouteSettings, UIStartSettings } from 'incyclist-services';
-import { useLogging, useUnmountEffect } from '../../hooks';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { RouteDetailsView } from './RouteDetailsView';
 import { RouteDetailsDialogProps } from './types';
+import { useLogging, useUnmountEffect } from '../../hooks';
+import { getRouteListService } from '../../services';
+import { UIStartSettings, UIRouteSettings, DownloadRowDisplayProps } from 'incyclist-services';
+import RNFS from 'react-native-fs';
 
-export const RouteDetailsDialog = ({ routeId,onStart }:RouteDetailsDialogProps ) => {
-    const { height } = useWindowDimensions();
-    const compact = height < 420;
-    
-    const service = useRouteList();
-    const activities = useActivityList();
-    const card = service.getCard(routeId);
-    
-    const { logEvent } = useLogging('RouteDetailsDialog');
-    const refMounted = useRef(true);
-    const refInitialized = useRef(false);
-    const refDownloadObserver = useRef<any>(null);
-    
-    const [cardProps, setCardProps] = useState(() => card?.openSettings());
-    const [loading, setLoading] = useState(false);
-    const [prevRides, setPrevRides] = useState<any[] | null>(null);
-    const [showPrev, setShowPrev] = useState(false);
+export const RouteDetailsDialog = ({
+    routeDescr,
+    onClose,
+    onStart,
+    onCancel,
+    onEdit,
+    onDelete,
+    onShare,
+    onExport,
+    onDuplicate,
+    onImport,
+    onImportGpx,
+}: RouteDetailsDialogProps) => {
+    const { logEvent, logError } = useLogging('RouteDetailsDialog');
+    const service = getRouteListService();
+    const card = service?.getCard(routeDescr.id);
+    const routeId = routeDescr.id;
 
-    const route = card?.getData();
-    const routeDescr = route?.description;
-
-    const [downloadStatus, setDownloadStatus] = useState<'none' | 'downloading' | 'done' | 'failed'>(() => {
-        if (routeDescr?.isDownloaded) return 'done';
-        if (card?.getCurrentDownload()) return 'downloading';
-        return 'none';
-    });
+    const [downloadStatus, setDownloadStatus] = useState<'none' | 'downloading' | 'done' | 'failed'>('none');
     const [showDownloadModal, setShowDownloadModal] = useState(false);
+    const refObserver = useRef<any>(null);
+    const refInitialized = useRef(false);
 
-    const refreshPrevRides = useCallback(async (settings: UIRouteSettings) => {
-        if (!card) return { prevRides: undefined, showPrev: false };
-        const data = card.getData();
-        const routeHash = data.description.routeHash;
-        const rId = !routeHash ? data.description.id : undefined;
-        
-        const prev = await activities.getPastActivitiesWithDetails({
-            routeHash,
-            routeId: rId,
-            startPos: settings.startPos?.value,
-            endPos: settings.endPos?.value,
-            realityFactor: settings.realityFactor
-        });
+    const canStart = routeDescr.canStart ?? false;
+    const canEdit = routeDescr.canEdit ?? false;
+    const canDelete = routeDescr.canDelete ?? false;
+    const canShare = routeDescr.canShare ?? false;
+    const canExport = routeDescr.canExport ?? false;
+    const canDuplicate = routeDescr.canDuplicate ?? false;
+    const canImport = routeDescr.canImport ?? false;
+    const canImportGpx = routeDescr.canImportGpx ?? false;
 
-        if (!refMounted.current) return { prevRides: undefined, showPrev: false };
-        
-        const hasPrev = prev?.length > 0;
-        setPrevRides(hasPrev ? prev : null);
-        setShowPrev(hasPrev);
-        return { prevRides: hasPrev ? prev : undefined, showPrev: hasPrev };
-    }, [card, activities]);
+    const hasDownloadableVideo = routeDescr.downloadUrl || (routeDescr.videoUrl?.startsWith('https://'));
+    const showDownloadButton = hasDownloadableVideo || routeDescr.requiresDownload === true;
 
-    useEffect(() => {
-        if (!card || refInitialized.current) return;
-        refInitialized.current = true;
-        
-        const currentProps = card.openSettings();
-        setCardProps(currentProps);
-        
-        const data = card.getData();
-        
-        if (!data.details) {
-            setLoading(true);
-            service.getRouteDetails(routeId)
-                .then(() => { if (refMounted.current) setLoading(false); })
-                .catch(() => { if (refMounted.current) setLoading(false); });
-        }
-
-        refreshPrevRides(currentProps.settings as UIRouteSettings);
-        logEvent({ message: 'dialog shown', title:'select route',route: data.description.title });
-    }, [routeId, card, service, refreshPrevRides, logEvent]);
-
-    useEffect(() => {
-        if (!card) return;
-        
-        const subscribe = (observer: any) => {
-            if (!observer || refDownloadObserver.current === observer) return;
-            refDownloadObserver.current = observer;
-
-            const onProgress = () => setDownloadStatus('downloading');
-            const onDone = () => {
-                setDownloadStatus('done');
-                refDownloadObserver.current = null;
-            };
-            const onError = () => {
-                setDownloadStatus('failed');
-                refDownloadObserver.current = null;
-            };
-
-            observer.on('progress', onProgress);
-            observer.on('done', onDone);
-            observer.on('error', onError);
-
-            return () => {
-                observer.off('progress', onProgress);
-                observer.off('done', onDone);
-                observer.off('error', onError);
-                refDownloadObserver.current = null;
-            };
-        };
-
-        const currentObserver = card.getCurrentDownload();
-        if (currentObserver) {
-            return subscribe(currentObserver);
-        }
-    }, [card]);
-
-    useUnmountEffect(() => {
-        refMounted.current = false;
-    });
-
-    if (!card || !cardProps || !routeDescr) return null;
-
-    const { 
-        totalDistance, 
-        totalElevation, 
-        showLoopOverwrite, 
-        showNextOverwrite, 
-        hasWorkout, 
-        canStart: cardCanStart, 
-        updateStartPos, 
-        settings 
-    } = cardProps;
-
-    const { hasVideo, hasGpx, isLoop, videoFormat, previewUrl, segments } = routeDescr;
-    const points = route.details?.points ?? route.points;
-    const routeType = `${hasVideo ? 'Video' : 'GPX'} - ${isLoop ? 'Loop' : 'Point to Point'}`;
-    const isAvi = videoFormat?.toLowerCase() === 'avi';
-    const canStart = !isAvi && (cardCanStart ?? true) && downloadStatus !== 'downloading';
-    const canNotStartReason = isAvi ? 'AVI videos are not supported on mobile' : undefined;
-
-    const hasDownloadUrl = !!(routeDescr.downloadUrl || (routeDescr.videoUrl?.startsWith('https://')));
-    const showDownloadButton = hasDownloadUrl || routeDescr.requiresDownload === true;
-
+    // Determine download button label and disabled state
     let downloadButtonLabel: string | undefined;
     let downloadButtonDisabled = false;
-
     if (showDownloadButton) {
         if (downloadStatus === 'downloading') {
             downloadButtonLabel = 'Downloading…';
             downloadButtonDisabled = true;
-        } else if (downloadStatus === 'done') {
+        } else if (routeDescr.isDownloaded) {
             downloadButtonLabel = 'Downloaded ✓';
         } else if (downloadStatus === 'failed') {
             downloadButtonLabel = 'Retry';
@@ -155,101 +57,132 @@ export const RouteDetailsDialog = ({ routeId,onStart }:RouteDetailsDialogProps )
         }
     }
 
-    const onDownloadPress = useCallback(() => {
-        if (downloadStatus === 'none' || downloadStatus === 'failed') {
+    const startDisabled = downloadStatus === 'downloading';
+
+    // Subscribe to download observer
+    useEffect(() => {
+        if (!card || refInitialized.current) return;
+        refInitialized.current = true;
+
+        const observer = card.getCurrentDownload();
+        if (observer) {
+            refObserver.current = observer;
+            setDownloadStatus('downloading');
+
+            observer.on('progress', () => {
+                setDownloadStatus('downloading');
+            });
+            observer.on('done', () => {
+                setDownloadStatus('done');
+                refObserver.current = null;
+            });
+            observer.on('error', () => {
+                setDownloadStatus('failed');
+                refObserver.current = null;
+            });
+        } else if (routeDescr.isDownloaded) {
+            setDownloadStatus('done');
+        } else {
+            setDownloadStatus('none');
+        }
+    }, [card, routeDescr.isDownloaded]);
+
+    useUnmountEffect(() => {
+        if (refObserver.current) {
+            refObserver.current.removeAllListeners();
+            refObserver.current = null;
+        }
+    });
+
+    const handleDownloadPress = useCallback(() => {
+        if (!card) return;
+
+        if (downloadStatus === 'failed' || downloadStatus === 'none') {
             const videoDir = RNFS.DocumentDirectoryPath + '/videos';
             card.setVideoDir(videoDir);
             card.download();
-            logEvent({ 
-                message: 'button clicked', 
-                button: downloadStatus === 'failed' ? 'download-retry' : 'download', 
-                eventSource: 'user' 
-            });
-        } else {
             logEvent({ message: 'button clicked', button: 'download', eventSource: 'user' });
+        } else if (downloadStatus === 'failed') {
+            card.download();
+            logEvent({ message: 'button clicked', button: 'download-retry', eventSource: 'user' });
         }
+
         setShowDownloadModal(true);
     }, [card, downloadStatus, logEvent]);
 
-    const onDownloadModalClose = useCallback(() => {
+    const handleDownloadModalClose = useCallback(() => {
         setShowDownloadModal(false);
     }, []);
 
-    const onDownloadStop = useCallback((id: string) => {
-        service.getCard(id)?.stopDownload();
-    }, [service]);
+    const handleStart = useCallback((settings: UIStartSettings) => {
+        onStart(settings);
+    }, [onStart]);
 
-    const onDownloadRetry = useCallback((id: string) => {
-        const c = service.getCard(id);
-        if (c) {
-            const videoDir = RNFS.DocumentDirectoryPath + '/videos';
-            c.setVideoDir(videoDir);
-            c.download();
-        }
-    }, [service]);
+    const handleCancel = useCallback(() => {
+        onCancel();
+    }, [onCancel]);
 
-    const onDownloadDelete = useCallback((id: string) => {
-        service.getCard(id)?.delete();
-    }, [service]);
+    const handleEdit = useCallback((settings: UIRouteSettings) => {
+        onEdit(settings);
+    }, [onEdit]);
 
-    // Obtain global download rows from service if possible
-    const downloadRows = (service as any).getPageDisplayProperties?.().downloadRows ?? [];
+    const handleDelete = useCallback(() => {
+        onDelete();
+    }, [onDelete]);
+
+    const handleShare = useCallback(() => {
+        onShare();
+    }, [onShare]);
+
+    const handleExport = useCallback(() => {
+        onExport();
+    }, [onExport]);
+
+    const handleDuplicate = useCallback(() => {
+        onDuplicate();
+    }, [onDuplicate]);
+
+    const handleImport = useCallback(() => {
+        onImport();
+    }, [onImport]);
+
+    const handleImportGpx = useCallback(() => {
+        onImportGpx();
+    }, [onImportGpx]);
+
+    const downloadRows: DownloadRowDisplayProps[] = downloadStatus !== 'none' ? [{
+        routeId,
+        title: routeDescr.title ?? '',
+        status: downloadStatus,
+    }] : [];
 
     return (
         <RouteDetailsView
-            title={routeDescr.title ?? ''}
-            compact={compact}
-            hasGpx={hasGpx ?? false}
-            points={points}
-            previewUrl={previewUrl}
-            totalDistance={totalDistance}
-            totalElevation={totalElevation}
-            routeType={routeType}
-            videoFormat={videoFormat}
-            segments={segments}
+            data={routeDescr}
             canStart={canStart}
-            canNotStartReason={canNotStartReason}
-            showLoopOverwrite={!!showLoopOverwrite}
-            showNextOverwrite={!!showNextOverwrite}
-            showWorkout={!hasWorkout}
-            showPrev={showPrev}
-            loading={loading}
-            initialSettings={settings as UIRouteSettings}
-            prevRides={prevRides ?? undefined}
-            onStart={(updatedSettings) => {
-                logEvent({ message: 'button clicked', button: 'start', eventSource: 'user' });
-                card.changeSettings(updatedSettings);
-                card.start();
-                onStart();
-            }}
-            onCancel={() => {
-                logEvent({ message: 'button clicked', button: 'cancel', eventSource: 'user' });
-                card.cancel();
-            }}
-            onStartWithWorkout={(updatedSettings) => {
-                logEvent({ message: 'button clicked', button: 'start-with-workout', eventSource: 'user' });
-                card.changeSettings(updatedSettings);
-                card.addWorkout();
-            }}
-            onSettingsChanged={refreshPrevRides}
-            onUpdateStartPos={(value) => {
-                if (!updateStartPos) return null;
-                const result = updateStartPos(value);
-                if (!result) return null;
-                return {
-                    ...(cardProps.settings as UIStartSettings),
-                    ...result
-                };
-            }}
+            canEdit={canEdit}
+            canDelete={canDelete}
+            canShare={canShare}
+            canExport={canExport}
+            canDuplicate={canDuplicate}
+            canImport={canImport}
+            canImportGpx={canImportGpx}
+            startDisabled={startDisabled}
+            onStart={handleStart}
+            onCancel={handleCancel}
+            onEdit={handleEdit}
+            onDelete={handleDelete}
+            onShare={handleShare}
+            onExport={handleExport}
+            onDuplicate={handleDuplicate}
+            onImport={handleImport}
+            onImportGpx={handleImportGpx}
             downloadButtonLabel={downloadButtonLabel}
             downloadButtonDisabled={downloadButtonDisabled}
-            onDownloadPress={onDownloadPress}
+            onDownloadPress={handleDownloadPress}
             showDownloadModal={showDownloadModal}
-            onDownloadModalClose={onDownloadModalClose}
+            onDownloadModalClose={handleDownloadModalClose}
             downloadRows={downloadRows}
-            onDownloadStop={onDownloadStop}
-            onDownloadRetry={onDownloadRetry}
-            onDownloadDelete={onDownloadDelete}
         />
     );
 };

--- a/src/components/RouteDetailsDialog/RouteDetailsView.test.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.test.tsx
@@ -1,137 +1,144 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, fireEvent } from '@testing-library/react-native';
 import { RouteDetailsView } from './RouteDetailsView';
-import type { UIRouteSettings, UIStartSettings } from 'incyclist-services';
+import { RouteDetailsViewProps } from './types';
 
-jest.mock('incyclist-services', () => ({
-    useUnitConverter: () => ({ convert: (v: number) => v }),
-    useRouteList: jest.fn(),
-    useActivityList: jest.fn(),
-}));
-jest.mock('../../bindings/ui', () => ({}));
-jest.mock('../../hooks', () => ({
-    useLogging: () => ({ logError: jest.fn(), logEvent: jest.fn() }),
-    useUnmountEffect: jest.fn(),
-    useScreenLayout: () => ({ compact: false }),
+// Mock child components
+jest.mock('../../components/Dialog', () => ({
+    Dialog: ({ children, visible }: any) => visible ? <>{children}</> : null,
 }));
 
-jest.mock('@maplibre/maplibre-react-native', () => ({
-    MapView: 'MapView',
-    Camera: 'Camera',
-    ShapeSource: 'ShapeSource',
-    LineLayer: 'LineLayer',
-    setAccessToken: jest.fn(),
-    default: { createFragment: jest.fn() },
+jest.mock('../../components/ButtonBar', () => ({
+    ButtonBar: ({ buttons }: any) => (
+        <>
+            {buttons.map((btn: any) => (
+                <button key={btn.label} onClick={btn.onClick}>
+                    {btn.label}
+                </button>
+            ))}
+        </>
+    ),
 }));
 
-jest.mock('../DownloadModal', () => {
-    const { Text } = require('react-native');
-    return {
-        DownloadModalView: ({ visible }: any) => visible ? <Text>DownloadModalView</Text> : null,
-    };
-});
+jest.mock('../../components/DownloadModal/DownloadModalView', () => ({
+    DownloadModalView: ({ visible }: any) => visible ? <div>DownloadModalView</div> : null,
+}));
 
-const MOCK_SETTINGS = {
-    startPos: { value: 0, unit: 'km' },
-    realityFactor: 100,
-    prevRides: [],
-    showPrev: false,
-} as unknown as UIRouteSettings;
-
-const MOCK_PROPS = {
-    title: 'Test Route',
-    compact: false,
-    hasGpx: false,
-    points: [],
-    previewUrl: undefined,
-    totalDistance: { value: 50, unit: 'km' },
-    totalElevation: { value: 800, unit: 'm' },
-    routeType: 'Video - Point to Point',
-    segments: [],
-    canStart: true,
-    showLoopOverwrite: false,
-    showNextOverwrite: false,
-    showWorkout: false,
-    showPrev: false,
-    loading: false,
-    initialSettings: MOCK_SETTINGS,
-    onStart: jest.fn(),
-    onCancel: jest.fn(),
-    onStartWithWorkout: jest.fn(),
-    onSettingsChanged: jest.fn().mockResolvedValue({}),
-    onUpdateStartPos: jest.fn((value: number) => {
-        return { startPos: { value, unit: 'km' } } as unknown as UIStartSettings;
-    }),
-    downloadButtonLabel: undefined,
-    downloadButtonDisabled: false,
-    onDownloadPress: jest.fn(),
-    showDownloadModal: false,
-    onDownloadModalClose: jest.fn(),
-    downloadRows: [],
-    onDownloadStop: jest.fn(),
-    onDownloadRetry: jest.fn(),
-    onDownloadDelete: jest.fn(),
-};
+jest.mock('../../components/Icon', () => ({
+    Icon: () => <div>Icon</div>,
+}));
 
 describe('RouteDetailsView', () => {
-    it('renders in normal layout', () => {
-        render(<RouteDetailsView {...MOCK_PROPS} />);
+    const defaultProps: RouteDetailsViewProps = {
+        data: {
+            id: 'route1',
+            title: 'Test Route',
+            description: 'A test route',
+            distance: 42,
+            elevation: 1000,
+            duration: 3600,
+            canStart: true,
+            canEdit: false,
+            canDelete: false,
+            canShare: false,
+            canExport: false,
+            canDuplicate: false,
+            canImport: false,
+            canImportGpx: false,
+        },
+        canStart: true,
+        canEdit: false,
+        canDelete: false,
+        canShare: false,
+        canExport: false,
+        canDuplicate: false,
+        canImport: false,
+        canImportGpx: false,
+        startDisabled: false,
+        onStart: jest.fn(),
+        onCancel: jest.fn(),
+        onEdit: jest.fn(),
+        onDelete: jest.fn(),
+        onShare: jest.fn(),
+        onExport: jest.fn(),
+        onDuplicate: jest.fn(),
+        onImport: jest.fn(),
+        onImportGpx: jest.fn(),
+    };
+
+    it('renders without crashing', () => {
+        const { getByText } = render(<RouteDetailsView {...defaultProps} />);
+        expect(getByText('Test Route')).toBeTruthy();
+        expect(getByText('A test route')).toBeTruthy();
+        expect(getByText('42 km')).toBeTruthy();
+        expect(getByText('1000 m')).toBeTruthy();
+        expect(getByText('01:00:00')).toBeTruthy();
     });
 
-    it('renders in compact layout', () => {
-        render(<RouteDetailsView {...MOCK_PROPS} compact={true} />);
+    it('does not show download button when downloadButtonLabel is undefined', () => {
+        const { queryByText } = render(<RouteDetailsView {...defaultProps} />);
+        expect(queryByText('Download')).toBeNull();
+        expect(queryByText('Downloading…')).toBeNull();
+        expect(queryByText('Downloaded ✓')).toBeNull();
+        expect(queryByText('Retry')).toBeNull();
     });
 
-    it('renders with no segments', () => {
-        render(<RouteDetailsView {...MOCK_PROPS} segments={[]} />);
-    });
-
-    it('renders with segments (chips)', () => {
-        const segments = [{ name: 'Seg 1', start: 0, end: 1000 }];
-        render(<RouteDetailsView {...MOCK_PROPS} segments={segments} compact={false} />);
-    });
-
-    it('renders with segments (dropdown — compact)', () => {
-        const segments = [{ name: 'Seg 1', start: 0, end: 1000 }];
-        render(<RouteDetailsView {...MOCK_PROPS} segments={segments} compact={true} />);
-    });
-
-    it('renders with endPos visible (segment active)', () => {
-        const settings = {
-            ...MOCK_PROPS.initialSettings,
-            segment: 'Seg 1',
-            endPos: { value: 10, unit: 'km' },
-        } as unknown as UIRouteSettings;
-        render(<RouteDetailsView {...MOCK_PROPS} initialSettings={settings} />);
-    });
-
-    it('renders with endPos undefined (no segment)', () => {
-        render(<RouteDetailsView {...MOCK_PROPS} />);
-    });
-
-    it('renders with loading state', () => {
-        render(<RouteDetailsView {...MOCK_PROPS} loading={true} />);
-    });
-
-    it('renders with download button', () => {
-        const { getByText } = render(<RouteDetailsView {...MOCK_PROPS} downloadButtonLabel="Download" />);
+    it('shows download button with correct label when downloadButtonLabel is provided', () => {
+        const props = {
+            ...defaultProps,
+            downloadButtonLabel: 'Download',
+            downloadButtonDisabled: false,
+            onDownloadPress: jest.fn(),
+        };
+        const { getByText } = render(<RouteDetailsView {...props} />);
         expect(getByText('Download')).toBeTruthy();
     });
 
-    it('renders with disabled download button', () => {
-        const { getByText } = render(
-            <RouteDetailsView 
-                {...MOCK_PROPS} 
-                downloadButtonLabel="Downloading…" 
-                downloadButtonDisabled={true} 
-            />
-        );
-        expect(getByText('Downloading…')).toBeTruthy();
+    it('disables download button when downloadButtonDisabled is true', () => {
+        const props = {
+            ...defaultProps,
+            downloadButtonLabel: 'Downloading…',
+            downloadButtonDisabled: true,
+            onDownloadPress: jest.fn(),
+        };
+        const { getByText } = render(<RouteDetailsView {...props} />);
+        const button = getByText('Downloading…');
+        expect(button).toBeTruthy();
+        // Note: disabled state is handled by ButtonBar internally; we just verify the label appears
     });
 
-    it('renders with DownloadModal when showDownloadModal is true', () => {
-        const { getByText } = render(<RouteDetailsView {...MOCK_PROPS} showDownloadModal={true} />);
-        // The mock renders the name of the component
+    it('calls onDownloadPress when download button is clicked', () => {
+        const onDownloadPress = jest.fn();
+        const props = {
+            ...defaultProps,
+            downloadButtonLabel: 'Download',
+            downloadButtonDisabled: false,
+            onDownloadPress,
+        };
+        const { getByText } = render(<RouteDetailsView {...props} />);
+        fireEvent.press(getByText('Download'));
+        expect(onDownloadPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows DownloadModal when showDownloadModal is true', () => {
+        const props = {
+            ...defaultProps,
+            showDownloadModal: true,
+            onDownloadModalClose: jest.fn(),
+            downloadRows: [],
+        };
+        const { getByText } = render(<RouteDetailsView {...props} />);
         expect(getByText('DownloadModalView')).toBeTruthy();
+    });
+
+    it('does not show DownloadModal when showDownloadModal is false', () => {
+        const props = {
+            ...defaultProps,
+            showDownloadModal: false,
+            onDownloadModalClose: jest.fn(),
+            downloadRows: [],
+        };
+        const { queryByText } = render(<RouteDetailsView {...props} />);
+        expect(queryByText('DownloadModalView')).toBeNull();
     });
 });

--- a/src/components/RouteDetailsDialog/RouteDetailsView.test.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.test.tsx
@@ -11,7 +11,8 @@ jest.mock('incyclist-services', () => ({
 jest.mock('../../bindings/ui', () => ({}));
 jest.mock('../../hooks', () => ({
     useLogging: () => ({ logError: jest.fn(), logEvent: jest.fn() }),
-    useUnmountEffect: jest.fn((cb) => cb()),
+    useUnmountEffect: jest.fn(),
+    useScreenLayout: () => ({ compact: false }),
 }));
 
 jest.mock('@maplibre/maplibre-react-native', () => ({
@@ -22,14 +23,13 @@ jest.mock('@maplibre/maplibre-react-native', () => ({
     setAccessToken: jest.fn(),
     default: { createFragment: jest.fn() },
 }));
-jest.mock('../../hooks', () => ({
-    useLogging: () => ({ logError: jest.fn(), logEvent: jest.fn() }),
-    useUnmountEffect: jest.fn(),
-    useScreenLayout: () => ({ compact: false }),
-}));
-jest.mock('../DownloadModal', () => ({
-    DownloadModalView: 'DownloadModalView',
-}));
+
+jest.mock('../DownloadModal', () => {
+    const { Text } = require('react-native');
+    return {
+        DownloadModalView: ({ visible }: any) => visible ? <Text>DownloadModalView</Text> : null,
+    };
+});
 
 const MOCK_SETTINGS = {
     startPos: { value: 0, unit: 'km' },

--- a/src/components/RouteDetailsDialog/RouteDetailsView.test.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.test.tsx
@@ -1,144 +1,137 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render } from '@testing-library/react-native';
 import { RouteDetailsView } from './RouteDetailsView';
-import { RouteDetailsViewProps } from './types';
+import type { UIRouteSettings, UIStartSettings } from 'incyclist-services';
 
-// Mock child components
-jest.mock('../../components/Dialog', () => ({
-    Dialog: ({ children, visible }: any) => visible ? <>{children}</> : null,
+jest.mock('incyclist-services', () => ({
+    useUnitConverter: () => ({ convert: (v: number) => v }),
+    useRouteList: jest.fn(),
+    useActivityList: jest.fn(),
+}));
+jest.mock('../../bindings/ui', () => ({}));
+jest.mock('../../hooks', () => ({
+    useLogging: () => ({ logError: jest.fn(), logEvent: jest.fn() }),
+    useUnmountEffect: jest.fn(),
+    useScreenLayout: () => ({ compact: false }),
 }));
 
-jest.mock('../../components/ButtonBar', () => ({
-    ButtonBar: ({ buttons }: any) => (
-        <>
-            {buttons.map((btn: any) => (
-                <button key={btn.label} onClick={btn.onClick}>
-                    {btn.label}
-                </button>
-            ))}
-        </>
-    ),
+jest.mock('@maplibre/maplibre-react-native', () => ({
+    MapView: 'MapView',
+    Camera: 'Camera',
+    ShapeSource: 'ShapeSource',
+    LineLayer: 'LineLayer',
+    setAccessToken: jest.fn(),
+    default: { createFragment: jest.fn() },
 }));
 
-jest.mock('../../components/DownloadModal/DownloadModalView', () => ({
-    DownloadModalView: ({ visible }: any) => visible ? <div>DownloadModalView</div> : null,
-}));
+jest.mock('../DownloadModal', () => {
+    const { Text } = require('react-native');
+    return {
+        DownloadModalView: ({ visible }: any) => visible ? <Text>DownloadModalView</Text> : null,
+    };
+});
 
-jest.mock('../../components/Icon', () => ({
-    Icon: () => <div>Icon</div>,
-}));
+const MOCK_SETTINGS = {
+    startPos: { value: 0, unit: 'km' },
+    realityFactor: 100,
+    prevRides: [],
+    showPrev: false,
+} as unknown as UIRouteSettings;
+
+const MOCK_PROPS = {
+    title: 'Test Route',
+    compact: false,
+    hasGpx: false,
+    points: [],
+    previewUrl: undefined,
+    totalDistance: { value: 50, unit: 'km' },
+    totalElevation: { value: 800, unit: 'm' },
+    routeType: 'Video - Point to Point',
+    segments: [],
+    canStart: true,
+    showLoopOverwrite: false,
+    showNextOverwrite: false,
+    showWorkout: false,
+    showPrev: false,
+    loading: false,
+    initialSettings: MOCK_SETTINGS,
+    onStart: jest.fn(),
+    onCancel: jest.fn(),
+    onStartWithWorkout: jest.fn(),
+    onSettingsChanged: jest.fn().mockResolvedValue({}),
+    onUpdateStartPos: jest.fn((value: number) => {
+        return { startPos: { value, unit: 'km' } } as unknown as UIStartSettings;
+    }),
+    downloadButtonLabel: undefined,
+    downloadButtonDisabled: false,
+    onDownloadPress: jest.fn(),
+    showDownloadModal: false,
+    onDownloadModalClose: jest.fn(),
+    downloadRows: [],
+    onDownloadStop: jest.fn(),
+    onDownloadRetry: jest.fn(),
+    onDownloadDelete: jest.fn(),
+};
 
 describe('RouteDetailsView', () => {
-    const defaultProps: RouteDetailsViewProps = {
-        data: {
-            id: 'route1',
-            title: 'Test Route',
-            description: 'A test route',
-            distance: 42,
-            elevation: 1000,
-            duration: 3600,
-            canStart: true,
-            canEdit: false,
-            canDelete: false,
-            canShare: false,
-            canExport: false,
-            canDuplicate: false,
-            canImport: false,
-            canImportGpx: false,
-        },
-        canStart: true,
-        canEdit: false,
-        canDelete: false,
-        canShare: false,
-        canExport: false,
-        canDuplicate: false,
-        canImport: false,
-        canImportGpx: false,
-        startDisabled: false,
-        onStart: jest.fn(),
-        onCancel: jest.fn(),
-        onEdit: jest.fn(),
-        onDelete: jest.fn(),
-        onShare: jest.fn(),
-        onExport: jest.fn(),
-        onDuplicate: jest.fn(),
-        onImport: jest.fn(),
-        onImportGpx: jest.fn(),
-    };
-
-    it('renders without crashing', () => {
-        const { getByText } = render(<RouteDetailsView {...defaultProps} />);
-        expect(getByText('Test Route')).toBeTruthy();
-        expect(getByText('A test route')).toBeTruthy();
-        expect(getByText('42 km')).toBeTruthy();
-        expect(getByText('1000 m')).toBeTruthy();
-        expect(getByText('01:00:00')).toBeTruthy();
+    it('renders in normal layout', () => {
+        render(<RouteDetailsView {...MOCK_PROPS} />);
     });
 
-    it('does not show download button when downloadButtonLabel is undefined', () => {
-        const { queryByText } = render(<RouteDetailsView {...defaultProps} />);
-        expect(queryByText('Download')).toBeNull();
-        expect(queryByText('Downloading…')).toBeNull();
-        expect(queryByText('Downloaded ✓')).toBeNull();
-        expect(queryByText('Retry')).toBeNull();
+    it('renders in compact layout', () => {
+        render(<RouteDetailsView {...MOCK_PROPS} compact={true} />);
     });
 
-    it('shows download button with correct label when downloadButtonLabel is provided', () => {
-        const props = {
-            ...defaultProps,
-            downloadButtonLabel: 'Download',
-            downloadButtonDisabled: false,
-            onDownloadPress: jest.fn(),
-        };
-        const { getByText } = render(<RouteDetailsView {...props} />);
+    it('renders with no segments', () => {
+        render(<RouteDetailsView {...MOCK_PROPS} segments={[]} />);
+    });
+
+    it('renders with segments (chips)', () => {
+        const segments = [{ name: 'Seg 1', start: 0, end: 1000 }];
+        render(<RouteDetailsView {...MOCK_PROPS} segments={segments} compact={false} />);
+    });
+
+    it('renders with segments (dropdown — compact)', () => {
+        const segments = [{ name: 'Seg 1', start: 0, end: 1000 }];
+        render(<RouteDetailsView {...MOCK_PROPS} segments={segments} compact={true} />);
+    });
+
+    it('renders with endPos visible (segment active)', () => {
+        const settings = {
+            ...MOCK_PROPS.initialSettings,
+            segment: 'Seg 1',
+            endPos: { value: 10, unit: 'km' },
+        } as unknown as UIRouteSettings;
+        render(<RouteDetailsView {...MOCK_PROPS} initialSettings={settings} />);
+    });
+
+    it('renders with endPos undefined (no segment)', () => {
+        render(<RouteDetailsView {...MOCK_PROPS} />);
+    });
+
+    it('renders with loading state', () => {
+        render(<RouteDetailsView {...MOCK_PROPS} loading={true} />);
+    });
+
+    it('renders with download button', () => {
+        const { getByText } = render(<RouteDetailsView {...MOCK_PROPS} downloadButtonLabel="Download" />);
         expect(getByText('Download')).toBeTruthy();
     });
 
-    it('disables download button when downloadButtonDisabled is true', () => {
-        const props = {
-            ...defaultProps,
-            downloadButtonLabel: 'Downloading…',
-            downloadButtonDisabled: true,
-            onDownloadPress: jest.fn(),
-        };
-        const { getByText } = render(<RouteDetailsView {...props} />);
-        const button = getByText('Downloading…');
-        expect(button).toBeTruthy();
-        // Note: disabled state is handled by ButtonBar internally; we just verify the label appears
+    it('renders with disabled download button', () => {
+        const { getByText } = render(
+            <RouteDetailsView 
+                {...MOCK_PROPS} 
+                downloadButtonLabel="Downloading…" 
+                downloadButtonDisabled={true} 
+            />
+        );
+        expect(getByText('Downloading…')).toBeTruthy();
     });
 
-    it('calls onDownloadPress when download button is clicked', () => {
-        const onDownloadPress = jest.fn();
-        const props = {
-            ...defaultProps,
-            downloadButtonLabel: 'Download',
-            downloadButtonDisabled: false,
-            onDownloadPress,
-        };
-        const { getByText } = render(<RouteDetailsView {...props} />);
-        fireEvent.press(getByText('Download'));
-        expect(onDownloadPress).toHaveBeenCalledTimes(1);
-    });
-
-    it('shows DownloadModal when showDownloadModal is true', () => {
-        const props = {
-            ...defaultProps,
-            showDownloadModal: true,
-            onDownloadModalClose: jest.fn(),
-            downloadRows: [],
-        };
-        const { getByText } = render(<RouteDetailsView {...props} />);
+    it('renders with DownloadModal when showDownloadModal is true', () => {
+        const { getByText } = render(<RouteDetailsView {...MOCK_PROPS} showDownloadModal={true} />);
+        // The mock renders the name of the component
         expect(getByText('DownloadModalView')).toBeTruthy();
-    });
-
-    it('does not show DownloadModal when showDownloadModal is false', () => {
-        const props = {
-            ...defaultProps,
-            showDownloadModal: false,
-            onDownloadModalClose: jest.fn(),
-            downloadRows: [],
-        };
-        const { queryByText } = render(<RouteDetailsView {...props} />);
-        expect(queryByText('DownloadModalView')).toBeNull();
     });
 });

--- a/src/components/RouteDetailsDialog/RouteDetailsView.test.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.test.tsx
@@ -27,6 +27,10 @@ jest.mock('../../hooks', () => ({
     useUnmountEffect: jest.fn(),
     useScreenLayout: () => ({ compact: false }),
 }));
+jest.mock('../DownloadModal', () => ({
+    DownloadModalView: 'DownloadModalView',
+}));
+
 const MOCK_SETTINGS = {
     startPos: { value: 0, unit: 'km' },
     realityFactor: 100,
@@ -58,6 +62,15 @@ const MOCK_PROPS = {
     onUpdateStartPos: jest.fn((value: number) => {
         return { startPos: { value, unit: 'km' } } as unknown as UIStartSettings;
     }),
+    downloadButtonLabel: undefined,
+    downloadButtonDisabled: false,
+    onDownloadPress: jest.fn(),
+    showDownloadModal: false,
+    onDownloadModalClose: jest.fn(),
+    downloadRows: [],
+    onDownloadStop: jest.fn(),
+    onDownloadRetry: jest.fn(),
+    onDownloadDelete: jest.fn(),
 };
 
 describe('RouteDetailsView', () => {
@@ -98,5 +111,27 @@ describe('RouteDetailsView', () => {
 
     it('renders with loading state', () => {
         render(<RouteDetailsView {...MOCK_PROPS} loading={true} />);
+    });
+
+    it('renders with download button', () => {
+        const { getByText } = render(<RouteDetailsView {...MOCK_PROPS} downloadButtonLabel="Download" />);
+        expect(getByText('Download')).toBeTruthy();
+    });
+
+    it('renders with disabled download button', () => {
+        const { getByText } = render(
+            <RouteDetailsView 
+                {...MOCK_PROPS} 
+                downloadButtonLabel="Downloading…" 
+                downloadButtonDisabled={true} 
+            />
+        );
+        expect(getByText('Downloading…')).toBeTruthy();
+    });
+
+    it('renders with DownloadModal when showDownloadModal is true', () => {
+        const { getByText } = render(<RouteDetailsView {...MOCK_PROPS} showDownloadModal={true} />);
+        // The mock renders the name of the component
+        expect(getByText('DownloadModalView')).toBeTruthy();
     });
 });

--- a/src/components/RouteDetailsDialog/RouteDetailsView.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.tsx
@@ -264,7 +264,7 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
         ...(downloadButtonLabel ? [{
             label: downloadButtonLabel,
             disabled: downloadButtonDisabled,
-            onClick: onDownloadPress,
+            onClick: onDownloadPress ?? (() => {}),
             primary: downloadButtonLabel === 'Download',
         }] : []),
         ...(canStart ? [

--- a/src/components/RouteDetailsDialog/RouteDetailsView.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.tsx
@@ -18,6 +18,7 @@ import { BinarySelect } from '../BinarySelect';
 import { EditNumber } from '../EditNumber';
 import { ChipSelect } from '../ChipSelect';
 import { SingleSelect } from '../SingleSelect';
+import { DownloadModalView } from '../DownloadModal';
 
 const SEGMENT_CHIP_THRESHOLD = 5;
 
@@ -27,7 +28,10 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
         totalElevation, routeType, canStart, canNotStartReason,
         showLoopOverwrite, showNextOverwrite, showWorkout, loading,
         initialSettings, segments, prevRides, showPrev: initialShowPrev,
-        onStart, onCancel, onStartWithWorkout, onSettingsChanged, onUpdateStartPos
+        onStart, onCancel, onStartWithWorkout, onSettingsChanged, onUpdateStartPos,
+        downloadButtonLabel, downloadButtonDisabled, onDownloadPress,
+        showDownloadModal, onDownloadModalClose, downloadRows,
+        onDownloadStop, onDownloadRetry, onDownloadDelete
     } = props;
 
     const { logEvent } = useLogging('RouteDetailsView');
@@ -257,6 +261,12 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
 
     const dialogButtons = [
         { label: 'Cancel', onClick: onCancel },
+        ...(downloadButtonLabel ? [{
+            label: downloadButtonLabel,
+            disabled: downloadButtonDisabled,
+            onClick: onDownloadPress,
+            primary: downloadButtonLabel === 'Download',
+        }] : []),
         ...(canStart ? [
             { label: 'Start', primary: true, onClick: () => onStart(data) },
             ...(showWorkout ? [{ label: 'Start with Workout', onClick: () => onStartWithWorkout(data) }] : [])
@@ -284,6 +294,14 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
                     </Text>
                     {canNotStartReason && <Text style={styles.errorText}>{canNotStartReason}</Text>}
                 </View>
+                <DownloadModalView
+                    visible={!!showDownloadModal}
+                    rows={downloadRows ?? []}
+                    onStop={onDownloadStop ?? (() => {})}
+                    onRetry={onDownloadRetry ?? (() => {})}
+                    onDelete={onDownloadDelete ?? (() => {})}
+                    onClose={onDownloadModalClose ?? (() => {})}
+                />
             </Dialog>
         );
     }
@@ -312,6 +330,14 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
                 {renderForm()}
                 {canNotStartReason && <Text style={styles.fullErrorText}>{canNotStartReason}</Text>}
             </View>
+            <DownloadModalView
+                visible={!!showDownloadModal}
+                rows={downloadRows ?? []}
+                onStop={onDownloadStop ?? (() => {})}
+                onRetry={onDownloadRetry ?? (() => {})}
+                onDelete={onDownloadDelete ?? (() => {})}
+                onClose={onDownloadModalClose ?? (() => {})}
+            />
         </Dialog>
     );
 };

--- a/src/components/RouteDetailsDialog/RouteDetailsView.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.tsx
@@ -28,6 +28,7 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
         totalElevation, routeType, canStart, canNotStartReason,
         showLoopOverwrite, showNextOverwrite, showWorkout, loading,
         initialSettings, segments, prevRides, showPrev: initialShowPrev,
+        downloadButtonPrimary,
         onStart, onCancel, onStartWithWorkout, onSettingsChanged, onUpdateStartPos,
         downloadButtonLabel, downloadButtonDisabled, onDownloadPress,
         showDownloadModal, onDownloadModalClose, downloadRows,
@@ -259,19 +260,21 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
         );
     };
 
-    const dialogButtons = [
-        { label: 'Cancel', onClick: onCancel },
-        ...(downloadButtonLabel ? [{
-            label: downloadButtonLabel,
-            disabled: downloadButtonDisabled,
-            onClick: onDownloadPress ?? (() => {}),
-            primary: downloadButtonLabel === 'Download',
-        }] : []),
-        ...(canStart ? [
-            { label: 'Start', primary: true, onClick: () => onStart(data) },
-            ...(showWorkout ? [{ label: 'Start with Workout', onClick: () => onStartWithWorkout(data) }] : [])
-        ] : [])
-    ];
+    const cancelButton = { label: 'Cancel', onClick: onCancel }
+
+    const startButtons = canStart ? [
+        { label: 'Start', primary: true, onClick: () => onStart(data) },
+        ...(showWorkout ? [{ label: 'Start with Workout', onClick: () => onStartWithWorkout(data) }] : [])
+    ] : []
+
+    const downloadButton = downloadButtonLabel ? [{
+        label: downloadButtonLabel,
+        disabled: downloadButtonDisabled,
+        onClick: onDownloadPress ?? (() => {}),
+        primary: downloadButtonPrimary ?? false,
+    }] : []
+
+    const dialogButtons = [cancelButton, ...startButtons, ...downloadButton]
 
     if (compact) {
         const showCompactPanel = (hasGpx && !!points?.length) || !!previewUrl;
@@ -333,6 +336,7 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
             <DownloadModalView
                 visible={!!showDownloadModal}
                 rows={downloadRows ?? []}
+                nested={true}
                 onStop={onDownloadStop ?? (() => {})}
                 onRetry={onDownloadRetry ?? (() => {})}
                 onDelete={onDownloadDelete ?? (() => {})}

--- a/src/components/RouteDetailsDialog/types.ts
+++ b/src/components/RouteDetailsDialog/types.ts
@@ -44,6 +44,7 @@ export interface RouteDetailsViewProps {
     showWorkout: boolean;
     showPrev: boolean;
     loading: boolean;
+    downloadButtonPrimary?: boolean
 
     // Settings
     initialSettings: UIRouteSettings;

--- a/src/components/RouteDetailsDialog/types.ts
+++ b/src/components/RouteDetailsDialog/types.ts
@@ -1,4 +1,4 @@
-import type { UIRouteSettings, UIStartSettings } from 'incyclist-services';
+import type { UIRouteSettings, UIStartSettings, DownloadRowDisplayProps } from 'incyclist-services';
 
 export interface RouteDetailsDialogProps {
     routeId: string     
@@ -58,4 +58,15 @@ export interface RouteDetailsViewProps {
         showPrev?: boolean;
     }>;
     onUpdateStartPos: (value: number) => UIStartSettings | null;
+
+    // Download props
+    downloadButtonLabel?: string;
+    downloadButtonDisabled?: boolean;
+    onDownloadPress?: () => void;
+    showDownloadModal?: boolean;
+    onDownloadModalClose?: () => void;
+    downloadRows?: DownloadRowDisplayProps[];
+    onDownloadStop?: (routeId: string) => void;
+    onDownloadRetry?: (routeId: string) => void;
+    onDownloadDelete?: (routeId: string) => void;
 }

--- a/src/pages/RoutesPage/RoutesPage.tsx
+++ b/src/pages/RoutesPage/RoutesPage.tsx
@@ -1,6 +1,5 @@
 import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useWindowDimensions } from 'react-native';
-import RNFS from 'react-native-fs';
 import { 
     getRoutesPageService, 
     useRouteList,
@@ -151,13 +150,12 @@ export const RoutesPage = () => {
     const onDownloadRetry = useCallback((routeId: string) => {
         const card = routeList.getCard(routeId);
         if (card) {
-            card.setVideoDir(RNFS.DocumentDirectoryPath + '/videos');
             card.download();
         }
     }, [routeList]);
 
     const onDownloadDelete = useCallback((routeId: string) => {
-        routeList.getCard(routeId)?.delete();
+        routeList.getCard(routeId)?.deleteDownload();
     }, [routeList]);
 
     const onNavigate= useCallback( (page:string)=> {


### PR DESCRIPTION
Closes #244

This PR extends the `RouteDetailsDialog` to support route downloads directly from the dialog. 

Key changes:
- Added a dynamic Download button to the `RouteDetailsDialog` button bar.
- The button state (label, disabled, style) reflects the current download status: 'Download', 'Downloading…', 'Downloaded ✓', or 'Retry'.
- Tapping the Download button opens the `DownloadModal` (global download manager).
- If the route is not yet downloaded or failed, tapping the button triggers the download after setting the video directory to the standard path (`DocumentDirectory/videos`).
- The Start button is now disabled while a download is active for the current route.
- Subscribed to the card's download observer to update UI state in real-time.
- Integrated `DownloadModalView` into `RouteDetailsView` for displaying the download progress and managing other active downloads.
- Added unit tests for the new download button variants in `RouteDetailsView`.