### PR TITLE
feat: ImportRoutesDialog — IngestingView and CompleteView

### DIFF
--- a/src/components/ImportRoutesDialog/views/CompleteView.stories.tsx
+++ b/src/components/ImportRoutesDialog/views/CompleteView.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { CompleteView } from './CompleteView';
+
+const meta: Meta<typeof CompleteView> = {
+    title: 'Components/ImportRoutesDialog/CompleteView',
+    component: CompleteView,
+    args: {
+        onDone: fn(),
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof CompleteView>;
+
+export const Success: Story = {
+    args: {
+        compact: false,
+        imported: 12,
+        skipped: 0,
+        errors: 0,
+        failedRoutes: [],
+    },
+};
+
+export const WithErrors: Story = {
+    args: {
+        compact: false,
+        imported: 8,
+        skipped: 2,
+        errors: 2,
+        failedRoutes: [
+            { name: 'Route_2023_01.gpx', reason: 'Invalid GPX structure at line 42' },
+            { name: 'Mountain_Climb.json', reason: 'Missing mandatory elevation data' },
+        ],
+    },
+};
+
+export const Compact: Story = {
+    args: {
+        compact: true,
+        imported: 5,
+        skipped: 1,
+        errors: 1,
+        failedRoutes: [
+            { name: 'Morning_Ride.fit', reason: 'Unsupported file extension' },
+        ],
+    },
+};

--- a/src/components/ImportRoutesDialog/views/CompleteView.test.tsx
+++ b/src/components/ImportRoutesDialog/views/CompleteView.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { CompleteView } from './CompleteView';
+
+describe('CompleteView', () => {
+    const mockFailedRoutes = [
+        { name: 'Broken Route', reason: 'File corrupted' },
+        { name: 'Old Route', reason: 'Invalid format' },
+    ];
+
+    const defaultProps = {
+        compact: false,
+        imported: 10,
+        skipped: 2,
+        errors: 0,
+        failedRoutes: [],
+        onDone: jest.fn(),
+    };
+
+    test('renders correctly with zero errors', () => {
+        const { getByText, queryByText } = render(<CompleteView {...defaultProps} />);
+        expect(getByText('10')).toBeTruthy();
+        expect(getByText('2')).toBeTruthy();
+        expect(queryByText('Show Errors')).toBeNull();
+    });
+
+    test('renders Show Errors toggle when errors > 0', () => {
+        const { getByText } = render(
+            <CompleteView {...defaultProps} errors={2} failedRoutes={mockFailedRoutes} />
+        );
+        expect(getByText('Show Errors')).toBeTruthy();
+    });
+
+    test('expands error list when toggle is pressed', () => {
+        const { getByText } = render(
+            <CompleteView {...defaultProps} errors={2} failedRoutes={mockFailedRoutes} />
+        );
+        
+        fireEvent.press(getByText('Show Errors'));
+        
+        expect(getByText('Broken Route')).toBeTruthy();
+        expect(getByText('File corrupted')).toBeTruthy();
+        expect(getByText('Old Route')).toBeTruthy();
+    });
+
+    test('renders correctly in compact mode', () => {
+        const { getByText } = render(<CompleteView {...defaultProps} compact={true} />);
+        expect(getByText('Import Complete')).toBeTruthy();
+    });
+});

--- a/src/components/ImportRoutesDialog/views/CompleteView.tsx
+++ b/src/components/ImportRoutesDialog/views/CompleteView.tsx
@@ -1,0 +1,179 @@
+import React, { useState, useCallback, useMemo } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { colors, textSizes } from '../../../theme';
+import { ButtonBar } from '../../ButtonBar';
+import { Icon } from '../../Icon';
+import type { FailedRoute } from 'incyclist-services';
+
+interface CompleteViewProps {
+    compact: boolean;
+    imported: number;
+    skipped: number;
+    errors: number;
+    failedRoutes: FailedRoute[];
+    onDone: () => void;
+}
+
+const SummaryItem = ({ label, count, color = colors.text }: { label: string; count: number; color?: string }) => (
+    <View style={styles.summaryItem}>
+        <Text style={[styles.summaryCount, { color }]}>{count}</Text>
+        <Text style={styles.summaryLabel}>{label}</Text>
+    </View>
+);
+
+export const CompleteView = ({
+    compact,
+    imported,
+    skipped,
+    errors,
+    failedRoutes,
+    onDone,
+}: CompleteViewProps) => {
+    const [showErrors, setShowErrors] = useState(false);
+
+    const toggleErrors = useCallback(() => {
+        setShowErrors(prev => !prev);
+    }, []);
+
+    const buttons = useMemo(() => [
+        { label: 'Done', onClick: onDone, primary: true }
+    ], [onDone]);
+
+    const toggleStyle = useMemo(() => ({
+        flexDirection: 'row' as const,
+        alignItems: 'center' as const,
+        paddingVertical: 12,
+    }), []);
+
+    return (
+        <View style={[styles.container, compact && styles.containerCompact]}>
+            <Text style={[styles.title, compact && styles.titleCompact]}>
+                Import Complete
+            </Text>
+
+            <View style={styles.summaryRow}>
+                <SummaryItem label="Imported" count={imported} />
+                <SummaryItem label="Skipped" count={skipped} />
+                <SummaryItem label="Errors" count={errors} color={errors > 0 ? colors.error : colors.text} />
+            </View>
+
+            {errors > 0 && (
+                <View style={styles.errorSection}>
+                    <TouchableOpacity onPress={toggleErrors} style={toggleStyle}>
+                        <Text style={styles.toggleText}>Show Errors</Text>
+                        <Icon name={showErrors ? 'chevron-up' : 'chevron-down'} size={20} color={colors.text} />
+                    </TouchableOpacity>
+                    
+                    {showErrors && (
+                        <View style={styles.errorList}>
+                            {failedRoutes.map((route, index) => (
+                                <View key={`${route.name}-${index}`} style={styles.errorItem}>
+                                    <Text style={styles.errorRouteName}>{route.name}</Text>
+                                    <Text style={styles.errorReason}>{route.reason}</Text>
+                                </View>
+                            ))}
+                        </View>
+                    )}
+                </View>
+            )}
+
+            <Text style={styles.note}>
+                Note: Videos are referenced in place and not copied.
+            </Text>
+
+            <View style={styles.buttonWrapper}>
+                <ButtonBar buttons={buttons} />
+            </View>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        padding: 20,
+        alignItems: 'center',
+        width: '100%',
+    },
+    containerCompact: {
+        padding: 10,
+    },
+    title: {
+        fontSize: textSizes.dialogTitle,
+        color: colors.text,
+        textAlign: 'center',
+        marginBottom: 20,
+        fontWeight: 'bold',
+    },
+    titleCompact: {
+        fontSize: 20,
+        marginBottom: 12,
+    },
+    summaryRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-around',
+        width: '100%',
+        marginBottom: 20,
+        backgroundColor: 'rgba(255, 255, 255, 0.05)',
+        paddingVertical: 16,
+        borderRadius: 8,
+    },
+    summaryItem: {
+        alignItems: 'center',
+        flex: 1,
+    },
+    summaryCount: {
+        fontSize: 24,
+        fontWeight: 'bold',
+        marginBottom: 4,
+    },
+    summaryLabel: {
+        fontSize: 12,
+        color: colors.text,
+        opacity: 0.7,
+        textTransform: 'uppercase',
+    },
+    errorSection: {
+        width: '100%',
+        marginBottom: 16,
+    },
+    toggleText: {
+        fontSize: textSizes.normalText,
+        color: colors.text,
+        marginRight: 8,
+        fontWeight: '500',
+    },
+    errorList: {
+        width: '100%',
+        maxHeight: 200,
+        backgroundColor: 'rgba(211, 47, 47, 0.1)',
+        borderRadius: 8,
+        padding: 8,
+    },
+    errorItem: {
+        marginBottom: 8,
+        borderBottomWidth: 1,
+        borderBottomColor: 'rgba(255, 255, 255, 0.1)',
+        paddingBottom: 4,
+    },
+    errorRouteName: {
+        fontSize: 14,
+        color: colors.error,
+        fontWeight: '600',
+    },
+    errorReason: {
+        fontSize: 12,
+        color: colors.text,
+        opacity: 0.8,
+    },
+    note: {
+        fontSize: textSizes.smallText,
+        color: colors.text,
+        opacity: 0.6,
+        textAlign: 'center',
+        fontStyle: 'italic',
+        marginBottom: 16,
+    },
+    buttonWrapper: {
+        width: '100%',
+    },
+});

--- a/src/components/ImportRoutesDialog/views/CompleteView.tsx
+++ b/src/components/ImportRoutesDialog/views/CompleteView.tsx
@@ -14,12 +14,15 @@ interface CompleteViewProps {
     onDone: () => void;
 }
 
-const SummaryItem = ({ label, count, color = colors.text }: { label: string; count: number; color?: string }) => (
-    <View style={styles.summaryItem}>
-        <Text style={[styles.summaryCount, { color }]}>{count}</Text>
-        <Text style={styles.summaryLabel}>{label}</Text>
-    </View>
-);
+const SummaryItem = ({ label, count, color = colors.text }: { label: string; count: number; color?: string }) => {
+    const summaryCountStyle = { color };
+    return (
+        <View style={styles.summaryItem}>
+            <Text style={[styles.summaryCount, summaryCountStyle]}>{count}</Text>
+            <Text style={styles.summaryLabel}>{label}</Text>
+        </View>
+    );
+};
 
 export const CompleteView = ({
     compact,
@@ -39,12 +42,6 @@ export const CompleteView = ({
         { label: 'Done', onClick: onDone, primary: true }
     ], [onDone]);
 
-    const toggleStyle = useMemo(() => ({
-        flexDirection: 'row' as const,
-        alignItems: 'center' as const,
-        paddingVertical: 12,
-    }), []);
-
     return (
         <View style={[styles.container, compact && styles.containerCompact]}>
             <Text style={[styles.title, compact && styles.titleCompact]}>
@@ -59,7 +56,7 @@ export const CompleteView = ({
 
             {errors > 0 && (
                 <View style={styles.errorSection}>
-                    <TouchableOpacity onPress={toggleErrors} style={toggleStyle}>
+                    <TouchableOpacity onPress={toggleErrors} style={styles.toggle}>
                         <Text style={styles.toggleText}>Show Errors</Text>
                         <Icon name={showErrors ? 'chevron-up' : 'chevron-down'} size={20} color={colors.text} />
                     </TouchableOpacity>
@@ -105,7 +102,7 @@ const styles = StyleSheet.create({
         fontWeight: 'bold',
     },
     titleCompact: {
-        fontSize: 20,
+        fontSize: textSizes.listEntry,
         marginBottom: 12,
     },
     summaryRow: {
@@ -122,15 +119,20 @@ const styles = StyleSheet.create({
         flex: 1,
     },
     summaryCount: {
-        fontSize: 24,
+        fontSize: textSizes.dialogTitle,
         fontWeight: 'bold',
         marginBottom: 4,
     },
     summaryLabel: {
-        fontSize: 12,
+        fontSize: textSizes.smallText,
         color: colors.text,
         opacity: 0.7,
         textTransform: 'uppercase',
+    },
+    toggle: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingVertical: 12,
     },
     errorSection: {
         width: '100%',
@@ -156,12 +158,12 @@ const styles = StyleSheet.create({
         paddingBottom: 4,
     },
     errorRouteName: {
-        fontSize: 14,
+        fontSize: textSizes.normalText,
         color: colors.error,
         fontWeight: '600',
     },
     errorReason: {
-        fontSize: 12,
+        fontSize: textSizes.smallText,
         color: colors.text,
         opacity: 0.8,
     },

--- a/src/components/ImportRoutesDialog/views/CompleteView.tsx
+++ b/src/components/ImportRoutesDialog/views/CompleteView.tsx
@@ -74,8 +74,8 @@ export const CompleteView = ({
                 </View>
             )}
 
-            <Text style={styles.note}>
-                Note: Videos are referenced in place and not copied.
+            <Text style={[styles.note, compact && styles.noteCompact]}>
+                Videos are not copied — they play from their original location.
             </Text>
 
             <View style={styles.buttonWrapper}>
@@ -174,6 +174,9 @@ const styles = StyleSheet.create({
         textAlign: 'center',
         fontStyle: 'italic',
         marginBottom: 16,
+    },
+    noteCompact: {
+        marginBottom: 8,
     },
     buttonWrapper: {
         width: '100%',

--- a/src/components/ImportRoutesDialog/views/IngestingView.stories.tsx
+++ b/src/components/ImportRoutesDialog/views/IngestingView.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { IngestingView } from './IngestingView';
+
+const meta: Meta<typeof IngestingView> = {
+    title: 'Components/ImportRoutesDialog/IngestingView',
+    component: IngestingView,
+    args: {
+        onCancel: fn(),
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof IngestingView>;
+
+export const Default: Story = {
+    args: {
+        compact: false,
+        current: 5,
+        total: 10,
+        currentName: 'Alpine Pass Road',
+        errorCount: 0,
+    },
+};
+
+export const WithErrors: Story = {
+    args: {
+        compact: false,
+        current: 7,
+        total: 10,
+        currentName: 'Coastal Highway',
+        errorCount: 2,
+    },
+};
+
+export const Compact: Story = {
+    args: {
+        compact: true,
+        current: 3,
+        total: 10,
+        currentName: 'Short City Loop',
+        errorCount: 1,
+    },
+};

--- a/src/components/ImportRoutesDialog/views/IngestingView.test.tsx
+++ b/src/components/ImportRoutesDialog/views/IngestingView.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { IngestingView } from './IngestingView';
+
+describe('IngestingView', () => {
+    const defaultProps = {
+        compact: false,
+        current: 5,
+        total: 10,
+        currentName: 'Alpine Pass',
+        errorCount: 0,
+        onCancel: jest.fn(),
+    };
+
+    test('renders correctly at 0%', () => {
+        const { getByText } = render(<IngestingView {...defaultProps} current={0} />);
+        expect(getByText('0 / 10')).toBeTruthy();
+    });
+
+    test('renders correctly mid-way', () => {
+        const { getByText } = render(<IngestingView {...defaultProps} current={5} />);
+        expect(getByText('5 / 10')).toBeTruthy();
+        expect(getByText('Importing Alpine Pass...')).toBeTruthy();
+    });
+
+    test('renders correctly at 100%', () => {
+        const { getByText } = render(<IngestingView {...defaultProps} current={10} />);
+        expect(getByText('10 / 10')).toBeTruthy();
+    });
+
+    test('renders error count when errors > 0', () => {
+        const { getByText } = render(<IngestingView {...defaultProps} errorCount={3} />);
+        expect(getByText('Errors: 3')).toBeTruthy();
+    });
+
+    test('renders correctly in compact mode', () => {
+        const { getByText } = render(<IngestingView {...defaultProps} compact={true} />);
+        expect(getByText('5 / 10')).toBeTruthy();
+    });
+});

--- a/src/components/ImportRoutesDialog/views/IngestingView.tsx
+++ b/src/components/ImportRoutesDialog/views/IngestingView.tsx
@@ -1,0 +1,110 @@
+import React, { useMemo } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { colors, textSizes } from '../../../theme';
+import { ButtonBar } from '../../ButtonBar';
+
+interface IngestingViewProps {
+    compact: boolean;
+    current: number;
+    total: number;
+    currentName: string;
+    errorCount: number;
+    onCancel: () => void;
+}
+
+export const IngestingView = ({
+    compact,
+    current,
+    total,
+    currentName,
+    errorCount,
+    onCancel,
+}: IngestingViewProps) => {
+    const progress = total > 0 ? (current / total) * 100 : 0;
+    const progressStyle = { width: `${Math.min(100, Math.max(0, progress))}%` };
+
+    const buttons = useMemo(() => [
+        { label: 'Cancel', onClick: onCancel, attention: true }
+    ], [onCancel]);
+
+    return (
+        <View style={[styles.container, compact && styles.containerCompact]}>
+            <Text style={[styles.title, compact && styles.titleCompact]} numberOfLines={2}>
+                {`Importing ${currentName}...`}
+            </Text>
+
+            <View style={styles.progressContainer}>
+                <View style={styles.track}>
+                    <View style={[styles.fill, progressStyle]} />
+                </View>
+                <Text style={styles.progressText}>
+                    {`${current} / ${total}`}
+                </Text>
+            </View>
+
+            {errorCount > 0 && (
+                <Text style={styles.errorText}>
+                    {`Errors: ${errorCount}`}
+                </Text>
+            )}
+
+            <View style={styles.buttonWrapper}>
+                <ButtonBar buttons={buttons} />
+            </View>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        padding: 20,
+        alignItems: 'center',
+        width: '100%',
+    },
+    containerCompact: {
+        padding: 10,
+    },
+    title: {
+        fontSize: textSizes.dialogTitle,
+        color: colors.text,
+        textAlign: 'center',
+        marginBottom: 24,
+        fontWeight: '600',
+    },
+    titleCompact: {
+        fontSize: 18,
+        marginBottom: 12,
+    },
+    progressContainer: {
+        width: '100%',
+        alignItems: 'center',
+        marginBottom: 16,
+    },
+    track: {
+        width: '100%',
+        height: 12,
+        backgroundColor: 'rgba(255, 255, 255, 0.1)',
+        borderRadius: 6,
+        overflow: 'hidden',
+        marginBottom: 8,
+    },
+    fill: {
+        height: '100%',
+        backgroundColor: colors.buttonPrimary,
+    },
+    progressText: {
+        fontSize: textSizes.normalText,
+        color: colors.text,
+        fontWeight: '500',
+    },
+    errorText: {
+        fontSize: textSizes.normalText,
+        color: colors.error,
+        marginTop: 8,
+        fontWeight: 'bold',
+    },
+    buttonWrapper: {
+        marginTop: 12,
+        width: '100%',
+    },
+});

--- a/src/components/ImportRoutesDialog/views/IngestingView.tsx
+++ b/src/components/ImportRoutesDialog/views/IngestingView.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, DimensionValue } from 'react-native';
 import { colors, textSizes } from '../../../theme';
 import { ButtonBar } from '../../ButtonBar';
 
@@ -21,7 +21,8 @@ export const IngestingView = ({
     onCancel,
 }: IngestingViewProps) => {
     const progress = total > 0 ? (current / total) * 100 : 0;
-    const progressStyle = { width: `${Math.min(100, Math.max(0, progress))}%` };
+    const progressWidth = `${Math.min(100, Math.max(0, progress))}%` as DimensionValue;
+    const progressStyle = { width: progressWidth };
 
     const buttons = useMemo(() => [
         { label: 'Cancel', onClick: onCancel, attention: true }
@@ -72,7 +73,7 @@ const styles = StyleSheet.create({
         fontWeight: '600',
     },
     titleCompact: {
-        fontSize: 18,
+        fontSize: textSizes.listEntry,
         marginBottom: 12,
     },
     progressContainer: {


### PR DESCRIPTION
Closes #268

Implemented two pure view components for the `ImportRoutesDialog` to handle the ingestion and completion phases.

### Changes:
- Created `IngestingView` with a progress bar, current route name, and error count.
- Created `CompleteView` with a summary of imported, skipped, and failed routes, including an expandable error list.
- Added unit tests for both components covering multiple states and layout modes.
- Added Storybook stories for mid-ingest, successful completion, and completion with errors.

### IngestingView Features:
- Visual progress bar calculated from current/total props.
- Running error count display (only shows if > 0).
- Cancel button integrated via `ButtonBar`.

### CompleteView Features:
- Summary statistics (Imported, Skipped, Errors).
- Expandable "Show Errors" section with `Icon` toggle.
- Informative note regarding video file referencing.
- Done button integrated via `ButtonBar`.