### PR TITLE
RouteImportDialog — move buttons to Dialog footer and fix scrolling

### DIFF
--- a/src/components/RouteImportDialog/RouteImportDialog.stories.tsx
+++ b/src/components/RouteImportDialog/RouteImportDialog.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { fn } from 'storybook/test';
-import { ImportRoutesDialogView } from './RouteImportDialogView';
+import { RouteImportDialogView } from './RouteImportDialogView';
 
-const meta: Meta<typeof ImportRoutesDialogView> = {
+const meta: Meta<typeof RouteImportDialogView> = {
     title: 'Components/RouteImportDialog',
-    component: ImportRoutesDialogView,
+    component: RouteImportDialogView,
     args: {
         compact: false,
         displayProps: {
@@ -12,6 +12,10 @@ const meta: Meta<typeof ImportRoutesDialogView> = {
             routes: [],
         },
         selectedIds: [],
+        isSingleImporting: false,
+        title: 'Import Routes',
+        buttons: [],
+        onOutsideClick: fn(),
         onAddGpx: fn(),
         onAddVideoRoute: fn(),
         onSelectFolder: fn(),
@@ -27,7 +31,7 @@ const meta: Meta<typeof ImportRoutesDialogView> = {
 
 export default meta;
 
-type Story = StoryObj<typeof ImportRoutesDialogView>;
+type Story = StoryObj<typeof RouteImportDialogView>;
 
 export const Landing: Story = {
     args: {
@@ -35,6 +39,7 @@ export const Landing: Story = {
             phase: 'landing',
             routes: [],
         },
+        title: 'Import Routes',
     },
 };
 
@@ -45,6 +50,8 @@ export const Scanning: Story = {
             scanProgress: { scannedFolders: 12 },
             routes: [],
         },
+        title: 'Scanning Folders...',
+        buttons: [{ label: 'Cancel', onClick: fn() }],
     },
 };
 
@@ -58,6 +65,11 @@ export const Parsing: Story = {
                 { label: 'Route 2', distance: 5000, format: 'video', importable: true, alreadyImported: false },
             ] as any,
         },
+        title: 'Parsing Routes...',
+        buttons: [
+            { label: 'Import (0)', onClick: fn(), primary: true, disabled: true },
+            { label: 'Cancel', onClick: fn() },
+        ],
     },
 };
 
@@ -72,7 +84,12 @@ export const Selecting: Story = {
                 { label: 'Existing Route', distance: 12000, format: 'gpx', importable: true, alreadyImported: true },
             ] as any,
         },
-        selectedIds: [],
+        selectedIds: ['1', '2'],
+        title: 'Select Routes',
+        buttons: [
+            { label: 'Import (2)', onClick: fn(), primary: true },
+            { label: 'Cancel', onClick: fn() },
+        ],
     },
 };
 
@@ -83,6 +100,8 @@ export const Ingesting: Story = {
             ingestProgress: { current: 2, total: 4, currentName: 'Forest Trail' },
             routes: [],
         },
+        title: 'Importing...',
+        buttons: [{ label: 'Cancel', onClick: fn() }],
     },
 };
 
@@ -100,6 +119,8 @@ export const Complete: Story = {
             },
             routes: [],
         },
+        title: 'Import Summary',
+        buttons: [{ label: 'Done', onClick: fn(), primary: true }],
     },
 };
 
@@ -110,6 +131,8 @@ export const ResultSuccess: Story = {
             resultSuccess: { routeName: 'Evening Ride' },
             routes: [],
         },
+        title: 'Import Result',
+        buttons: [{ label: 'Done', onClick: fn(), primary: true }],
     },
 };
 
@@ -120,6 +143,11 @@ export const ResultError: Story = {
             error: 'File is not a valid GPX.',
             routes: [],
         },
+        title: 'Import Result',
+        buttons: [
+            { label: 'Try Again', onClick: fn(), primary: true },
+            { label: 'Cancel', onClick: fn() },
+        ],
     },
 };
 
@@ -132,5 +160,10 @@ export const Compact: Story = {
                 { label: 'Route 1', distance: 10000, format: 'gpx', importable: true, alreadyImported: false },
             ] as any,
         },
+        title: 'Select Routes',
+        buttons: [
+            { label: 'Import (0)', onClick: fn(), primary: true, disabled: true },
+            { label: 'Cancel', onClick: fn() },
+        ],
     },
 };

--- a/src/components/RouteImportDialog/RouteImportDialog.tsx
+++ b/src/components/RouteImportDialog/RouteImportDialog.tsx
@@ -187,7 +187,7 @@ export const RouteImportDialog = ({ onClose }: RouteImportDialogProps) => {
             refSingleObserver.current = observer;
             observer.on('success', onSingleResult);
             observer.on('error', onSingleResult);
-            // Fix: No immediate onUpdate here to avoid race with app resume
+            // No immediate onUpdate here to avoid race with app resume
         } catch (err) {
             logError(err, 'onAddGpx');
         }
@@ -203,7 +203,7 @@ export const RouteImportDialog = ({ onClose }: RouteImportDialogProps) => {
             refSingleObserver.current = observer;
             observer.on('success', onSingleResult);
             observer.on('error', onSingleResult);
-            // Fix: No immediate onUpdate here to avoid race with app resume
+            // No immediate onUpdate here to avoid race with app resume
         } catch (err) {
             logError(err, 'onAddVideoRoute');
         }

--- a/src/components/RouteImportDialog/RouteImportDialog.tsx
+++ b/src/components/RouteImportDialog/RouteImportDialog.tsx
@@ -6,22 +6,20 @@ import {
     ScannedRoute,
     IObserver,
 } from 'incyclist-services';
-import { Dialog } from '../Dialog';
-import { ImportRoutesDialogView } from './RouteImportDialogView';
-import { ImportRoutesDialogProps } from './types';
+import { RouteImportDialogView } from './RouteImportDialogView';
+import { RouteImportDialogProps } from './types';
 import { useScreenLayout, useLogging, useUnmountEffect } from '../../hooks';
 import { useFilePicker } from '../../hooks/files/useFilePicker';
 import { getUIBinding } from '../../bindings/ui';
-import { SingleImportingView } from './views/SingleImportingView';
 
 /**
  * Smart component for the Import Routes dialog.
  * Owns service subscriptions and lifecycle directly.
  */
-export const ImportRoutesDialog = ({ onClose }: ImportRoutesDialogProps) => {
+export const RouteImportDialog = ({ onClose }: RouteImportDialogProps) => {
     const layout = useScreenLayout();
     const isCompact = layout === 'compact';
-    const { logError } = useLogging('ImportRoutesDialog');
+    const { logError } = useLogging('RouteImportDialog');
     const { pickFile } = useFilePicker();
 
     const [displayProps, setDisplayProps] = useState<ImportDisplayProps>(() =>
@@ -263,7 +261,6 @@ export const ImportRoutesDialog = ({ onClose }: ImportRoutesDialogProps) => {
 
     useEffect(() => {
         if (!refInitialized.current) {
-            getRoutesPageService().onImportClicked();
             onUpdate();
             refInitialized.current = true;
         }
@@ -302,27 +299,68 @@ export const ImportRoutesDialog = ({ onClose }: ImportRoutesDialogProps) => {
         }
     }, [phase, isSingleImporting]);
 
+    const buttons = useMemo(() => {
+        if (isSingleImporting) return [];
+        switch (phase) {
+            case 'landing':
+                return [];
+            case 'scanning':
+                return [{ label: 'Cancel', onClick: onCancel }];
+            case 'parsing':
+            case 'selecting':
+                return [
+                    {
+                        label: `Import (${selectedIds.length})`,
+                        onClick: onConfirmSelection,
+                        primary: true,
+                        disabled: phase === 'parsing' || selectedIds.length === 0,
+                    },
+                    { label: 'Cancel', onClick: onCancel },
+                ];
+            case 'ingesting':
+                return [{ label: 'Cancel', onClick: onCancel }];
+            case 'complete':
+                return [{ label: 'Done', onClick: onDone, primary: true }];
+            case 'result':
+                return displayProps.resultSuccess
+                    ? [{ label: 'Done', onClick: onDone, primary: true }]
+                    : [
+                          { label: 'Try Again', onClick: handleTryAgain, primary: true },
+                          { label: 'Cancel', onClick: onCancel },
+                      ];
+            default:
+                return [];
+        }
+    }, [
+        phase,
+        isSingleImporting,
+        selectedIds.length,
+        displayProps.resultSuccess,
+        onCancel,
+        onConfirmSelection,
+        onDone,
+        handleTryAgain,
+    ]);
+
     return (
-        <Dialog title={title} visible={true} onOutsideClick={onOutsideClick} variant="details">
-            {isSingleImporting ? (
-                <SingleImportingView compact={isCompact} />
-            ) : (
-                <ImportRoutesDialogView
-                    compact={isCompact}
-                    displayProps={displayProps}
-                    selectedIds={selectedIds}
-                    onAddGpx={onAddGpx}
-                    onAddVideoRoute={onAddVideoRoute}
-                    onSelectFolder={onSelectFolder}
-                    onToggleRoute={onToggleRoute}
-                    onSelectAll={onSelectAll}
-                    onDeselectAll={onDeselectAll}
-                    onConfirmSelection={onConfirmSelection}
-                    onDone={onDone}
-                    onTryAgain={handleTryAgain}
-                    onCancel={onCancel}
-                />
-            )}
-        </Dialog>
+        <RouteImportDialogView
+            compact={isCompact}
+            title={title}
+            buttons={buttons}
+            isSingleImporting={isSingleImporting}
+            onOutsideClick={onOutsideClick}
+            displayProps={displayProps}
+            selectedIds={selectedIds}
+            onAddGpx={onAddGpx}
+            onAddVideoRoute={onAddVideoRoute}
+            onSelectFolder={onSelectFolder}
+            onToggleRoute={onToggleRoute}
+            onSelectAll={onSelectAll}
+            onDeselectAll={onDeselectAll}
+            onConfirmSelection={onConfirmSelection}
+            onDone={onDone}
+            onTryAgain={handleTryAgain}
+            onCancel={onCancel}
+        />
     );
 };

--- a/src/components/RouteImportDialog/RouteImportDialog.tsx
+++ b/src/components/RouteImportDialog/RouteImportDialog.tsx
@@ -187,6 +187,7 @@ export const RouteImportDialog = ({ onClose }: RouteImportDialogProps) => {
             refSingleObserver.current = observer;
             observer.on('success', onSingleResult);
             observer.on('error', onSingleResult);
+            // Fix: No immediate onUpdate here to avoid race with app resume
         } catch (err) {
             logError(err, 'onAddGpx');
         }
@@ -202,6 +203,7 @@ export const RouteImportDialog = ({ onClose }: RouteImportDialogProps) => {
             refSingleObserver.current = observer;
             observer.on('success', onSingleResult);
             observer.on('error', onSingleResult);
+            // Fix: No immediate onUpdate here to avoid race with app resume
         } catch (err) {
             logError(err, 'onAddVideoRoute');
         }

--- a/src/components/RouteImportDialog/RouteImportDialogView.test.tsx
+++ b/src/components/RouteImportDialog/RouteImportDialogView.test.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
-import { ImportRoutesDialogView } from './RouteImportDialogView';
-import { ImportRoutesDialogViewProps } from './types';
+import { RouteImportDialogView } from './RouteImportDialogView';
+import { RouteImportDialogViewProps } from './types';
 
-const defaultProps: ImportRoutesDialogViewProps = {
+const defaultProps: RouteImportDialogViewProps = {
     compact: false,
     displayProps: {
         phase: 'landing',
         routes: [],
     },
     selectedIds: [],
+    isSingleImporting: false,
+    title: 'Import Routes',
+    buttons: [],
     onAddGpx: jest.fn(),
     onAddVideoRoute: jest.fn(),
     onSelectFolder: jest.fn(),
@@ -22,14 +25,14 @@ const defaultProps: ImportRoutesDialogViewProps = {
     onCancel: jest.fn(),
 };
 
-describe('ImportRoutesDialogView', () => {
+describe('RouteImportDialogView', () => {
     it('renders landing phase without crashing', () => {
-        render(<ImportRoutesDialogView {...defaultProps} />);
+        render(<RouteImportDialogView {...defaultProps} />);
     });
 
     it('renders scanning phase without crashing', () => {
         render(
-            <ImportRoutesDialogView
+            <RouteImportDialogView
                 {...defaultProps}
                 displayProps={{
                     ...defaultProps.displayProps,
@@ -42,7 +45,7 @@ describe('ImportRoutesDialogView', () => {
 
     it('renders parsing phase without crashing', () => {
         render(
-            <ImportRoutesDialogView
+            <RouteImportDialogView
                 {...defaultProps}
                 displayProps={{
                     ...defaultProps.displayProps,
@@ -55,7 +58,7 @@ describe('ImportRoutesDialogView', () => {
 
     it('renders selecting phase without crashing', () => {
         render(
-            <ImportRoutesDialogView
+            <RouteImportDialogView
                 {...defaultProps}
                 displayProps={{
                     ...defaultProps.displayProps,
@@ -67,7 +70,7 @@ describe('ImportRoutesDialogView', () => {
 
     it('renders ingesting phase without crashing', () => {
         render(
-            <ImportRoutesDialogView
+            <RouteImportDialogView
                 {...defaultProps}
                 displayProps={{
                     ...defaultProps.displayProps,
@@ -80,7 +83,7 @@ describe('ImportRoutesDialogView', () => {
 
     it('renders complete phase without crashing', () => {
         render(
-            <ImportRoutesDialogView
+            <RouteImportDialogView
                 {...defaultProps}
                 displayProps={{
                     ...defaultProps.displayProps,
@@ -93,7 +96,7 @@ describe('ImportRoutesDialogView', () => {
 
     it('renders result phase without crashing', () => {
         render(
-            <ImportRoutesDialogView
+            <RouteImportDialogView
                 {...defaultProps}
                 displayProps={{
                     ...defaultProps.displayProps,
@@ -105,6 +108,6 @@ describe('ImportRoutesDialogView', () => {
     });
 
     it('renders correctly in compact mode', () => {
-        render(<ImportRoutesDialogView {...defaultProps} compact={true} />);
+        render(<RouteImportDialogView {...defaultProps} compact={true} />);
     });
 });

--- a/src/components/RouteImportDialog/RouteImportDialogView.tsx
+++ b/src/components/RouteImportDialog/RouteImportDialogView.tsx
@@ -1,32 +1,34 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
-import { ImportRoutesDialogViewProps } from './types';
+import { RouteImportDialogViewProps } from './types';
 import { LandingView } from './views/LandingView';
 import { ScanningView } from './views/ScanningView';
 import { ParseSelectionView } from './views/ParseSelectionView';
 import { IngestingView } from './views/IngestingView';
 import { CompleteView } from './views/CompleteView';
 import { ResultView } from './views/ResultView';
+import { SingleImportingView } from './views/SingleImportingView';
+import { Dialog } from '../Dialog';
 
 /**
  * Pure view component for the Import Routes dialog.
  * Switches between sub-views based on the current import phase.
  */
-export const ImportRoutesDialogView = ({
+export const RouteImportDialogView = ({
     compact,
     displayProps,
     selectedIds,
+    isSingleImporting,
+    title,
+    buttons,
+    onOutsideClick,
     onAddGpx,
     onAddVideoRoute,
     onSelectFolder,
     onToggleRoute,
     onSelectAll,
     onDeselectAll,
-    onConfirmSelection,
-    onDone,
-    onTryAgain,
-    onCancel,
-}: ImportRoutesDialogViewProps) => {
+}: RouteImportDialogViewProps) => {
     const {
         phase,
         scanProgress,
@@ -39,6 +41,9 @@ export const ImportRoutesDialogView = ({
     } = displayProps;
 
     const renderContent = () => {
+        if (isSingleImporting) {
+            return <SingleImportingView compact={compact} />;
+        }
         switch (phase) {
             case 'landing':
                 return (
@@ -47,7 +52,6 @@ export const ImportRoutesDialogView = ({
                         onAddGpx={onAddGpx}
                         onAddVideoRoute={onAddVideoRoute}
                         onSelectFolder={onSelectFolder}
-                        onCancel={onCancel}
                     />
                 );
 
@@ -56,7 +60,6 @@ export const ImportRoutesDialogView = ({
                     <ScanningView
                         compact={compact}
                         scannedFolders={scanProgress?.scannedFolders ?? 0}
-                        onCancel={onCancel}
                     />
                 );
 
@@ -71,8 +74,6 @@ export const ImportRoutesDialogView = ({
                         onToggle={onToggleRoute}
                         onSelectAll={onSelectAll}
                         onDeselectAll={onDeselectAll}
-                        onConfirm={onConfirmSelection}
-                        onCancel={onCancel}
                     />
                 );
 
@@ -84,7 +85,6 @@ export const ImportRoutesDialogView = ({
                         total={ingestProgress?.total ?? 0}
                         currentName={ingestProgress?.currentName ?? ''}
                         errorCount={0}
-                        onCancel={onCancel}
                     />
                 );
 
@@ -96,7 +96,6 @@ export const ImportRoutesDialogView = ({
                         skipped={completionSummary?.skipped ?? 0}
                         errors={completionSummary?.errors ?? 0}
                         failedRoutes={completionSummary?.failedRoutes ?? []}
-                        onDone={onDone}
                     />
                 );
 
@@ -107,9 +106,6 @@ export const ImportRoutesDialogView = ({
                         success={resultSuccess != null}
                         routeName={resultSuccess?.routeName}
                         error={error}
-                        onDone={onDone}
-                        onTryAgain={onTryAgain}
-                        onCancel={onCancel}
                     />
                 );
 
@@ -119,14 +115,22 @@ export const ImportRoutesDialogView = ({
     };
 
     return (
-        <View style={styles.container}>
-            {renderContent()}
-        </View>
+        <Dialog
+            title={title}
+            visible={true}
+            onOutsideClick={onOutsideClick}
+            variant="details"
+            buttons={buttons}
+        >
+            <View style={styles.container}>
+                {renderContent()}
+            </View>
+        </Dialog>
     );
 };
 
 const styles = StyleSheet.create({
     container: {
-        flex: 1,
+        // Leave empty as per requirements
     },
 });

--- a/src/components/RouteImportDialog/types.ts
+++ b/src/components/RouteImportDialog/types.ts
@@ -1,13 +1,18 @@
 import { ImportDisplayProps } from 'incyclist-services';
+import { ButtonProps } from '../ButtonBar/types';
 
-export interface ImportRoutesDialogProps {
+export interface RouteImportDialogProps {
     onClose: () => void;
 }
 
-export interface ImportRoutesDialogViewProps {
+export interface RouteImportDialogViewProps {
     compact: boolean;
     displayProps: ImportDisplayProps;
     selectedIds: string[];
+    isSingleImporting: boolean;
+    title: string;
+    buttons: ButtonProps[];
+    onOutsideClick?: () => void;
     onAddGpx: () => void;
     onAddVideoRoute: () => void;
     onSelectFolder: () => void;

--- a/src/components/RouteImportDialog/views/CompleteView.tsx
+++ b/src/components/RouteImportDialog/views/CompleteView.tsx
@@ -1,7 +1,6 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { colors, textSizes } from '../../../theme';
-import { ButtonBar } from '../../ButtonBar';
 import { Icon } from '../../Icon';
 import type { FailedRoute } from 'incyclist-services';
 
@@ -11,7 +10,6 @@ interface CompleteViewProps {
     skipped: number;
     errors: number;
     failedRoutes: FailedRoute[];
-    onDone: () => void;
 }
 
 const SummaryItem = ({ label, count, color = colors.text }: { label: string; count: number; color?: string }) => {
@@ -30,17 +28,12 @@ export const CompleteView = ({
     skipped,
     errors,
     failedRoutes,
-    onDone,
 }: CompleteViewProps) => {
     const [showErrors, setShowErrors] = useState(false);
 
     const toggleErrors = useCallback(() => {
         setShowErrors(prev => !prev);
     }, []);
-
-    const buttons = useMemo(() => [
-        { label: 'Done', onClick: onDone, primary: true }
-    ], [onDone]);
 
     return (
         <View style={[styles.container, compact && styles.containerCompact]}>
@@ -77,10 +70,6 @@ export const CompleteView = ({
             <Text style={[styles.note, compact && styles.noteCompact]}>
                 Videos are not copied — they play from their original location.
             </Text>
-
-            <View style={styles.buttonWrapper}>
-                <ButtonBar buttons={buttons} />
-            </View>
         </View>
     );
 };
@@ -177,8 +166,5 @@ const styles = StyleSheet.create({
     },
     noteCompact: {
         marginBottom: 8,
-    },
-    buttonWrapper: {
-        width: '100%',
     },
 });

--- a/src/components/RouteImportDialog/views/IngestingView.tsx
+++ b/src/components/RouteImportDialog/views/IngestingView.tsx
@@ -1,7 +1,6 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { View, Text, StyleSheet, DimensionValue } from 'react-native';
 import { colors, textSizes } from '../../../theme';
-import { ButtonBar } from '../../ButtonBar';
 
 interface IngestingViewProps {
     compact: boolean;
@@ -9,7 +8,6 @@ interface IngestingViewProps {
     total: number;
     currentName: string;
     errorCount: number;
-    onCancel: () => void;
 }
 
 export const IngestingView = ({
@@ -18,15 +16,10 @@ export const IngestingView = ({
     total,
     currentName,
     errorCount,
-    onCancel,
 }: IngestingViewProps) => {
     const progress = total > 0 ? (current / total) * 100 : 0;
     const progressWidth = `${Math.min(100, Math.max(0, progress))}%` as DimensionValue;
     const progressStyle = { width: progressWidth };
-
-    const buttons = useMemo(() => [
-        { label: 'Cancel', onClick: onCancel, attention: true }
-    ], [onCancel]);
 
     return (
         <View style={[styles.container, compact && styles.containerCompact]}>
@@ -48,10 +41,6 @@ export const IngestingView = ({
                     {`Errors: ${errorCount}`}
                 </Text>
             )}
-
-            <View style={styles.buttonWrapper}>
-                <ButtonBar buttons={buttons} />
-            </View>
         </View>
     );
 };
@@ -103,9 +92,5 @@ const styles = StyleSheet.create({
         color: colors.error,
         marginTop: 8,
         fontWeight: 'bold',
-    },
-    buttonWrapper: {
-        marginTop: 12,
-        width: '100%',
     },
 });

--- a/src/components/RouteImportDialog/views/LandingView.test.tsx
+++ b/src/components/RouteImportDialog/views/LandingView.test.tsx
@@ -9,7 +9,6 @@ describe('LandingView', () => {
         onAddGpx: jest.fn(),
         onAddVideoRoute: jest.fn(),
         onSelectFolder: jest.fn(),
-        onCancel: jest.fn(),
     };
 
     it('renders without crashing in normal mode', () => {

--- a/src/components/RouteImportDialog/views/LandingView.tsx
+++ b/src/components/RouteImportDialog/views/LandingView.tsx
@@ -1,16 +1,14 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Platform } from 'react-native';
 import { colors, textSizes } from '../../../theme';
 import { Icon } from '../../Icon';
 import { IconName } from '../../Icon/types';
-import { ButtonBar } from '../../ButtonBar/ButtonBar';
 
 interface LandingViewProps {
     compact: boolean;
     onAddGpx: () => void;
     onAddVideoRoute: () => void;
     onSelectFolder: () => void;
-    onCancel: () => void;
 }
 
 const OptionTile = ({ 
@@ -47,12 +45,7 @@ export const LandingView = ({
     onAddGpx, 
     onAddVideoRoute, 
     onSelectFolder, 
-    onCancel 
 }: LandingViewProps) => {
-    const buttons = useMemo(() => [
-        { label: 'Cancel', onClick: onCancel }
-    ], [onCancel]);
-
     return (
         <View style={[styles.container, compact && styles.containerCompact]}>
             <View style={styles.optionsContainer}>
@@ -80,7 +73,6 @@ export const LandingView = ({
                     compact={compact} 
                 />
             </View>
-            <ButtonBar buttons={buttons} />
         </View>
     );
 };

--- a/src/components/RouteImportDialog/views/ParseSelectionView.tsx
+++ b/src/components/RouteImportDialog/views/ParseSelectionView.tsx
@@ -2,7 +2,6 @@ import React, { useCallback } from 'react';
 import { View, Text, StyleSheet, FlatList, TouchableOpacity } from 'react-native';
 import type { RouteDisplayItem } from 'incyclist-services';
 import { colors, textSizes } from '../../../theme';
-import { ButtonBar } from '../../ButtonBar';
 import { Icon } from '../../Icon';
 
 interface ParseSelectionViewProps {
@@ -13,8 +12,6 @@ interface ParseSelectionViewProps {
     onToggle: (id: string) => void;
     onSelectAll: () => void;
     onDeselectAll: () => void;
-    onConfirm: () => void;
-    onCancel: () => void;
 }
 
 const Checkbox = ({ checked, disabled, onToggle }: { checked: boolean; disabled?: boolean; onToggle: () => void }) => {
@@ -99,11 +96,8 @@ export const ParseSelectionView = ({
     onToggle,
     onSelectAll,
     onDeselectAll,
-    onConfirm,
-    onCancel,
 }: ParseSelectionViewProps) => {
     const isParsing = !!parseProgress;
-    const noop = useCallback(() => {}, []);
     
     const renderItem = useCallback(({ item: routeItem }: { item: RouteDisplayItem }) => (
         <RouteRow 
@@ -114,21 +108,7 @@ export const ParseSelectionView = ({
         />
     ), [selectedIds, onToggle, compact]);
 
-    const buttons = [
-        {
-            label: `Import (${selectedIds.length})`,
-            onClick: isParsing ? noop : onConfirm,
-            primary: true,
-        },
-        {
-            label: 'Cancel',
-            onClick: onCancel,
-            primary: false,
-        },
-    ];
-
     const containerStyle = [styles.container, compact && styles.containerCompact];
-    const footerStyle = [styles.footer, isParsing && styles.footerDisabled];
 
     return (
         <View style={containerStyle}>
@@ -158,10 +138,6 @@ export const ParseSelectionView = ({
                 style={styles.list}
                 contentContainerStyle={styles.listContent}
             />
-
-            <View style={footerStyle}>
-                <ButtonBar buttons={buttons} />
-            </View>
         </View>
     );
 };
@@ -294,13 +270,5 @@ const styles = StyleSheet.create({
         color: colors.iconSelected,
         fontSize: textSizes.subtitle,
         fontWeight: 'bold',
-    },
-    footer: {
-        borderTopWidth: 1,
-        borderTopColor: colors.listSeparator,
-        paddingTop: 8,
-    },
-    footerDisabled: {
-        opacity: 0.5,
     },
 });

--- a/src/components/RouteImportDialog/views/ResultView.tsx
+++ b/src/components/RouteImportDialog/views/ResultView.tsx
@@ -1,17 +1,13 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { colors, textSizes } from '../../../theme';
 import { Icon } from '../../Icon';
-import { ButtonBar } from '../../ButtonBar/ButtonBar';
 
 interface ResultViewProps {
     compact: boolean;
     success: boolean;
     routeName?: string;
     error?: string;
-    onDone: () => void;
-    onTryAgain: () => void;
-    onCancel: () => void;
 }
 
 export const ResultView = ({ 
@@ -19,22 +15,7 @@ export const ResultView = ({
     success, 
     routeName, 
     error, 
-    onDone, 
-    onTryAgain, 
-    onCancel 
 }: ResultViewProps) => {
-    const buttons = useMemo(() => {
-        if (success) {
-            return [
-                { label: 'Done', primary: true, onClick: onDone }
-            ];
-        }
-        return [
-            { label: 'Try Again', primary: true, onClick: onTryAgain },
-            { label: 'Cancel', onClick: onCancel }
-        ];
-    }, [success, onDone, onTryAgain, onCancel]);
-
     const statusColor = success ? colors.success : colors.error;
     const title = success ? 'Import Successful' : 'Import Failed';
     
@@ -62,7 +43,6 @@ export const ResultView = ({
                 <Text style={[styles.title, compact && styles.titleCompact]}>{title}</Text>
                 <Text style={[styles.message, compact && styles.messageCompact]}>{message}</Text>
             </View>
-            <ButtonBar buttons={buttons} />
         </View>
     );
 };

--- a/src/components/RouteImportDialog/views/ScanningView.tsx
+++ b/src/components/RouteImportDialog/views/ScanningView.tsx
@@ -1,23 +1,13 @@
 import React from 'react';
 import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import { colors, textSizes } from '../../../theme';
-import { ButtonBar } from '../../ButtonBar';
 
 interface ScanningViewProps {
     compact: boolean;
     scannedFolders: number;
-    onCancel: () => void;
 }
 
-export const ScanningView = ({ compact, scannedFolders, onCancel }: ScanningViewProps) => {
-    const buttons = [
-        {
-            label: 'Cancel',
-            onClick: onCancel,
-            primary: false,
-        },
-    ];
-
+export const ScanningView = ({ compact, scannedFolders }: ScanningViewProps) => {
     const containerStyle = [styles.container, compact && styles.containerCompact];
     const titleStyle = [styles.title, compact && styles.titleCompact];
     const textStyle = [styles.text, compact && styles.textCompact];
@@ -35,9 +25,6 @@ export const ScanningView = ({ compact, scannedFolders, onCancel }: ScanningView
             <Text style={textStyle}>
                 Folders scanned: {scannedFolders}
             </Text>
-            <View style={styles.footer}>
-                <ButtonBar buttons={buttons} />
-            </View>
         </View>
     );
 };
@@ -76,9 +63,5 @@ const styles = StyleSheet.create({
     textCompact: {
         fontSize: textSizes.smallText,
         marginBottom: 16,
-    },
-    footer: {
-        width: '100%',
-        marginTop: 'auto',
     },
 });

--- a/src/components/RouteImportDialog/views/SingleImportingView.stories.tsx
+++ b/src/components/RouteImportDialog/views/SingleImportingView.stories.tsx
@@ -2,18 +2,18 @@ import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { SingleImportingView } from './SingleImportingView';
 
 const meta: Meta<typeof SingleImportingView> = {
-    title: 'Components/ImportRoutesDialog/Views/SingleImportingView',
+    title: 'Components/RouteImportDialog/Views/SingleImportingView',
     component: SingleImportingView,
-};
-
-export default meta;
-type Story = StoryObj<typeof SingleImportingView>;
-
-export const Default: Story = {
     args: {
         compact: false,
     },
 };
+
+export default meta;
+
+type Story = StoryObj<typeof SingleImportingView>;
+
+export const Default: Story = {};
 
 export const Compact: Story = {
     args: {

--- a/src/components/RouteImportDialog/views/SingleImportingView.test.tsx
+++ b/src/components/RouteImportDialog/views/SingleImportingView.test.tsx
@@ -3,11 +3,11 @@ import { render } from '@testing-library/react-native';
 import { SingleImportingView } from './SingleImportingView';
 
 describe('SingleImportingView', () => {
-    it('renders without crashing', () => {
+    it('renders without crashing in normal mode', () => {
         render(<SingleImportingView compact={false} />);
     });
 
-    it('renders correctly in compact mode', () => {
+    it('renders without crashing in compact mode', () => {
         render(<SingleImportingView compact={true} />);
     });
 });

--- a/src/components/RouteImportDialog/views/SingleImportingView.test.tsx
+++ b/src/components/RouteImportDialog/views/SingleImportingView.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react-native';
 import { SingleImportingView } from './SingleImportingView';
 
 describe('SingleImportingView', () => {
-    it('renders correctly', () => {
+    it('renders without crashing', () => {
         render(<SingleImportingView compact={false} />);
     });
 

--- a/src/components/RouteImportDialog/views/SingleImportingView.tsx
+++ b/src/components/RouteImportDialog/views/SingleImportingView.tsx
@@ -7,7 +7,7 @@ interface SingleImportingViewProps {
 }
 
 /**
- * Pure view component shown during a single file import.
+ * Pure view shown when a single file is being imported after selection.
  */
 export const SingleImportingView = ({ compact }: SingleImportingViewProps) => {
     const containerStyle = [styles.container, compact && styles.containerCompact];
@@ -15,10 +15,10 @@ export const SingleImportingView = ({ compact }: SingleImportingViewProps) => {
 
     return (
         <View style={containerStyle}>
-            <ActivityIndicator 
-                size="large" 
-                color={colors.buttonPrimary} 
-                style={styles.spinner} 
+            <ActivityIndicator
+                size="large"
+                color={colors.buttonPrimary}
+                style={styles.spinner}
             />
             <Text style={titleStyle}>
                 Importing route...

--- a/src/components/RouteImportDialog/views/SingleImportingView.tsx
+++ b/src/components/RouteImportDialog/views/SingleImportingView.tsx
@@ -6,6 +6,9 @@ interface SingleImportingViewProps {
     compact: boolean;
 }
 
+/**
+ * Pure view component shown during a single file import.
+ */
 export const SingleImportingView = ({ compact }: SingleImportingViewProps) => {
     const containerStyle = [styles.container, compact && styles.containerCompact];
     const titleStyle = [styles.title, compact && styles.titleCompact];


### PR DESCRIPTION
Closes #282

This PR refactors the `RouteImportDialog` to align with the project's UI foundations:
- Renames all remaining `ImportRoutesDialog` references to `RouteImportDialog` convention.
- Moves `Dialog` rendering from the smart component to the pure view component.
- Moves all action buttons from sub-views into the `Dialog` footer via the `buttons` prop.
- Removes `ButtonBar` from all sub-views.
- Fixes scrolling issues by removing `flex: 1` from the view container.
- Removes redundant `onImportClicked()` call from the dialog initialization.