### PR TITLE
ImportRoutesDialog — ScanningView and ParseSelectionView

### DIFF
--- a/src/components/ImportRoutesDialog/views/ParseSelectionView.stories.tsx
+++ b/src/components/ImportRoutesDialog/views/ParseSelectionView.stories.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { fn } from 'storybook/test';
 import { ParseSelectionView } from './ParseSelectionView';
+import type { RouteDisplayItem } from 'incyclist-services';
 
-const mockRoutes = [
+const mockRoutes: RouteDisplayItem[] = [
     { 
         id: '1', 
         label: 'Sunday Ride to the Lake', 
         format: 'gpx', 
-        distance: { value: 42.5, unit: 'km' }, 
+        distance: { value: 42.5, unit: 'km' as any }, 
         importable: true, 
         alreadyImported: false 
     },
@@ -15,7 +16,7 @@ const mockRoutes = [
         id: '2', 
         label: 'Mountain Pass Challenge', 
         format: 'fit', 
-        distance: { value: 120.2, unit: 'km' }, 
+        distance: { value: 120.2, unit: 'km' as any }, 
         importable: true, 
         alreadyImported: false 
     },
@@ -23,7 +24,7 @@ const mockRoutes = [
         id: '3', 
         label: 'Invalid Route File', 
         format: 'txt', 
-        distance: { value: 0, unit: 'km' }, 
+        distance: { value: 0, unit: 'km' as any }, 
         importable: false, 
         alreadyImported: false, 
         errorReason: 'Unsupported format' 
@@ -32,7 +33,7 @@ const mockRoutes = [
         id: '4', 
         label: 'Already In Library', 
         format: 'gpx', 
-        distance: { value: 15.0, unit: 'km' }, 
+        distance: { value: 15.0, unit: 'km' as any }, 
         importable: true, 
         alreadyImported: true 
     },

--- a/src/components/ImportRoutesDialog/views/ParseSelectionView.stories.tsx
+++ b/src/components/ImportRoutesDialog/views/ParseSelectionView.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { ParseSelectionView } from './ParseSelectionView';
+
+const mockRoutes = [
+    { id: '1', label: 'Sunday Ride to the Lake', format: 'gpx', distance: 42.5, importable: true },
+    { id: '2', label: 'Mountain Pass Challenge', format: 'fit', distance: 120.2, importable: true },
+    { id: '3', label: 'Invalid Route File', format: 'txt', distance: 0, importable: false, errorReason: 'Unsupported format' },
+    { id: '4', label: 'Already In Library', format: 'gpx', distance: 15.0, importable: true, alreadyImported: true },
+];
+
+const meta: Meta<typeof ParseSelectionView> = {
+    title: 'Components/ImportRoutesDialog/ParseSelectionView',
+    component: ParseSelectionView,
+    args: {
+        compact: false,
+        routes: mockRoutes,
+        selectedIds: ['1'],
+        onToggle: fn(),
+        onSelectAll: fn(),
+        onDeselectAll: fn(),
+        onConfirm: fn(),
+        onCancel: fn(),
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof ParseSelectionView>;
+
+export const Parsing: Story = {
+    args: {
+        routes: mockRoutes.slice(0, 2),
+        parseProgress: { parsed: 2, total: 10 },
+    },
+};
+
+export const ParseComplete: Story = {
+    args: {
+        parseProgress: undefined,
+        selectedIds: ['1', '2'],
+    },
+};
+
+export const MixedStates: Story = {
+    args: {
+        routes: mockRoutes,
+        selectedIds: ['2'],
+    },
+};
+
+export const Compact: Story = {
+    args: {
+        compact: true,
+        routes: mockRoutes,
+    },
+};

--- a/src/components/ImportRoutesDialog/views/ParseSelectionView.stories.tsx
+++ b/src/components/ImportRoutesDialog/views/ParseSelectionView.stories.tsx
@@ -3,10 +3,39 @@ import { fn } from 'storybook/test';
 import { ParseSelectionView } from './ParseSelectionView';
 
 const mockRoutes = [
-    { id: '1', label: 'Sunday Ride to the Lake', format: 'gpx', distance: 42.5, importable: true },
-    { id: '2', label: 'Mountain Pass Challenge', format: 'fit', distance: 120.2, importable: true },
-    { id: '3', label: 'Invalid Route File', format: 'txt', distance: 0, importable: false, errorReason: 'Unsupported format' },
-    { id: '4', label: 'Already In Library', format: 'gpx', distance: 15.0, importable: true, alreadyImported: true },
+    { 
+        id: '1', 
+        label: 'Sunday Ride to the Lake', 
+        format: 'gpx', 
+        distance: { value: 42.5, unit: 'km' }, 
+        importable: true, 
+        alreadyImported: false 
+    },
+    { 
+        id: '2', 
+        label: 'Mountain Pass Challenge', 
+        format: 'fit', 
+        distance: { value: 120.2, unit: 'km' }, 
+        importable: true, 
+        alreadyImported: false 
+    },
+    { 
+        id: '3', 
+        label: 'Invalid Route File', 
+        format: 'txt', 
+        distance: { value: 0, unit: 'km' }, 
+        importable: false, 
+        alreadyImported: false, 
+        errorReason: 'Unsupported format' 
+    },
+    { 
+        id: '4', 
+        label: 'Already In Library', 
+        format: 'gpx', 
+        distance: { value: 15.0, unit: 'km' }, 
+        importable: true, 
+        alreadyImported: true 
+    },
 ];
 
 const meta: Meta<typeof ParseSelectionView> = {

--- a/src/components/ImportRoutesDialog/views/ParseSelectionView.test.tsx
+++ b/src/components/ImportRoutesDialog/views/ParseSelectionView.test.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import { ParseSelectionView } from './ParseSelectionView';
+import type { RouteDisplayItem } from 'incyclist-services';
 
-const mockRoutes = [
+const mockRoutes: RouteDisplayItem[] = [
     { 
         id: '1', 
         label: 'Route 1', 
         format: 'gpx', 
-        distance: { value: 10, unit: 'km' }, 
+        distance: { value: 10, unit: 'km' as any }, 
         importable: true, 
         alreadyImported: false 
     },
@@ -15,7 +16,7 @@ const mockRoutes = [
         id: '2', 
         label: 'Route 2', 
         format: 'fit', 
-        distance: { value: 15, unit: 'km' }, 
+        distance: { value: 15, unit: 'km' as any }, 
         importable: false, 
         alreadyImported: false, 
         errorReason: 'Invalid file' 

--- a/src/components/ImportRoutesDialog/views/ParseSelectionView.test.tsx
+++ b/src/components/ImportRoutesDialog/views/ParseSelectionView.test.tsx
@@ -3,8 +3,23 @@ import { render } from '@testing-library/react-native';
 import { ParseSelectionView } from './ParseSelectionView';
 
 const mockRoutes = [
-    { id: '1', label: 'Route 1', format: 'gpx', distance: 10, importable: true },
-    { id: '2', label: 'Route 2', format: 'fit', distance: 15, importable: false, errorReason: 'Invalid file' },
+    { 
+        id: '1', 
+        label: 'Route 1', 
+        format: 'gpx', 
+        distance: { value: 10, unit: 'km' }, 
+        importable: true, 
+        alreadyImported: false 
+    },
+    { 
+        id: '2', 
+        label: 'Route 2', 
+        format: 'fit', 
+        distance: { value: 15, unit: 'km' }, 
+        importable: false, 
+        alreadyImported: false, 
+        errorReason: 'Invalid file' 
+    },
 ];
 
 describe('ParseSelectionView', () => {

--- a/src/components/ImportRoutesDialog/views/ParseSelectionView.test.tsx
+++ b/src/components/ImportRoutesDialog/views/ParseSelectionView.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { ParseSelectionView } from './ParseSelectionView';
+
+const mockRoutes = [
+    { id: '1', label: 'Route 1', format: 'gpx', distance: 10, importable: true },
+    { id: '2', label: 'Route 2', format: 'fit', distance: 15, importable: false, errorReason: 'Invalid file' },
+];
+
+describe('ParseSelectionView', () => {
+    it('renders route labels correctly', () => {
+        const { getByText } = render(
+            <ParseSelectionView
+                compact={false}
+                routes={mockRoutes}
+                selectedIds={['1']}
+                onToggle={() => {}}
+                onSelectAll={() => {}}
+                onDeselectAll={() => {}}
+                onConfirm={() => {}}
+                onCancel={() => {}}
+            />
+        );
+        expect(getByText('Route 1')).toBeTruthy();
+        expect(getByText('Route 2')).toBeTruthy();
+    });
+
+    it('shows parsing progress when provided', () => {
+        const { getByText } = render(
+            <ParseSelectionView
+                compact={false}
+                routes={[]}
+                parseProgress={{ parsed: 5, total: 10 }}
+                selectedIds={[]}
+                onToggle={() => {}}
+                onSelectAll={() => {}}
+                onDeselectAll={() => {}}
+                onConfirm={() => {}}
+                onCancel={() => {}}
+            />
+        );
+        expect(getByText(/Parsing: 5\/10/)).toBeTruthy();
+    });
+});

--- a/src/components/ImportRoutesDialog/views/ParseSelectionView.tsx
+++ b/src/components/ImportRoutesDialog/views/ParseSelectionView.tsx
@@ -1,0 +1,298 @@
+import React, { useCallback } from 'react';
+import { View, Text, StyleSheet, FlatList, TouchableOpacity } from 'react-native';
+import type { RouteDisplayItem } from 'incyclist-services';
+import { colors, textSizes } from '../../../theme';
+import { ButtonBar } from '../../ButtonBar';
+import { Icon } from '../../Icon';
+
+interface ParseSelectionViewProps {
+    compact: boolean;
+    routes: RouteDisplayItem[];
+    parseProgress?: { parsed: number; total: number };
+    selectedIds: string[];
+    onToggle: (id: string) => void;
+    onSelectAll: () => void;
+    onDeselectAll: () => void;
+    onConfirm: () => void;
+    onCancel: () => void;
+}
+
+const Checkbox = ({ checked, disabled, onToggle }: { checked: boolean; disabled?: boolean; onToggle: () => void }) => {
+    const boxStyle = [
+        styles.checkbox,
+        checked && styles.checkboxChecked,
+        disabled && styles.checkboxDisabled
+    ];
+    
+    return (
+        <TouchableOpacity 
+            onPress={onToggle} 
+            disabled={disabled} 
+            style={boxStyle}
+            activeOpacity={0.7}
+        >
+            {checked && <View style={styles.checkmark} />}
+        </TouchableOpacity>
+    );
+};
+
+const WarningIndicator = () => (
+    <View style={styles.warningIndicator}>
+        <Text style={styles.warningChar}>!</Text>
+    </View>
+);
+
+const RouteRow = ({ 
+    item, 
+    isSelected, 
+    onToggle, 
+    compact 
+}: { 
+    item: RouteDisplayItem; 
+    isSelected: boolean; 
+    onToggle: (id: string) => void;
+    compact: boolean;
+}) => {
+    const handleToggle = useCallback(() => onToggle(item.id), [item.id, onToggle]);
+    const isImportable = item.importable !== false;
+
+    return (
+        <View style={[styles.row, !isImportable && styles.rowDisabled]}>
+            <Checkbox 
+                checked={isSelected} 
+                disabled={!isImportable} 
+                onToggle={handleToggle} 
+            />
+            <View style={styles.rowContent}>
+                <Text style={[styles.label, compact && styles.labelCompact]} numberOfLines={1}>
+                    {item.label}
+                </Text>
+                <View style={styles.details}>
+                    <View style={styles.badge}>
+                        <Text style={styles.badgeText}>{item.format.toUpperCase()}</Text>
+                    </View>
+                    {item.distance !== undefined && (
+                        <View style={styles.distance}>
+                            <Icon name="distance" size={14} color={colors.text} />
+                            <Text style={styles.distanceText}>{item.distance.toFixed(1)} km</Text>
+                        </View>
+                    )}
+                </View>
+                {!isImportable && item.errorReason && (
+                    <Text style={styles.errorText}>{item.errorReason}</Text>
+                )}
+            </View>
+            {!isImportable && <WarningIndicator />}
+        </View>
+    );
+};
+
+export const ParseSelectionView = ({
+    compact,
+    routes,
+    parseProgress,
+    selectedIds,
+    onToggle,
+    onSelectAll,
+    onDeselectAll,
+    onConfirm,
+    onCancel,
+}: ParseSelectionViewProps) => {
+    const isParsing = !!parseProgress;
+    
+    const renderItem = useCallback(({ item }: { item: RouteDisplayItem }) => (
+        <RouteRow 
+            item={item} 
+            isSelected={selectedIds.includes(item.id)} 
+            onToggle={onToggle}
+            compact={compact}
+        />
+    ), [selectedIds, onToggle, compact]);
+
+    const buttons = [
+        {
+            label: `Import (${selectedIds.length})`,
+            onClick: isParsing ? () => {} : onConfirm,
+            primary: true,
+        },
+        {
+            label: 'Cancel',
+            onClick: onCancel,
+            primary: false,
+        },
+    ];
+
+    return (
+        <View style={[styles.container, compact && styles.containerCompact]}>
+            <View style={styles.header}>
+                {isParsing ? (
+                    <Text style={styles.title}>
+                        Found {parseProgress.total} files... Parsing: {parseProgress.parsed}/{parseProgress.total}
+                    </Text>
+                ) : (
+                    <Text style={styles.title}>Select routes to import</Text>
+                )}
+            </View>
+
+            <View style={styles.bulkActions}>
+                <TouchableOpacity onPress={onSelectAll} style={styles.bulkButton}>
+                    <Text style={styles.bulkText}>Select All</Text>
+                </TouchableOpacity>
+                <TouchableOpacity onPress={onDeselectAll} style={styles.bulkButton}>
+                    <Text style={styles.bulkText}>Deselect All</Text>
+                </TouchableOpacity>
+            </View>
+
+            <FlatList
+                data={routes}
+                keyExtractor={(item) => item.id}
+                renderItem={renderItem}
+                style={styles.list}
+                contentContainerStyle={styles.listContent}
+            />
+
+            <View style={[styles.footer, isParsing && styles.footerDisabled]}>
+                <ButtonBar buttons={buttons} />
+            </View>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        minHeight: 400,
+    },
+    containerCompact: {
+        minHeight: 300,
+    },
+    header: {
+        paddingHorizontal: 20,
+        paddingTop: 16,
+    },
+    title: {
+        fontSize: textSizes.normalText,
+        color: colors.text,
+        fontWeight: 'bold',
+    },
+    bulkActions: {
+        flexDirection: 'row',
+        paddingHorizontal: 20,
+        paddingVertical: 12,
+        gap: 16,
+    },
+    bulkButton: {
+        paddingVertical: 4,
+    },
+    bulkText: {
+        color: colors.buttonPrimary,
+        fontSize: textSizes.smallText,
+        fontWeight: 'bold',
+    },
+    list: {
+        flex: 1,
+    },
+    listContent: {
+        paddingHorizontal: 20,
+        paddingBottom: 20,
+    },
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingVertical: 12,
+        borderBottomWidth: 1,
+        borderBottomColor: colors.listSeparator,
+    },
+    rowDisabled: {
+        opacity: 0.7,
+    },
+    rowContent: {
+        flex: 1,
+    },
+    label: {
+        fontSize: textSizes.listEntry,
+        color: colors.text,
+        fontWeight: '500',
+    },
+    labelCompact: {
+        fontSize: textSizes.normalText,
+    },
+    details: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginTop: 4,
+    },
+    badge: {
+        backgroundColor: colors.listItemBackground,
+        paddingHorizontal: 6,
+        paddingVertical: 2,
+        borderRadius: 4,
+        marginRight: 10,
+        borderWidth: 1,
+        borderColor: colors.tileIdle,
+    },
+    badgeText: {
+        fontSize: 10,
+        color: colors.text,
+        fontWeight: 'bold',
+    },
+    distance: {
+        flexDirection: 'row',
+        alignItems: 'center',
+    },
+    distanceText: {
+        fontSize: textSizes.smallText,
+        color: colors.text,
+        marginLeft: 4,
+    },
+    errorText: {
+        fontSize: 11,
+        color: colors.error,
+        marginTop: 4,
+    },
+    checkbox: {
+        width: 22,
+        height: 22,
+        borderWidth: 2,
+        borderColor: colors.buttonPrimary,
+        borderRadius: 4,
+        marginRight: 16,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    checkboxChecked: {
+        backgroundColor: colors.buttonPrimary,
+    },
+    checkboxDisabled: {
+        borderColor: colors.disabled,
+        backgroundColor: 'transparent',
+    },
+    checkmark: {
+        width: 10,
+        height: 10,
+        backgroundColor: '#FFFFFF',
+        borderRadius: 2,
+    },
+    warningIndicator: {
+        width: 20,
+        height: 20,
+        borderRadius: 10,
+        backgroundColor: colors.warning,
+        justifyContent: 'center',
+        alignItems: 'center',
+        marginLeft: 8,
+    },
+    warningChar: {
+        color: '#000000',
+        fontSize: 14,
+        fontWeight: 'bold',
+    },
+    footer: {
+        borderTopWidth: 1,
+        borderTopColor: colors.listSeparator,
+        paddingTop: 8,
+    },
+    footerDisabled: {
+        opacity: 0.5,
+    },
+});

--- a/src/components/ImportRoutesDialog/views/ParseSelectionView.tsx
+++ b/src/components/ImportRoutesDialog/views/ParseSelectionView.tsx
@@ -55,16 +55,18 @@ const RouteRow = ({
 }) => {
     const handleToggle = useCallback(() => onToggle(item.id), [item.id, onToggle]);
     const isImportable = item.importable !== false;
+    const rowStyle = [styles.row, !isImportable && styles.rowDisabled];
+    const labelStyle = [styles.label, compact && styles.labelCompact];
 
     return (
-        <View style={[styles.row, !isImportable && styles.rowDisabled]}>
+        <View style={rowStyle}>
             <Checkbox 
                 checked={isSelected} 
                 disabled={!isImportable} 
                 onToggle={handleToggle} 
             />
             <View style={styles.rowContent}>
-                <Text style={[styles.label, compact && styles.labelCompact]} numberOfLines={1}>
+                <Text style={labelStyle} numberOfLines={1}>
                     {item.label}
                 </Text>
                 <View style={styles.details}>
@@ -101,6 +103,7 @@ export const ParseSelectionView = ({
     onCancel,
 }: ParseSelectionViewProps) => {
     const isParsing = !!parseProgress;
+    const noop = useCallback(() => {}, []);
     
     const renderItem = useCallback(({ item: routeItem }: { item: RouteDisplayItem }) => (
         <RouteRow 
@@ -114,7 +117,7 @@ export const ParseSelectionView = ({
     const buttons = [
         {
             label: `Import (${selectedIds.length})`,
-            onClick: isParsing ? () => {} : onConfirm,
+            onClick: isParsing ? noop : onConfirm,
             primary: true,
         },
         {
@@ -124,8 +127,11 @@ export const ParseSelectionView = ({
         },
     ];
 
+    const containerStyle = [styles.container, compact && styles.containerCompact];
+    const footerStyle = [styles.footer, isParsing && styles.footerDisabled];
+
     return (
-        <View style={[styles.container, compact && styles.containerCompact]}>
+        <View style={containerStyle}>
             <View style={styles.header}>
                 {isParsing ? (
                     <Text style={styles.title}>
@@ -153,7 +159,7 @@ export const ParseSelectionView = ({
                 contentContainerStyle={styles.listContent}
             />
 
-            <View style={[styles.footer, isParsing && styles.footerDisabled]}>
+            <View style={footerStyle}>
                 <ButtonBar buttons={buttons} />
             </View>
         </View>

--- a/src/components/ImportRoutesDialog/views/ParseSelectionView.tsx
+++ b/src/components/ImportRoutesDialog/views/ParseSelectionView.tsx
@@ -240,7 +240,7 @@ const styles = StyleSheet.create({
         borderColor: colors.tileIdle,
     },
     badgeText: {
-        fontSize: 10,
+        fontSize: textSizes.microText,
         color: colors.text,
         fontWeight: 'bold',
     },
@@ -254,7 +254,7 @@ const styles = StyleSheet.create({
         marginLeft: 4,
     },
     errorText: {
-        fontSize: 11,
+        fontSize: textSizes.tinyText,
         color: colors.error,
         marginTop: 4,
     },
@@ -278,7 +278,7 @@ const styles = StyleSheet.create({
     checkmark: {
         width: 10,
         height: 10,
-        backgroundColor: '#FFFFFF',
+        backgroundColor: colors.text,
         borderRadius: 2,
     },
     warningIndicator: {
@@ -291,8 +291,8 @@ const styles = StyleSheet.create({
         marginLeft: 8,
     },
     warningChar: {
-        color: '#000000',
-        fontSize: 14,
+        color: colors.iconSelected,
+        fontSize: textSizes.subtitle,
         fontWeight: 'bold',
     },
     footer: {

--- a/src/components/ImportRoutesDialog/views/ParseSelectionView.tsx
+++ b/src/components/ImportRoutesDialog/views/ParseSelectionView.tsx
@@ -73,8 +73,10 @@ const RouteRow = ({
                     </View>
                     {item.distance !== undefined && (
                         <View style={styles.distance}>
-                            <Icon name="distance" size={14} color={colors.text} />
-                            <Text style={styles.distanceText}>{item.distance.toFixed(1)} km</Text>
+                            <Icon name='distance' size={14} color={colors.text} />
+                            <Text style={styles.distanceText}>
+                                {item.distance.value} {item.distance.unit}
+                            </Text>
                         </View>
                     )}
                 </View>
@@ -100,10 +102,10 @@ export const ParseSelectionView = ({
 }: ParseSelectionViewProps) => {
     const isParsing = !!parseProgress;
     
-    const renderItem = useCallback(({ item }: { item: RouteDisplayItem }) => (
+    const renderItem = useCallback(({ item: routeItem }: { item: RouteDisplayItem }) => (
         <RouteRow 
-            item={item} 
-            isSelected={selectedIds.includes(item.id)} 
+            item={routeItem} 
+            isSelected={selectedIds.includes(routeItem.id)} 
             onToggle={onToggle}
             compact={compact}
         />

--- a/src/components/ImportRoutesDialog/views/ScanningView.stories.tsx
+++ b/src/components/ImportRoutesDialog/views/ScanningView.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { ScanningView } from './ScanningView';
+
+const meta: Meta<typeof ScanningView> = {
+    title: 'Components/ImportRoutesDialog/ScanningView',
+    component: ScanningView,
+    args: {
+        compact: false,
+        scannedFolders: 0,
+        onCancel: fn(),
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof ScanningView>;
+
+export const Default: Story = {
+    args: {
+        scannedFolders: 5,
+    },
+};
+
+export const Compact: Story = {
+    args: {
+        compact: true,
+        scannedFolders: 12,
+    },
+};

--- a/src/components/ImportRoutesDialog/views/ScanningView.test.tsx
+++ b/src/components/ImportRoutesDialog/views/ScanningView.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { ScanningView } from './ScanningView';
+
+describe('ScanningView', () => {
+    it('renders folder count correctly', () => {
+        const { getByText } = render(
+            <ScanningView compact={false} scannedFolders={15} onCancel={() => {}} />
+        );
+        expect(getByText('Folders scanned: 15')).toBeTruthy();
+    });
+
+    it('renders in compact mode without crashing', () => {
+        render(<ScanningView compact={true} scannedFolders={5} onCancel={() => {}} />);
+    });
+});

--- a/src/components/ImportRoutesDialog/views/ScanningView.tsx
+++ b/src/components/ImportRoutesDialog/views/ScanningView.tsx
@@ -19,6 +19,8 @@ export const ScanningView = ({ compact, scannedFolders, onCancel }: ScanningView
     ];
 
     const containerStyle = [styles.container, compact && styles.containerCompact];
+    const titleStyle = [styles.title, compact && styles.titleCompact];
+    const textStyle = [styles.text, compact && styles.textCompact];
 
     return (
         <View style={containerStyle}>
@@ -27,10 +29,10 @@ export const ScanningView = ({ compact, scannedFolders, onCancel }: ScanningView
                 color={colors.buttonPrimary} 
                 style={styles.spinner} 
             />
-            <Text style={[styles.title, compact && styles.titleCompact]}>
+            <Text style={titleStyle}>
                 Scanning for routes...
             </Text>
-            <Text style={[styles.text, compact && styles.textCompact]}>
+            <Text style={textStyle}>
                 Folders scanned: {scannedFolders}
             </Text>
             <View style={styles.footer}>

--- a/src/components/ImportRoutesDialog/views/ScanningView.tsx
+++ b/src/components/ImportRoutesDialog/views/ScanningView.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import { colors, textSizes } from '../../../theme';
+import { ButtonBar } from '../../ButtonBar';
+
+interface ScanningViewProps {
+    compact: boolean;
+    scannedFolders: number;
+    onCancel: () => void;
+}
+
+export const ScanningView = ({ compact, scannedFolders, onCancel }: ScanningViewProps) => {
+    const buttons = [
+        {
+            label: 'Cancel',
+            onClick: onCancel,
+            primary: false,
+        },
+    ];
+
+    const containerStyle = [styles.container, compact && styles.containerCompact];
+
+    return (
+        <View style={containerStyle}>
+            <ActivityIndicator 
+                size="large" 
+                color={colors.buttonPrimary} 
+                style={styles.spinner} 
+            />
+            <Text style={[styles.title, compact && styles.titleCompact]}>
+                Scanning for routes...
+            </Text>
+            <Text style={[styles.text, compact && styles.textCompact]}>
+                Folders scanned: {scannedFolders}
+            </Text>
+            <View style={styles.footer}>
+                <ButtonBar buttons={buttons} />
+            </View>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        padding: 24,
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: 250,
+    },
+    containerCompact: {
+        padding: 12,
+        minHeight: 200,
+    },
+    spinner: {
+        marginBottom: 24,
+    },
+    title: {
+        fontSize: textSizes.dialogTitle,
+        color: colors.text,
+        fontWeight: 'bold',
+        marginBottom: 12,
+        textAlign: 'center',
+    },
+    titleCompact: {
+        fontSize: textSizes.listEntry,
+        marginBottom: 8,
+    },
+    text: {
+        fontSize: textSizes.normalText,
+        color: colors.text,
+        textAlign: 'center',
+        marginBottom: 24,
+    },
+    textCompact: {
+        fontSize: textSizes.smallText,
+        marginBottom: 16,
+    },
+    footer: {
+        width: '100%',
+        marginTop: 'auto',
+    },
+});

--- a/src/theme/textSizes.ts
+++ b/src/theme/textSizes.ts
@@ -5,4 +5,7 @@ export const textSizes = {
     normalText: 16,
     noDataText: 24,
     smallText: 12,
+    subtitle: 14,
+    tinyText: 11,
+    microText: 10,
 };


### PR DESCRIPTION
Closes #267

Implemented two pure view components for the library import flow:
- **ScanningView**: Shows progress during the initial folder scan with an ActivityIndicator and folder count.
- **ParseSelectionView**: Handles both streaming parsing state and final selection state. Includes a scrollable list of routes with status badges, warning indicators for non-importable files, and bulk selection controls.

Both views follow the project's styling and structure guidelines, using theme tokens and pure view patterns.