### PR TITLE
RouteImportDialog structure and button consolidation

### DIFF
--- a/src/components/RouteImportDialog/RouteImportDialog.stories.tsx
+++ b/src/components/RouteImportDialog/RouteImportDialog.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import { RouteImportDialogView } from './RouteImportDialogView';
+
+const meta: Meta<typeof RouteImportDialogView> = {
+    title: 'Components/RouteImportDialog',
+    component: RouteImportDialogView,
+    args: {
+        title: 'Import Routes',
+        buttons: [],
+        onOutsideClick: fn(),
+        onAddGpx: fn(),
+        onAddVideoRoute: fn(),
+        onSelectFolder: fn(),
+        onToggleRoute: fn(),
+        onSelectAll: fn(),
+        onDeselectAll: fn(),
+        onConfirmSelection: fn(),
+        onDone: fn(),
+        onTryAgain: fn(),
+        onCancel: fn(),
+        selectedIds: [],
+        displayProps: {
+            phase: 'landing',
+        },
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof RouteImportDialogView>;
+
+export const Landing: Story = {
+    args: {
+        displayProps: { phase: 'landing' },
+    },
+};
+
+export const Selecting: Story = {
+    args: {
+        title: 'Select Routes',
+        buttons: [
+            { label: 'Import (2)', onClick: fn(), primary: true },
+            { label: 'Cancel', onClick: fn() },
+        ],
+        displayProps: {
+            phase: 'selecting',
+            routes: [
+                { id: '1', title: 'Route 1', distance: 10000 },
+                { id: '2', title: 'Route 2', distance: 20000 },
+            ],
+        },
+        selectedIds: ['1', '2'],
+    },
+};
+
+export const Ingesting: Story = {
+    args: {
+        title: 'Importing',
+        buttons: [{ label: 'Cancel', onClick: fn() }],
+        displayProps: {
+            phase: 'ingesting',
+            progress: 45,
+            statusText: 'Processing Route 2 of 5...',
+        },
+    },
+};
+
+export const Success: Story = {
+    args: {
+        title: 'Success',
+        buttons: [{ label: 'Done', onClick: fn(), primary: true }],
+        displayProps: {
+            phase: 'result',
+            resultSuccess: true,
+            resultMessage: 'Successfully imported 5 routes.',
+        },
+    },
+};

--- a/src/components/RouteImportDialog/RouteImportDialog.tsx
+++ b/src/components/RouteImportDialog/RouteImportDialog.tsx
@@ -1,0 +1,173 @@
+import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react';
+import { useRouteList, RouteImportDisplayProperties, IObserver } from 'incyclist-services';
+import { RouteImportDialogProps } from './types';
+import { RouteImportDialogView } from './RouteImportDialogView';
+import { useLogging, useUnmountEffect, useScreenLayout } from '../../hooks';
+
+export const RouteImportDialog = ({ onClose }: RouteImportDialogProps) => {
+    const service = useRouteList();
+    const { logError } = useLogging('RouteImportDialog');
+    const layout = useScreenLayout();
+    const isCompact = layout === 'compact';
+
+    const [displayProps, setDisplayProps] = useState<RouteImportDisplayProperties>(
+        service.getImportDisplayProperties()
+    );
+    const [selectedIds, setSelectedIds] = useState<string[]>([]);
+    const [isSingleImporting, setIsSingleImporting] = useState(false);
+    
+    const refObserver = useRef<IObserver | null>(null);
+
+    const onUpdate = useCallback(() => {
+        const updated = service.getImportDisplayProperties();
+        if (updated) {
+            setDisplayProps(updated);
+            // Default select all when new routes are parsed
+            if (updated.phase === 'selecting' && updated.routes) {
+                setSelectedIds(updated.routes.map(r => r.id));
+            }
+        }
+    }, [service]);
+
+    useEffect(() => {
+        if (refObserver.current) return;
+        
+        refObserver.current = service.openImport();
+        refObserver.current.on('import-update', onUpdate);
+        onUpdate();
+    }, [service, onUpdate]);
+
+    useUnmountEffect(() => {
+        service.closeImport();
+    });
+
+    const onAddGpx = useCallback(async () => {
+        setIsSingleImporting(true);
+        try {
+            await service.importGpxFile();
+        } catch (err) {
+            logError(err as Error, 'onAddGpx');
+        } finally {
+            setIsSingleImporting(false);
+        }
+    }, [service, logError]);
+
+    const onAddVideoRoute = useCallback(async () => {
+        setIsSingleImporting(true);
+        try {
+            await service.importVideoRoute();
+        } catch (err) {
+            logError(err as Error, 'onAddVideoRoute');
+        } finally {
+            setIsSingleImporting(false);
+        }
+    }, [service, logError]);
+
+    const onSelectFolder = useCallback(() => {
+        service.importFromFolder();
+    }, [service]);
+
+    const onToggleRoute = useCallback((id: string) => {
+        setSelectedIds(prev => 
+            prev.includes(id) ? prev.filter(i => i !== id) : [...prev, id]
+        );
+    }, []);
+
+    const onSelectAll = useCallback(() => {
+        if (displayProps.routes) {
+            setSelectedIds(displayProps.routes.map(r => r.id));
+        }
+    }, [displayProps.routes]);
+
+    const onDeselectAll = useCallback(() => {
+        setSelectedIds([]);
+    }, []);
+
+    const onConfirmSelection = useCallback(() => {
+        service.confirmImportSelection(selectedIds);
+    }, [service, selectedIds]);
+
+    const onDone = useCallback(() => {
+        onClose();
+    }, [onClose]);
+
+    const handleTryAgain = useCallback(() => {
+        service.resetImport();
+    }, [service]);
+
+    const onCancel = useCallback(() => {
+        onClose();
+    }, [onClose]);
+
+    const { phase } = displayProps;
+
+    const title = useMemo(() => {
+        switch (phase) {
+            case 'landing': return 'Import Routes';
+            case 'scanning': return 'Scanning Folder';
+            case 'parsing': return 'Parsing Routes';
+            case 'selecting': return 'Select Routes';
+            case 'ingesting': return 'Importing';
+            case 'complete': return 'Import Complete';
+            case 'result': return displayProps.resultSuccess ? 'Success' : 'Import Failed';
+            default: return 'Import Routes';
+        }
+    }, [phase, displayProps.resultSuccess]);
+
+    const buttons = useMemo(() => {
+        if (isSingleImporting) return [];
+        switch (phase) {
+            case 'landing':
+                return [];
+            case 'scanning':
+                return [{ label: 'Cancel', onClick: onCancel }];
+            case 'parsing':
+            case 'selecting':
+                return [
+                    { 
+                        label: `Import (${selectedIds.length})`, 
+                        onClick: onConfirmSelection, 
+                        primary: true, 
+                        disabled: phase === 'parsing' || selectedIds.length === 0 
+                    },
+                    { label: 'Cancel', onClick: onCancel },
+                ];
+            case 'ingesting':
+                return [{ label: 'Cancel', onClick: onCancel }];
+            case 'complete':
+                return [{ label: 'Done', onClick: onDone, primary: true }];
+            case 'result':
+                return displayProps.resultSuccess
+                    ? [{ label: 'Done', onClick: onDone, primary: true }]
+                    : [
+                        { label: 'Try Again', onClick: handleTryAgain, primary: true },
+                        { label: 'Cancel', onClick: onCancel },
+                    ];
+            default:
+                return [];
+        }
+    }, [phase, isSingleImporting, selectedIds.length, displayProps.resultSuccess, onCancel, onConfirmSelection, onDone, handleTryAgain]);
+
+    const onOutsideClick = phase === 'landing' || phase === 'result' || phase === 'complete' ? onCancel : undefined;
+
+    return (
+        <RouteImportDialogView
+            compact={isCompact}
+            title={title}
+            buttons={buttons}
+            onOutsideClick={onOutsideClick}
+            displayProps={displayProps}
+            selectedIds={selectedIds}
+            onAddGpx={onAddGpx}
+            onAddVideoRoute={onAddVideoRoute}
+            onSelectFolder={onSelectFolder}
+            onToggleRoute={onToggleRoute}
+            onSelectAll={onSelectAll}
+            onDeselectAll={onDeselectAll}
+            onConfirmSelection={onConfirmSelection}
+            onDone={onDone}
+            onTryAgain={handleTryAgain}
+            onCancel={onCancel}
+        />
+    );
+};

--- a/src/components/RouteImportDialog/RouteImportDialogView.tsx
+++ b/src/components/RouteImportDialog/RouteImportDialogView.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Dialog } from '../Dialog';
+import { RouteImportDialogViewProps } from './types';
+import { LandingView } from './views/LandingView';
+import { ScanningView } from './views/ScanningView';
+import { ParseSelectionView } from './views/ParseSelectionView';
+import { IngestingView } from './views/IngestingView';
+import { CompleteView } from './views/CompleteView';
+import { ResultView } from './views/ResultView';
+
+export const RouteImportDialogView = (props: RouteImportDialogViewProps) => {
+    const {
+        title,
+        buttons,
+        onOutsideClick,
+        displayProps,
+        selectedIds,
+        onAddGpx,
+        onAddVideoRoute,
+        onSelectFolder,
+        onToggleRoute,
+        onSelectAll,
+        onDeselectAll,
+    } = props;
+
+    const renderContent = () => {
+        switch (displayProps.phase) {
+            case 'landing':
+                return (
+                    <LandingView
+                        onAddGpx={onAddGpx}
+                        onAddVideoRoute={onAddVideoRoute}
+                        onSelectFolder={onSelectFolder}
+                    />
+                );
+            case 'scanning':
+                return <ScanningView statusText={displayProps.statusText ?? 'Scanning...'} />;
+            case 'parsing':
+            case 'selecting':
+                return (
+                    <ParseSelectionView
+                        displayProps={displayProps}
+                        selectedIds={selectedIds}
+                        onToggleRoute={onToggleRoute}
+                        onSelectAll={onSelectAll}
+                        onDeselectAll={onDeselectAll}
+                    />
+                );
+            case 'ingesting':
+                return (
+                    <IngestingView
+                        progress={displayProps.progress ?? 0}
+                        statusText={displayProps.statusText ?? 'Importing...'}
+                    />
+                );
+            case 'complete':
+                return <CompleteView count={displayProps.routes?.length ?? 0} />;
+            case 'result':
+                return (
+                    <ResultView
+                        success={displayProps.resultSuccess ?? false}
+                        message={displayProps.resultMessage ?? ''}
+                        errorDetails={displayProps.resultError}
+                    />
+                );
+            default:
+                return null;
+        }
+    };
+
+    return (
+        <Dialog
+            title={title}
+            visible={true}
+            onOutsideClick={onOutsideClick}
+            variant="details"
+            buttons={buttons}
+        >
+            <View style={styles.container}>
+                {renderContent()}
+            </View>
+        </Dialog>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        // flex: 1 removed to allow Dialog scroll to handle content
+    },
+});

--- a/src/components/RouteImportDialog/RoutesImportDialogView.test.tsx
+++ b/src/components/RouteImportDialog/RoutesImportDialogView.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { RouteImportDialogView } from './RouteImportDialogView';
+
+describe('RouteImportDialogView', () => {
+    const defaultProps = {
+        title: 'Test Dialog',
+        buttons: [],
+        displayProps: { phase: 'landing' as const },
+        selectedIds: [],
+        onAddGpx: jest.fn(),
+        onAddVideoRoute: jest.fn(),
+        onSelectFolder: jest.fn(),
+        onToggleRoute: jest.fn(),
+        onSelectAll: jest.fn(),
+        onDeselectAll: jest.fn(),
+        onConfirmSelection: jest.fn(),
+        onDone: jest.fn(),
+        onTryAgain: jest.fn(),
+        onCancel: jest.fn(),
+    };
+
+    it('renders without crashing', () => {
+        render(<RouteImportDialogView {...defaultProps} />);
+    });
+
+    it('renders the selecting phase', () => {
+        const props = {
+            ...defaultProps,
+            displayProps: {
+                phase: 'selecting' as const,
+                routes: [{ id: '1', title: 'Route 1' }],
+            },
+        };
+        render(<RouteImportDialogView {...props} />);
+    });
+});

--- a/src/components/RouteImportDialog/index.ts
+++ b/src/components/RouteImportDialog/index.ts
@@ -1,0 +1,3 @@
+export * from './RouteImportDialog';
+export * from './RouteImportDialogView';
+export * from './types';

--- a/src/components/RouteImportDialog/types.ts
+++ b/src/components/RouteImportDialog/types.ts
@@ -1,0 +1,57 @@
+import { RouteImportDisplayProperties } from 'incyclist-services';
+
+export interface RouteImportDialogProps {
+    onClose: () => void;
+}
+
+export interface RouteImportDialogViewProps {
+    compact?: boolean;
+    title: string;
+    buttons: { label: string; onClick: () => void; primary?: boolean; disabled?: boolean }[];
+    onOutsideClick?: () => void;
+    displayProps: RouteImportDisplayProperties;
+    selectedIds: string[];
+    onAddGpx: () => void;
+    onAddVideoRoute: () => void;
+    onSelectFolder: () => void;
+    onToggleRoute: (id: string) => void;
+    onSelectAll: () => void;
+    onDeselectAll: () => void;
+    onConfirmSelection: () => void;
+    onDone: () => void;
+    onTryAgain: () => void;
+    onCancel: () => void;
+}
+
+export interface LandingViewProps {
+    onAddGpx: () => void;
+    onAddVideoRoute: () => void;
+    onSelectFolder: () => void;
+}
+
+export interface ScanningViewProps {
+    statusText: string;
+}
+
+export interface ParseSelectionViewProps {
+    displayProps: RouteImportDisplayProperties;
+    selectedIds: string[];
+    onToggleRoute: (id: string) => void;
+    onSelectAll: () => void;
+    onDeselectAll: () => void;
+}
+
+export interface IngestingViewProps {
+    progress: number;
+    statusText: string;
+}
+
+export interface CompleteViewProps {
+    count: number;
+}
+
+export interface ResultViewProps {
+    success: boolean;
+    message: string;
+    errorDetails?: string;
+}

--- a/src/components/RouteImportDialog/views/CompleteView.tsx
+++ b/src/components/RouteImportDialog/views/CompleteView.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Icon } from '../../Icon';
+import { CompleteViewProps } from '../types';
+import { colors, textSizes } from '../../../theme';
+
+export const CompleteView = ({ count }: CompleteViewProps) => {
+    return (
+        <View style={styles.container}>
+            <Icon name="plus" size={48} color={colors.buttonPrimary} />
+            <Text style={styles.title}>Success!</Text>
+            <Text style={styles.message}>
+                {count === 1 ? '1 route has' : `${count} routes have`} been added to your library.
+            </Text>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        padding: 40,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    title: {
+        color: colors.text,
+        fontSize: textSizes.dialogTitle,
+        fontWeight: 'bold',
+        marginTop: 16,
+        marginBottom: 8,
+    },
+    message: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        textAlign: 'center',
+    },
+});

--- a/src/components/RouteImportDialog/views/IngestingView.tsx
+++ b/src/components/RouteImportDialog/views/IngestingView.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-max-native';
+import { IngestingViewProps } from '../types';
+import { colors, textSizes } from '../../../theme';
+
+export const IngestingView = ({ progress, statusText }: IngestingViewProps) => {
+    return (
+        <View style={styles.container}>
+            <View style={styles.progressContainer}>
+                <View style={[styles.progressBar, { width: `${progress}%` }]} />
+            </View>
+            <Text style={styles.statusText}>{statusText}</Text>
+            <Text style={styles.percentText}>{Math.round(progress)}%</Text>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        padding: 32,
+        alignItems: 'center',
+    },
+    progressContainer: {
+        width: '100%',
+        height: 8,
+        backgroundColor: 'rgba(255,255,255,0.1)',
+        borderRadius: 4,
+        overflow: 'hidden',
+        marginBottom: 16,
+    },
+    progressBar: {
+        height: '100%',
+        backgroundColor: colors.buttonPrimary,
+    },
+    statusText: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        textAlign: 'center',
+        marginBottom: 8,
+    },
+    percentText: {
+        color: colors.disabled,
+        fontSize: textSizes.smallText,
+    },
+});

--- a/src/components/RouteImportDialog/views/LandingView.test.tsx
+++ b/src/components/RouteImportDialog/views/LandingView.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { LandingView } from './LandingView';
+
+describe('LandingView', () => {
+    it('renders without crashing', () => {
+        render(
+            <LandingView
+                onAddGpx={jest.fn()}
+                onAddVideoRoute={jest.fn()}
+                onSelectFolder={jest.fn()}
+            />
+        );
+    });
+});

--- a/src/components/RouteImportDialog/views/LandingView.tsx
+++ b/src/components/RouteImportDialog/views/LandingView.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Icon } from '../../Icon';
+import { LandingViewProps } from '../types';
+import { colors, textSizes } from '../../../theme';
+
+export const LandingView = ({ onAddGpx, onAddVideoRoute, onSelectFolder }: LandingViewProps) => {
+    return (
+        <View style={styles.container}>
+            <Text style={styles.description}>
+                Choose how you want to add routes to your library.
+            </Text>
+
+            <View style={styles.tiles}>
+                <TouchableOpacity style={styles.tile} onPress={onAddGpx}>
+                    <Icon name="plus" size={32} color={colors.text} />
+                    <Text style={styles.tileTitle}>Add GPX</Text>
+                    <Text style={styles.tileSub}>Single route file</Text>
+                </TouchableOpacity>
+
+                <TouchableOpacity style={styles.tile} onPress={onAddVideoRoute}>
+                    <Icon name="plus" size={32} color={colors.text} />
+                    <Text style={styles.tileTitle}>Add Video</Text>
+                    <Text style={styles.tileSub}>Route with video</Text>
+                </TouchableOpacity>
+
+                <TouchableOpacity style={styles.tile} onPress={onSelectFolder}>
+                    <Icon name="funnel" size={32} color={colors.text} />
+                    <Text style={styles.tileTitle}>Import Folder</Text>
+                    <Text style={styles.tileSub}>Scan directory</Text>
+                </TouchableOpacity>
+            </View>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        padding: 16,
+    },
+    description: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        marginBottom: 24,
+        textAlign: 'center',
+    },
+    tiles: {
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        gap: 12,
+        justifyContent: 'center',
+    },
+    tile: {
+        width: 140,
+        height: 140,
+        backgroundColor: 'rgba(255,255,255,0.05)',
+        borderRadius: 12,
+        padding: 16,
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderWidth: 1,
+        borderColor: 'rgba(255,255,255,0.1)',
+    },
+    tileTitle: {
+        color: colors.text,
+        fontSize: textSizes.listEntry,
+        fontWeight: 'bold',
+        marginTop: 12,
+        textAlign: 'center',
+    },
+    tileSub: {
+        color: colors.disabled,
+        fontSize: textSizes.smallText,
+        marginTop: 4,
+        textAlign: 'center',
+    },
+});

--- a/src/components/RouteImportDialog/views/ParseSelectionView.tsx
+++ b/src/components/RouteImportDialog/views/ParseSelectionView.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import { ParseSelectionViewProps } from '../types';
+import { colors, textSizes } from '../../../theme';
+
+export const ParseSelectionView = ({
+    displayProps,
+    selectedIds,
+    onToggleRoute,
+    onSelectAll,
+    onDeselectAll,
+}: ParseSelectionViewProps) => {
+    const routes = displayProps.routes ?? [];
+
+    return (
+        <View style={styles.container}>
+            <View style={styles.header}>
+                <Text style={styles.countText}>{routes.length} routes found</Text>
+                <View style={styles.headerButtons}>
+                    <TouchableOpacity onPress={onSelectAll}>
+                        <Text style={styles.headerAction}>Select All</Text>
+                    </TouchableOpacity>
+                    <Text style={styles.divider}>|</Text>
+                    <TouchableOpacity onPress={onDeselectAll}>
+                        <Text style={styles.headerAction}>Deselect All</Text>
+                    </TouchableOpacity>
+                </View>
+            </View>
+
+            <ScrollView style={styles.list}>
+                {routes.map((route) => {
+                    const isSelected = selectedIds.includes(route.id);
+                    return (
+                        <TouchableOpacity
+                            key={route.id}
+                            style={[styles.item, isSelected && styles.itemSelected]}
+                            onPress={() => onToggleRoute(route.id)}
+                        >
+                            <View style={[styles.checkbox, isSelected && styles.checkboxSelected]} />
+                            <View style={styles.itemInfo}>
+                                <Text style={styles.itemTitle}>{route.title}</Text>
+                                <Text style={styles.itemSub}>
+                                    {route.distance ? `${(route.distance / 1000).toFixed(1)} km` : 'No distance'}
+                                </Text>
+                            </View>
+                        </TouchableOpacity>
+                    );
+                })}
+            </ScrollView>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        minHeight: 300,
+    },
+    header: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        paddingHorizontal: 16,
+        paddingVertical: 12,
+        backgroundColor: 'rgba(255,255,255,0.05)',
+    },
+    countText: {
+        color: colors.text,
+        fontSize: textSizes.smallText,
+    },
+    headerButtons: {
+        flexDirection: 'row',
+        gap: 8,
+    },
+    headerAction: {
+        color: colors.buttonPrimary,
+        fontSize: textSizes.smallText,
+        fontWeight: 'bold',
+    },
+    divider: {
+        color: colors.disabled,
+        fontSize: textSizes.smallText,
+    },
+    list: {
+        maxHeight: 400,
+    },
+    item: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        padding: 12,
+        borderBottomWidth: 1,
+        borderBottomColor: 'rgba(255,255,255,0.05)',
+    },
+    itemSelected: {
+        backgroundColor: 'rgba(221, 153, 51, 0.1)',
+    },
+    checkbox: {
+        width: 20,
+        height: 20,
+        borderRadius: 4,
+        borderWidth: 2,
+        borderColor: colors.disabled,
+        marginRight: 12,
+    },
+    checkboxSelected: {
+        backgroundColor: colors.buttonPrimary,
+        borderColor: colors.buttonPrimary,
+    },
+    itemInfo: {
+        flex: 1,
+    },
+    itemTitle: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        fontWeight: '500',
+    },
+    itemSub: {
+        color: colors.disabled,
+        fontSize: textSizes.smallText,
+    },
+});

--- a/src/components/RouteImportDialog/views/ResultView.tsx
+++ b/src/components/RouteImportDialog/views/ResultView.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { Icon } from '../../Icon';
+import { ResultViewProps } from '../types';
+import { colors, textSizes } from '../../../theme';
+
+export const ResultView = ({ success, message, errorDetails }: ResultViewProps) => {
+    return (
+        <View style={styles.container}>
+            <Icon 
+                name={success ? 'plus' : 'funnel'} 
+                size={48} 
+                color={success ? colors.buttonPrimary : colors.error} 
+            />
+            <Text style={styles.title}>{success ? 'Success' : 'Import Error'}</Text>
+            <Text style={styles.message}>{message}</Text>
+            
+            {errorDetails && (
+                <ScrollView style={styles.errorContainer}>
+                    <Text style={styles.errorText}>{errorDetails}</Text>
+                </ScrollView>
+            )}
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        padding: 32,
+        alignItems: 'center',
+    },
+    title: {
+        color: colors.text,
+        fontSize: textSizes.dialogTitle,
+        fontWeight: 'bold',
+        marginTop: 16,
+        marginBottom: 8,
+    },
+    message: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        textAlign: 'center',
+        marginBottom: 16,
+    },
+    errorContainer: {
+        width: '100%',
+        maxHeight: 150,
+        backgroundColor: 'rgba(211, 47, 47, 0.1)',
+        borderRadius: 8,
+        padding: 12,
+    },
+    errorText: {
+        color: colors.error,
+        fontSize: textSizes.smallText,
+        fontFamily: 'monospace',
+    },
+});

--- a/src/components/RouteImportDialog/views/ScanningView.tsx
+++ b/src/components/RouteImportDialog/views/ScanningView.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import { ScanningViewProps } from '../types';
+import { colors, textSizes } from '../../../theme';
+
+export const ScanningView = ({ statusText }: ScanningViewProps) => {
+    return (
+        <View style={styles.container}>
+            <ActivityIndicator size="large" color={colors.buttonPrimary} />
+            <Text style={styles.statusText}>{statusText}</Text>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        padding: 40,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    statusText: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
+        marginTop: 20,
+        textAlign: 'center',
+    },
+});


### PR DESCRIPTION
Closes #282

This PR performs three structural fixes to the `RouteImportDialog` component:

1. **Fix naming conventions**: Renamed all internal component and prop references from `ImportRoutesDialog` to `RouteImportDialog` to match the file system.
2. **Move Dialog to View**: Relocated the `<Dialog>` wrapper from the smart component (`RouteImportDialog.tsx`) to the pure view (`RouteImportDialogView.tsx`).
3. **Consolidate Buttons**: Moved all action buttons (Cancel, Import, Done, Try Again) out of the individual sub-views and into the `Dialog` footer using the `buttons` prop.

Additional changes:
- Removed the redundant `onImportClicked()` call from `useEffect` in the smart component.
- Implemented `useMemo` for calculating the dialog buttons based on the current import phase.
- Removed `flex: 1` from the main container in `RouteImportDialogView` to fix scrolling issues.
- Updated tests and stories to match the new prop structure.