### PR TITLE
fix(293): resolve iOS app stuck on loader by platform guarding SAF module

### DIFF
--- a/src/bindings/fs/index.test.ts
+++ b/src/bindings/fs/index.test.ts
@@ -1,3 +1,18 @@
+jest.mock('react-native', () => {
+    const saf = {
+        readFile: jest.fn(),
+        exists: jest.fn(),
+        listFiles: jest.fn(),
+    };
+    return {
+        Platform: { OS: 'android' },
+        TurboModule: {},
+        TurboModuleRegistry: {
+            getEnforcing: jest.fn(() => saf),
+        },
+    };
+});
+
 import RNFS from 'react-native-fs';
 import { TurboModuleRegistry } from 'react-native';
 import { FileSystemBinding } from './index';
@@ -14,20 +29,6 @@ jest.mock('react-native-fs', () => ({
         appendFile: jest.fn(),
     },
 }));
-
-jest.mock('react-native', () => {
-    const saf = {
-        readFile: jest.fn(),
-        exists: jest.fn(),
-        listFiles: jest.fn(),
-    };
-    return {
-        TurboModule: {},
-        TurboModuleRegistry: {
-            getEnforcing: jest.fn().mockReturnValue(saf),
-        },
-    };
-});
 
 const rnfs = RNFS as jest.Mocked<typeof RNFS>;
 // getEnforcing always returns the same SAF mock object, so calling it here gives us a stable reference

--- a/src/bindings/fs/index.ts
+++ b/src/bindings/fs/index.ts
@@ -1,15 +1,11 @@
 import RNFS from 'react-native-fs';
 import { IFileSystem, ReadDirResult } from 'incyclist-services';
-import { TurboModuleRegistry, TurboModule } from 'react-native';
+import { Platform, TurboModuleRegistry } from 'react-native';
+import type { Spec as SAFSpec } from '../../specs/NativeSAF';
 
-// Define the interface for SAF native module
-interface SAFSpec extends TurboModule {
-    listFiles(uri: string): Promise<Array<{ name: string; uri: string; isDirectory: boolean }>>
-    exists(uri: string): Promise<boolean>
-    readFile(uri: string, encoding: string): Promise<string>
-}
-
-const SAF = TurboModuleRegistry.getEnforcing<SAFSpec>('SAF');
+const SAF: SAFSpec | null = Platform.OS === 'android'
+    ? TurboModuleRegistry.getEnforcing<SAFSpec>('SAF')
+    : null;
 
 export class FileSystemBinding implements IFileSystem {
     async writeFile(path: string, data: any, encoding?: string): Promise<void> {
@@ -29,19 +25,27 @@ export class FileSystemBinding implements IFileSystem {
     }
 
     async readFile(path: string, encoding?: string): Promise<string|Buffer> {
-        const readRaw = path.startsWith('content://')
-            ? (enc: string) => SAF.readFile(path, enc)
-            : (enc: string) => RNFS.readFile(path, enc)
+        const readRaw = async (enc: string): Promise<string> => {
+            if (path.startsWith('content://')) {
+                if (!SAF) {
+                    throw new Error(
+                        `content:// URIs are only supported on Android (got ${path} on ${Platform.OS})`
+                    );
+                }
+                return SAF.readFile(path, enc);
+            }
+            return RNFS.readFile(path, enc);
+        };
 
         if (encoding === 'ascii' || encoding === 'binary' || encoding === 'latin1') {
-            const base64 = await readRaw('base64')
-            const buffer = Buffer.from(base64, 'base64')
-            if (encoding==='binary') {
-                return buffer
+            const base64 = await readRaw('base64');
+            const buffer = Buffer.from(base64, 'base64');
+            if (encoding === 'binary') {
+                return buffer;
             }
-            return buffer.toString(encoding as BufferEncoding)
+            return buffer.toString(encoding as BufferEncoding);
         }
-        return readRaw(encoding === 'base64' ? 'base64' : 'utf8')
+        return readRaw(encoding === 'base64' ? 'base64' : 'utf8');
     }
 
     async appendFile(path: string, data: string, encoding?: string): Promise<void> {
@@ -88,6 +92,11 @@ export class FileSystemBinding implements IFileSystem {
     async existsFile(path: string): Promise<boolean> {
         // Path is guaranteed to be a string, no need for optional chaining
         if (path.startsWith('content://')) {
+            if (!SAF) {
+                throw new Error(
+                    `content:// URIs are only supported on Android (got ${path} on ${Platform.OS})`
+                );
+            }
             return await SAF.exists(path);
         }
         return await RNFS.exists(path);
@@ -109,6 +118,11 @@ export class FileSystemBinding implements IFileSystem {
     }
 
     private async listSafEntries(uri: string): Promise<ReadDirResult[]> {
+        if (!SAF) {
+            throw new Error(
+                `content:// URIs are only supported on Android (got ${uri} on ${Platform.OS})`
+            );
+        }
         return await SAF.listFiles(uri);
     }
 

--- a/src/bindings/loader/index.ts
+++ b/src/bindings/loader/index.ts
@@ -20,9 +20,9 @@ export class FileLoaderBinding implements IFileLoader {
                                 `content:// URIs are only supported on Android (got ${path} on ${Platform.OS})`
                             );
                         }
-                        return await SAF.readFile(path, enc);
+                        return SAF.readFile(path, enc);
                     }
-                    return await RNFS.readFile(path, enc);
+                    return RNFS.readFile(path, enc);
                 };
 
                 if (encoding === 'base64') {

--- a/src/bindings/loader/index.ts
+++ b/src/bindings/loader/index.ts
@@ -1,15 +1,11 @@
 import RNFS from 'react-native-fs';
 import { IFileLoader, FileInfo, FileLoaderResult } from 'incyclist-services';
-import { TurboModuleRegistry, TurboModule } from 'react-native';
+import { Platform, TurboModuleRegistry } from 'react-native';
+import type { Spec as SAFSpec } from '../../specs/NativeSAF';
 
-// Define the interface for SAF native module
-interface SAFSpec extends TurboModule {
-    listFiles(uri: string): Promise<Array<{ name: string; uri: string; isDirectory: boolean }>>
-    exists(uri: string): Promise<boolean>
-    readFile(uri: string, encoding: string): Promise<string>
-}
-
-const SAF = TurboModuleRegistry.getEnforcing<SAFSpec>('SAF');
+const SAF: SAFSpec | null = Platform.OS === 'android'
+    ? TurboModuleRegistry.getEnforcing<SAFSpec>('SAF')
+    : null;
 
 export class FileLoaderBinding implements IFileLoader {
     async open(file: FileInfo): Promise<FileLoaderResult> {
@@ -18,10 +14,16 @@ export class FileLoaderBinding implements IFileLoader {
 
             const readFileWithEncoding = async (path: string, encoding?: string): Promise<string|Buffer> => {
                 const readRaw = async (enc: string): Promise<string> => {
-                    return path.startsWith('content://')
-                        ? await SAF.readFile(path, enc)
-                        : await RNFS.readFile(path, enc)
-                }
+                    if (path.startsWith('content://')) {
+                        if (!SAF) {
+                            throw new Error(
+                                `content:// URIs are only supported on Android (got ${path} on ${Platform.OS})`
+                            );
+                        }
+                        return await SAF.readFile(path, enc);
+                    }
+                    return await RNFS.readFile(path, enc);
+                };
 
                 if (encoding === 'base64') {
                     return readRaw('base64')

--- a/src/specs/NativeSAF.ts
+++ b/src/specs/NativeSAF.ts
@@ -1,10 +1,7 @@
 import type { TurboModule } from 'react-native';
-import { TurboModuleRegistry } from 'react-native';
 
 export interface Spec extends TurboModule {
     listFiles(uri: string): Promise<Array<{ name: string; uri: string; isDirectory: boolean }>>;
     readFile(uri: string, encoding: string): Promise<string>;
     exists(uri: string): Promise<boolean>;
 }
-
-export default TurboModuleRegistry.getEnforcing<Spec>('SAF');


### PR DESCRIPTION
Closes #293

This PR fixes the iOS launch crash caused by eager initialization of the Android-only Storage Access Framework (SAF) TurboModule. 

Key changes:
- Removed eager `getEnforcing` call from `NativeSAF.ts` to prevent module-level exceptions on iOS.
- Implemented platform-guarded lookup for the SAF module in `FileSystemBinding` and `FileLoaderBinding` (Android-only, null otherwise).
- Added defensive null-guards and descriptive error messages at all SAF call sites.
- Consolidated the `SAFSpec` interface into a single source of truth in `src/specs/NativeSAF.ts`, removing local redeclarations in bindings.

## Manual Steps
The following steps must be performed manually by the PO after merging to clean up the iOS project:
- Delete `ios/SAF/SAFModule.swift` and `ios/SAF/SAFModule.m` from the Xcode project.
- Remove the `ios/SAF/` folder from the filesystem.
- Remove the `Compile Sources` entries in `ios/<App>.xcodeproj/project.pbxproj` referencing the deleted files.