### PR TITLE
fix: ImportRoutesDialog — fix result phase not shown, add single file importing state

### DIFF
--- a/src/components/ImportRoutesDialog/ImportRoutesDialog.tsx
+++ b/src/components/ImportRoutesDialog/ImportRoutesDialog.tsx
@@ -12,6 +12,7 @@ import { ImportRoutesDialogProps } from './types';
 import { useScreenLayout, useLogging, useUnmountEffect } from '../../hooks';
 import { useFilePicker } from '../../hooks/files/useFilePicker';
 import { getUIBinding } from '../../bindings/ui';
+import { SingleImportingView } from './views/SingleImportingView';
 
 /**
  * Smart component for the Import Routes dialog.
@@ -27,6 +28,7 @@ export const ImportRoutesDialog = ({ onClose }: ImportRoutesDialogProps) => {
         getRoutesPageService().getImportDisplayProps()
     );
     const [selectedIds, setSelectedIds] = useState<string[]>([]);
+    const [isSingleImporting, setIsSingleImporting] = useState(false);
 
     const refParsedRoutes = useRef<ParsedRoute[]>([]);
     const refInitialized = useRef(false);
@@ -64,6 +66,7 @@ export const ImportRoutesDialog = ({ onClose }: ImportRoutesDialogProps) => {
             obs.off('error', onSingleResult);
             refSingleObserver.current = null;
         }
+        setIsSingleImporting(false);
         onUpdate();
     }, [onUpdate]);
 
@@ -181,30 +184,30 @@ export const ImportRoutesDialog = ({ onClose }: ImportRoutesDialogProps) => {
             const fileInfo = await pickFile();
             if (!fileInfo) return;
 
+            setIsSingleImporting(true);
             const observer = getRoutesPageService().importSingleRoute(fileInfo);
             refSingleObserver.current = observer;
             observer.on('success', onSingleResult);
             observer.on('error', onSingleResult);
-            onUpdate();
         } catch (err) {
             logError(err, 'onAddGpx');
         }
-    }, [pickFile, onSingleResult, logError, onUpdate]);
+    }, [pickFile, onSingleResult, logError]);
 
     const onAddVideoRoute = useCallback(async () => {
         try {
             const fileInfo = await pickFile();
             if (!fileInfo) return;
 
+            setIsSingleImporting(true);
             const observer = getRoutesPageService().importSingleRoute(fileInfo);
             refSingleObserver.current = observer;
             observer.on('success', onSingleResult);
             observer.on('error', onSingleResult);
-            onUpdate();
         } catch (err) {
             logError(err, 'onAddVideoRoute');
         }
-    }, [pickFile, onSingleResult, logError, onUpdate]);
+    }, [pickFile, onSingleResult, logError]);
 
     const onSelectFolder = useCallback(async () => {
         try {
@@ -274,10 +277,13 @@ export const ImportRoutesDialog = ({ onClose }: ImportRoutesDialogProps) => {
     const { phase } = displayProps;
 
     // Non-dismissable during active processing phases
-    const isDismissable = phase !== 'scanning' && phase !== 'parsing' && phase !== 'ingesting';
+    const isDismissable = !isSingleImporting && phase !== 'scanning' && phase !== 'parsing' && phase !== 'ingesting';
     const onOutsideClick = isDismissable ? onCancel : undefined;
 
     const title = useMemo(() => {
+        if (isSingleImporting) {
+            return 'Importing...';
+        }
         switch (phase) {
             case 'scanning':
                 return 'Scanning Folders...';
@@ -294,25 +300,29 @@ export const ImportRoutesDialog = ({ onClose }: ImportRoutesDialogProps) => {
             default:
                 return 'Import Routes';
         }
-    }, [phase]);
+    }, [phase, isSingleImporting]);
 
     return (
         <Dialog title={title} visible={true} onOutsideClick={onOutsideClick} variant="details">
-            <ImportRoutesDialogView
-                compact={isCompact}
-                displayProps={displayProps}
-                selectedIds={selectedIds}
-                onAddGpx={onAddGpx}
-                onAddVideoRoute={onAddVideoRoute}
-                onSelectFolder={onSelectFolder}
-                onToggleRoute={onToggleRoute}
-                onSelectAll={onSelectAll}
-                onDeselectAll={onDeselectAll}
-                onConfirmSelection={onConfirmSelection}
-                onDone={onDone}
-                onTryAgain={handleTryAgain}
-                onCancel={onCancel}
-            />
+            {isSingleImporting ? (
+                <SingleImportingView compact={isCompact} />
+            ) : (
+                <ImportRoutesDialogView
+                    compact={isCompact}
+                    displayProps={displayProps}
+                    selectedIds={selectedIds}
+                    onAddGpx={onAddGpx}
+                    onAddVideoRoute={onAddVideoRoute}
+                    onSelectFolder={onSelectFolder}
+                    onToggleRoute={onToggleRoute}
+                    onSelectAll={onSelectAll}
+                    onDeselectAll={onDeselectAll}
+                    onConfirmSelection={onConfirmSelection}
+                    onDone={onDone}
+                    onTryAgain={handleTryAgain}
+                    onCancel={onCancel}
+                />
+            )}
         </Dialog>
     );
 };

--- a/src/components/ImportRoutesDialog/views/SingleImportingView.stories.tsx
+++ b/src/components/ImportRoutesDialog/views/SingleImportingView.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { SingleImportingView } from './SingleImportingView';
+
+const meta: Meta<typeof SingleImportingView> = {
+    title: 'Components/ImportRoutesDialog/Views/SingleImportingView',
+    component: SingleImportingView,
+};
+
+export default meta;
+type Story = StoryObj<typeof SingleImportingView>;
+
+export const Default: Story = {
+    args: {
+        compact: false,
+    },
+};
+
+export const Compact: Story = {
+    args: {
+        compact: true,
+    },
+};

--- a/src/components/ImportRoutesDialog/views/SingleImportingView.test.tsx
+++ b/src/components/ImportRoutesDialog/views/SingleImportingView.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { SingleImportingView } from './SingleImportingView';
+
+describe('SingleImportingView', () => {
+    it('renders correctly', () => {
+        render(<SingleImportingView compact={false} />);
+    });
+
+    it('renders correctly in compact mode', () => {
+        render(<SingleImportingView compact={true} />);
+    });
+});

--- a/src/components/ImportRoutesDialog/views/SingleImportingView.tsx
+++ b/src/components/ImportRoutesDialog/views/SingleImportingView.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import { colors, textSizes } from '../../../theme';
+
+interface SingleImportingViewProps {
+    compact: boolean;
+}
+
+export const SingleImportingView = ({ compact }: SingleImportingViewProps) => {
+    const containerStyle = [styles.container, compact && styles.containerCompact];
+    const titleStyle = [styles.title, compact && styles.titleCompact];
+
+    return (
+        <View style={containerStyle}>
+            <ActivityIndicator 
+                size="large" 
+                color={colors.buttonPrimary} 
+                style={styles.spinner} 
+            />
+            <Text style={titleStyle}>
+                Importing route...
+            </Text>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        padding: 24,
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: 250,
+    },
+    containerCompact: {
+        padding: 12,
+        minHeight: 200,
+    },
+    spinner: {
+        marginBottom: 24,
+    },
+    title: {
+        fontSize: textSizes.dialogTitle,
+        color: colors.text,
+        fontWeight: 'bold',
+        textAlign: 'center',
+    },
+    titleCompact: {
+        fontSize: textSizes.listEntry,
+    },
+});


### PR DESCRIPTION
Closes #280

- Fixes a race condition in `ImportRoutesDialog` where the `result` phase was overwritten by an immediate `onUpdate` call during single file imports.
- Adds `isSingleImporting` local state to provide immediate UI feedback after a file is selected.
- Implements `SingleImportingView` to show a spinner during the single file import process.