### PR TITLE
feat: LandingView and ResultView for ImportRoutesDialog

### DIFF
--- a/src/components/ImportRoutesDialog/views/LandingView.stories.tsx
+++ b/src/components/ImportRoutesDialog/views/LandingView.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { LandingView } from './LandingView';
+
+const meta: Meta<typeof LandingView> = {
+    title: 'Components/ImportRoutesDialog/LandingView',
+    component: LandingView,
+    args: {
+        compact: false,
+        onAddGpx: fn(),
+        onAddVideoRoute: fn(),
+        onSelectFolder: fn(),
+        onCancel: fn(),
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LandingView>;
+
+export const Default: Story = {
+    args: {
+        compact: false,
+    },
+};
+
+export const Compact: Story = {
+    args: {
+        compact: true,
+    },
+};

--- a/src/components/ImportRoutesDialog/views/LandingView.test.tsx
+++ b/src/components/ImportRoutesDialog/views/LandingView.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
+import { Platform } from 'react-native';
 import { LandingView } from './LandingView';
 
 describe('LandingView', () => {
@@ -17,5 +18,15 @@ describe('LandingView', () => {
 
     it('renders without crashing in compact mode', () => {
         render(<LandingView {...defaultProps} compact={true} />);
+    });
+
+    it('renders correctly on iOS', () => {
+        Object.defineProperty(Platform, 'OS', { value: 'ios', configurable: true });
+        render(<LandingView {...defaultProps} />);
+    });
+
+    it('renders correctly on Android', () => {
+        Object.defineProperty(Platform, 'OS', { value: 'android', configurable: true });
+        render(<LandingView {...defaultProps} />);
     });
 });

--- a/src/components/ImportRoutesDialog/views/LandingView.test.tsx
+++ b/src/components/ImportRoutesDialog/views/LandingView.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { LandingView } from './LandingView';
+
+describe('LandingView', () => {
+    const defaultProps = {
+        compact: false,
+        onAddGpx: jest.fn(),
+        onAddVideoRoute: jest.fn(),
+        onSelectFolder: jest.fn(),
+        onCancel: jest.fn(),
+    };
+
+    it('renders without crashing in normal mode', () => {
+        render(<LandingView {...defaultProps} />);
+    });
+
+    it('renders without crashing in compact mode', () => {
+        render(<LandingView {...defaultProps} compact={true} />);
+    });
+});

--- a/src/components/ImportRoutesDialog/views/LandingView.tsx
+++ b/src/components/ImportRoutesDialog/views/LandingView.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, Platform } from 'react-native';
 import { colors, textSizes } from '../../../theme';
 import { Icon } from '../../Icon';
 import { IconName } from '../../Icon/types';
@@ -63,13 +63,15 @@ export const LandingView = ({
                     onPress={onAddGpx} 
                     compact={compact} 
                 />
-                <OptionTile 
-                    icon='plus' 
-                    title='Add Video Route' 
-                    subtitle='EPM, RLV or XML file' 
-                    onPress={onAddVideoRoute} 
-                    compact={compact} 
-                />
+                {Platform.OS === 'ios' && (
+                    <OptionTile 
+                        icon='plus' 
+                        title='Add Video Route' 
+                        subtitle='EPM, RLV or XML file' 
+                        onPress={onAddVideoRoute} 
+                        compact={compact} 
+                    />
+                )}
                 <OptionTile 
                     icon='import-route' 
                     title='Import Video Library' 
@@ -129,6 +131,6 @@ const styles = StyleSheet.create({
         marginTop: 2,
     },
     tileSubtitleCompact: {
-        fontSize: 10,
+        fontSize: textSizes.smallText,
     },
 });

--- a/src/components/ImportRoutesDialog/views/LandingView.tsx
+++ b/src/components/ImportRoutesDialog/views/LandingView.tsx
@@ -1,0 +1,134 @@
+import React, { useMemo } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { colors, textSizes } from '../../../theme';
+import { Icon } from '../../Icon';
+import { IconName } from '../../Icon/types';
+import { ButtonBar } from '../../ButtonBar/ButtonBar';
+
+interface LandingViewProps {
+    compact: boolean;
+    onAddGpx: () => void;
+    onAddVideoRoute: () => void;
+    onSelectFolder: () => void;
+    onCancel: () => void;
+}
+
+const OptionTile = ({ 
+    icon, 
+    title, 
+    subtitle, 
+    onPress, 
+    compact 
+}: { 
+    icon: IconName; 
+    title: string; 
+    subtitle: string; 
+    onPress: () => void; 
+    compact: boolean;
+}) => {
+    return (
+        <TouchableOpacity 
+            style={[styles.tile, compact && styles.tileCompact]} 
+            onPress={onPress}
+        >
+            <View style={styles.iconContainer}>
+                <Icon name={icon} size={compact ? 24 : 32} color={colors.icon} />
+            </View>
+            <View style={styles.textContainer}>
+                <Text style={[styles.tileTitle, compact && styles.tileTitleCompact]}>{title}</Text>
+                <Text style={[styles.tileSubtitle, compact && styles.tileSubtitleCompact]}>{subtitle}</Text>
+            </View>
+        </TouchableOpacity>
+    );
+};
+
+export const LandingView = ({ 
+    compact, 
+    onAddGpx, 
+    onAddVideoRoute, 
+    onSelectFolder, 
+    onCancel 
+}: LandingViewProps) => {
+    const buttons = useMemo(() => [
+        { label: 'Cancel', onClick: onCancel }
+    ], [onCancel]);
+
+    return (
+        <View style={[styles.container, compact && styles.containerCompact]}>
+            <View style={styles.optionsContainer}>
+                <OptionTile 
+                    icon='plus' 
+                    title='Add GPX' 
+                    subtitle='Individual route file' 
+                    onPress={onAddGpx} 
+                    compact={compact} 
+                />
+                <OptionTile 
+                    icon='plus' 
+                    title='Add Video Route' 
+                    subtitle='EPM, RLV or XML file' 
+                    onPress={onAddVideoRoute} 
+                    compact={compact} 
+                />
+                <OptionTile 
+                    icon='import-route' 
+                    title='Import Video Library' 
+                    subtitle='Scan folder for videos' 
+                    onPress={onSelectFolder} 
+                    compact={compact} 
+                />
+            </View>
+            <ButtonBar buttons={buttons} />
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        padding: 20,
+        flex: 1,
+    },
+    containerCompact: {
+        padding: 10,
+    },
+    optionsContainer: {
+        flex: 1,
+        justifyContent: 'center',
+    },
+    tile: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        backgroundColor: colors.listItemBackground,
+        borderRadius: 8,
+        padding: 16,
+        marginVertical: 8,
+    },
+    tileCompact: {
+        padding: 12,
+        marginVertical: 4,
+    },
+    iconContainer: {
+        marginRight: 16,
+        width: 40,
+        alignItems: 'center',
+    },
+    textContainer: {
+        flex: 1,
+    },
+    tileTitle: {
+        fontSize: textSizes.listEntry,
+        color: colors.text,
+        fontWeight: '700',
+    },
+    tileTitleCompact: {
+        fontSize: textSizes.normalText,
+    },
+    tileSubtitle: {
+        fontSize: textSizes.smallText,
+        color: colors.disabled,
+        marginTop: 2,
+    },
+    tileSubtitleCompact: {
+        fontSize: 10,
+    },
+});

--- a/src/components/ImportRoutesDialog/views/ResultView.stories.tsx
+++ b/src/components/ImportRoutesDialog/views/ResultView.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { ResultView } from './ResultView';
+
+const meta: Meta<typeof ResultView> = {
+    title: 'Components/ImportRoutesDialog/ResultView',
+    component: ResultView,
+    args: {
+        compact: false,
+        success: true,
+        routeName: 'Alpe d\'Huez',
+        onDone: fn(),
+        onTryAgain: fn(),
+        onCancel: fn(),
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ResultView>;
+
+export const Success: Story = {
+    args: {
+        success: true,
+    },
+};
+
+export const SuccessCompact: Story = {
+    args: {
+        success: true,
+        compact: true,
+    },
+};
+
+export const Error: Story = {
+    args: {
+        success: false,
+        error: 'The file format is not recognized or is corrupted.',
+    },
+};
+
+export const ErrorCompact: Story = {
+    args: {
+        success: false,
+        compact: true,
+        error: 'Network connection lost.',
+    },
+};

--- a/src/components/ImportRoutesDialog/views/ResultView.test.tsx
+++ b/src/components/ImportRoutesDialog/views/ResultView.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { ResultView } from './ResultView';
+
+describe('ResultView', () => {
+    const defaultProps = {
+        compact: false,
+        success: true,
+        routeName: 'Test Route',
+        onDone: jest.fn(),
+        onTryAgain: jest.fn(),
+        onCancel: jest.fn(),
+    };
+
+    it('renders success state without crashing', () => {
+        render(<ResultView {...defaultProps} />);
+    });
+
+    it('renders error state without crashing', () => {
+        render(<ResultView {...defaultProps} success={false} error="Failed to load file" />);
+    });
+
+    it('renders in compact mode without crashing', () => {
+        render(<ResultView {...defaultProps} compact={true} />);
+    });
+});

--- a/src/components/ImportRoutesDialog/views/ResultView.tsx
+++ b/src/components/ImportRoutesDialog/views/ResultView.tsx
@@ -1,0 +1,108 @@
+import React, { useMemo } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { colors, textSizes } from '../../../theme';
+import { Icon } from '../../Icon';
+import { ButtonBar } from '../../ButtonBar/ButtonBar';
+
+interface ResultViewProps {
+    compact: boolean;
+    success: boolean;
+    routeName?: string;
+    error?: string;
+    onDone: () => void;
+    onTryAgain: () => void;
+    onCancel: () => void;
+}
+
+export const ResultView = ({ 
+    compact, 
+    success, 
+    routeName, 
+    error, 
+    onDone, 
+    onTryAgain, 
+    onCancel 
+}: ResultViewProps) => {
+    const buttons = useMemo(() => {
+        if (success) {
+            return [
+                { label: 'Done', primary: true, onClick: onDone }
+            ];
+        }
+        return [
+            { label: 'Try Again', primary: true, onClick: onTryAgain },
+            { label: 'Cancel', onClick: onCancel }
+        ];
+    }, [success, onDone, onTryAgain, onCancel]);
+
+    const statusColor = success ? colors.success : colors.error;
+    const title = success ? 'Import Successful' : 'Import Failed';
+    const message = success 
+        ? (routeName ? `Route "${routeName}" has been added.` : 'The route has been added to your library.')
+        : (error || 'An unexpected error occurred during import.');
+
+    return (
+        <View style={[styles.container, compact && styles.containerCompact]}>
+            <View style={styles.content}>
+                <View style={[styles.iconCircle, { borderColor: statusColor }]}>
+                    <Icon 
+                        name={success ? 'import-route' : 'funnel'} 
+                        size={compact ? 40 : 64} 
+                        color={statusColor} 
+                    />
+                </View>
+                <Text style={[styles.title, compact && styles.titleCompact]}>{title}</Text>
+                <Text style={[styles.message, compact && styles.messageCompact]}>{message}</Text>
+            </View>
+            <ButtonBar buttons={buttons} />
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        padding: 20,
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    containerCompact: {
+        padding: 10,
+    },
+    content: {
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: '100%',
+    },
+    iconCircle: {
+        width: 100,
+        height: 100,
+        borderRadius: 50,
+        borderWidth: 4,
+        alignItems: 'center',
+        justifyContent: 'center',
+        marginBottom: 24,
+    },
+    title: {
+        fontSize: textSizes.dialogTitle,
+        color: colors.text,
+        fontWeight: '700',
+        marginBottom: 12,
+        textAlign: 'center',
+    },
+    titleCompact: {
+        fontSize: textSizes.listEntry,
+        marginBottom: 8,
+    },
+    message: {
+        fontSize: textSizes.normalText,
+        color: colors.disabled,
+        textAlign: 'center',
+        paddingHorizontal: 20,
+    },
+    messageCompact: {
+        fontSize: textSizes.smallText,
+        paddingHorizontal: 10,
+    },
+});

--- a/src/components/ImportRoutesDialog/views/ResultView.tsx
+++ b/src/components/ImportRoutesDialog/views/ResultView.tsx
@@ -37,9 +37,15 @@ export const ResultView = ({
 
     const statusColor = success ? colors.success : colors.error;
     const title = success ? 'Import Successful' : 'Import Failed';
-    const message = success 
-        ? (routeName ? `Route "${routeName}" has been added.` : 'The route has been added to your library.')
-        : (error || 'An unexpected error occurred during import.');
+    
+    let message: string;
+    if (success) {
+        message = routeName
+            ? `Route "${routeName}" has been added.`
+            : 'The route has been added to your library.';
+    } else {
+        message = error || 'An unexpected error occurred during import.';
+    }
 
     return (
         <View style={[styles.container, compact && styles.containerCompact]}>

--- a/src/components/ImportRoutesDialog/views/ResultView.tsx
+++ b/src/components/ImportRoutesDialog/views/ResultView.tsx
@@ -47,10 +47,12 @@ export const ResultView = ({
         message = error || 'An unexpected error occurred during import.';
     }
 
+    const iconCircleStyle = { borderColor: statusColor };
+
     return (
         <View style={[styles.container, compact && styles.containerCompact]}>
             <View style={styles.content}>
-                <View style={[styles.iconCircle, { borderColor: statusColor }]}>
+                <View style={[styles.iconCircle, iconCircleStyle]}>
                     <Icon 
                         name={success ? 'import-route' : 'funnel'} 
                         size={compact ? 40 : 64} 


### PR DESCRIPTION
Closes #266

This PR implements the pure view components for the Import Routes dialog:
- **LandingView**: Entry screen with three import options (GPX, Video Route, Library) and a Cancel button.
- **ResultView**: Success and Error outcome screens with appropriate icons, messages, and action buttons.

Key features:
- Support for compact and normal layouts via `compact` prop.
- Full TypeScript coverage.
- Storybook stories for all states.
- Unit tests for rendering sanity check.