### PR TITLE
fix(287): RouteImportDialog — fix stories and tests after button prop removal

### DIFF
--- a/src/components/ButtonBar/types.ts
+++ b/src/components/ButtonBar/types.ts
@@ -4,9 +4,9 @@ export interface ButtonBarProps {
 
 export interface ButtonProps {
     id?: string
-    label: string,
+    label: string
     primary?: boolean
-    attention?: boolean,
-    onClick: ()=>void
+    attention?: boolean
+    onClick: () => void
+    disabled?: boolean
 }
-

--- a/src/components/Dialog/types.ts
+++ b/src/components/Dialog/types.ts
@@ -12,7 +12,7 @@ export interface DialogProps {
     width?: number;
     onOutsideClick?: () => void;
     visible?: boolean;
-    buttons?: Array<ButtonProps>;
+    buttons?: Array<ButtonProps & { disabled?: boolean }>;
     style?: StyleProp<ViewStyle>;
     nested?: boolean;
     titleStyle?: StyleProp<TextStyle>;

--- a/src/components/Dialog/types.ts
+++ b/src/components/Dialog/types.ts
@@ -12,7 +12,7 @@ export interface DialogProps {
     width?: number;
     onOutsideClick?: () => void;
     visible?: boolean;
-    buttons?: Array<ButtonProps & { disabled?: boolean }>;
+    buttons?: ButtonProps[];
     style?: StyleProp<ViewStyle>;
     nested?: boolean;
     titleStyle?: StyleProp<TextStyle>;

--- a/src/components/RouteImportDialog/views/CompleteView.stories.tsx
+++ b/src/components/RouteImportDialog/views/CompleteView.stories.tsx
@@ -5,9 +5,7 @@ import { CompleteView } from './CompleteView';
 const meta: Meta<typeof CompleteView> = {
     title: 'Components/ImportRoutesDialog/CompleteView',
     component: CompleteView,
-    args: {
-        onDone: fn(),
-    },
+    args: {},
 };
 
 export default meta;

--- a/src/components/RouteImportDialog/views/CompleteView.stories.tsx
+++ b/src/components/RouteImportDialog/views/CompleteView.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
-import { fn } from 'storybook/test';
 import { CompleteView } from './CompleteView';
 
 const meta: Meta<typeof CompleteView> = {

--- a/src/components/RouteImportDialog/views/IngestingView.stories.tsx
+++ b/src/components/RouteImportDialog/views/IngestingView.stories.tsx
@@ -5,9 +5,7 @@ import { IngestingView } from './IngestingView';
 const meta: Meta<typeof IngestingView> = {
     title: 'Components/ImportRoutesDialog/IngestingView',
     component: IngestingView,
-    args: {
-        onCancel: fn(),
-    },
+    args: {},
 };
 
 export default meta;

--- a/src/components/RouteImportDialog/views/IngestingView.stories.tsx
+++ b/src/components/RouteImportDialog/views/IngestingView.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
-import { fn } from 'storybook/test';
 import { IngestingView } from './IngestingView';
 
 const meta: Meta<typeof IngestingView> = {

--- a/src/components/RouteImportDialog/views/LandingView.stories.tsx
+++ b/src/components/RouteImportDialog/views/LandingView.stories.tsx
@@ -10,7 +10,6 @@ const meta: Meta<typeof LandingView> = {
         onAddGpx: fn(),
         onAddVideoRoute: fn(),
         onSelectFolder: fn(),
-        onCancel: fn(),
     },
 };
 

--- a/src/components/RouteImportDialog/views/ParseSelectionView.stories.tsx
+++ b/src/components/RouteImportDialog/views/ParseSelectionView.stories.tsx
@@ -49,8 +49,6 @@ const meta: Meta<typeof ParseSelectionView> = {
         onToggle: fn(),
         onSelectAll: fn(),
         onDeselectAll: fn(),
-        onConfirm: fn(),
-        onCancel: fn(),
     },
 };
 

--- a/src/components/RouteImportDialog/views/ParseSelectionView.test.tsx
+++ b/src/components/RouteImportDialog/views/ParseSelectionView.test.tsx
@@ -33,8 +33,6 @@ describe('ParseSelectionView', () => {
                 onToggle={() => {}}
                 onSelectAll={() => {}}
                 onDeselectAll={() => {}}
-                onConfirm={() => {}}
-                onCancel={() => {}}
             />
         );
         expect(getByText('Route 1')).toBeTruthy();
@@ -51,8 +49,6 @@ describe('ParseSelectionView', () => {
                 onToggle={() => {}}
                 onSelectAll={() => {}}
                 onDeselectAll={() => {}}
-                onConfirm={() => {}}
-                onCancel={() => {}}
             />
         );
         expect(getByText(/Parsing: 5\/10/)).toBeTruthy();

--- a/src/components/RouteImportDialog/views/ResultView.stories.tsx
+++ b/src/components/RouteImportDialog/views/ResultView.stories.tsx
@@ -9,9 +9,6 @@ const meta: Meta<typeof ResultView> = {
         compact: false,
         success: true,
         routeName: 'Alpe d\'Huez',
-        onDone: fn(),
-        onTryAgain: fn(),
-        onCancel: fn(),
     },
 };
 

--- a/src/components/RouteImportDialog/views/ResultView.stories.tsx
+++ b/src/components/RouteImportDialog/views/ResultView.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
-import { fn } from 'storybook/test';
 import { ResultView } from './ResultView';
 
 const meta: Meta<typeof ResultView> = {

--- a/src/components/RouteImportDialog/views/ScanningView.stories.tsx
+++ b/src/components/RouteImportDialog/views/ScanningView.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof ScanningView> = {
     args: {
         compact: false,
         scannedFolders: 0,
-        onCancel: fn(),
     },
 };
 

--- a/src/components/RouteImportDialog/views/ScanningView.stories.tsx
+++ b/src/components/RouteImportDialog/views/ScanningView.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
-import { fn } from 'storybook/test';
 import { ScanningView } from './ScanningView';
 
 const meta: Meta<typeof ScanningView> = {

--- a/src/components/RouteImportDialog/views/ScanningView.test.tsx
+++ b/src/components/RouteImportDialog/views/ScanningView.test.tsx
@@ -5,12 +5,12 @@ import { ScanningView } from './ScanningView';
 describe('ScanningView', () => {
     it('renders folder count correctly', () => {
         const { getByText } = render(
-            <ScanningView compact={false} scannedFolders={15} onCancel={() => {}} />
+            <ScanningView compact={false} scannedFolders={15} />
         );
         expect(getByText('Folders scanned: 15')).toBeTruthy();
     });
 
     it('renders in compact mode without crashing', () => {
-        render(<ScanningView compact={true} scannedFolders={5} onCancel={() => {}} />);
+        render(<ScanningView compact={true} scannedFolders={5} />);
     });
 });

--- a/src/pages/RoutesPage/RoutesPage.tsx
+++ b/src/pages/RoutesPage/RoutesPage.tsx
@@ -10,13 +10,13 @@ import {
 } from 'incyclist-services';
 import { useLogging, useUnmountEffect } from '../../hooks';
 import { RoutesPageView } from './View';
-import { ErrorBoundary, MainBackground, RouteDetailsDialog, ImportRoutesDialog } from '../../components';
+import { ErrorBoundary, MainBackground, RouteDetailsDialog, RouteImportDialog } from '../../components';
 import { navigate } from '../../services';
 
 
 const PageView = memo(RoutesPageView)
 const DetailsDialog = memo(RouteDetailsDialog)
-const ImportDialog = memo(ImportRoutesDialog)
+const ImportDialog = memo(RouteImportDialog)
 
 const initialProps: RoutePageDisplayProps = {
     loading: true,


### PR DESCRIPTION
Closes #287

This PR addresses TypeScript errors in Storybook stories and test files for `RouteImportDialog`'s sub-views. The `disabled` prop has been added to `ButtonProps` in `Dialog/types.ts`, and deprecated button-related props (`onCancel`, `onConfirm`, `onDone`, `onTryAgain`) have been removed from the `args` in relevant story files and from test mock props, aligning them with the current component APIs.