### PR TITLE
Show No Routes Found guidance when library scan returns zero files

### DIFF
--- a/src/components/RouteImportDialog/RouteImportDialog.tsx
+++ b/src/components/RouteImportDialog/RouteImportDialog.tsx
@@ -7,7 +7,7 @@ import {
     IObserver,
 } from 'incyclist-services';
 import { RouteImportDialogView } from './RouteImportDialogView';
-import { RouteImportDialogProps } from './types';
+import { RouteImportDialogProps, ExtendedImportDisplayProps } from './types';
 import { useScreenLayout, useLogging, useUnmountEffect } from '../../hooks';
 import { useFilePicker } from '../../hooks/files/useFilePicker';
 import { getUIBinding } from '../../bindings/ui';
@@ -23,8 +23,8 @@ export const RouteImportDialog = ({ onClose }: RouteImportDialogProps) => {
     const { logError,logEvent } = useLogging('RouteImportDialog');
     const { pickFile } = useFilePicker();
 
-    const [displayProps, setDisplayProps] = useState<ImportDisplayProps>(() =>
-        getRoutesPageService().getImportDisplayProps()
+    const [displayProps, setDisplayProps] = useState<ExtendedImportDisplayProps>(() =>
+        getRoutesPageService().getImportDisplayProps() as ExtendedImportDisplayProps
     );
     const [selectedIds, setSelectedIds] = useState<string[]>([]);
     const [isSingleImporting, setIsSingleImporting] = useState(false);
@@ -42,7 +42,7 @@ export const RouteImportDialog = ({ onClose }: RouteImportDialogProps) => {
     const onUpdate = useCallback(() => {
         const updated = getRoutesPageService().getImportDisplayProps();
         if (updated) {
-            setDisplayProps(updated);
+            setDisplayProps(updated as ExtendedImportDisplayProps);
         }
     }, []);
 
@@ -93,6 +93,15 @@ export const RouteImportDialog = ({ onClose }: RouteImportDialogProps) => {
                 obs.off('scan-progress', onScanProgress);
                 obs.off('scan-complete', onScanComplete);
                 refScanObserver.current = null;
+            }
+
+            if (scannedRoutes.length === 0) {
+                setDisplayProps((prev) => ({
+                    ...prev,
+                    phase: 'result',
+                    noRoutesFound: true,
+                }));
+                return;
             }
 
             const parseObserver = getRoutesPageService().startLibraryParse(scannedRoutes);
@@ -324,6 +333,12 @@ export const RouteImportDialog = ({ onClose }: RouteImportDialogProps) => {
             case 'complete':
                 return [{ label: 'Done', onClick: onDone, primary: true }];
             case 'result':
+                if (displayProps.noRoutesFound) {
+                    return [
+                        { label: 'Try Different Folder', onClick: onSelectFolder, primary: true },
+                        { label: 'Cancel', onClick: onCancel },
+                    ];
+                }
                 return displayProps.resultSuccess
                     ? [{ label: 'Done', onClick: onDone, primary: true }]
                     : [
@@ -338,10 +353,12 @@ export const RouteImportDialog = ({ onClose }: RouteImportDialogProps) => {
         isSingleImporting,
         selectedIds.length,
         displayProps.resultSuccess,
+        displayProps.noRoutesFound,
         onCancel,
         onConfirmSelection,
         onDone,
         handleTryAgain,
+        onSelectFolder,
     ]);
 
     logEvent({message:'render RouteImportDialog', displayProps})

--- a/src/components/RouteImportDialog/RouteImportDialog.tsx
+++ b/src/components/RouteImportDialog/RouteImportDialog.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo, useState, useRef, useEffect } from 'react';
 import {
-    ImportDisplayProps,
     getRoutesPageService,
     ParsedRoute,
     ScannedRoute,
@@ -20,7 +19,7 @@ import { ErrorBoundary } from '../ErrorBoundary';
 export const RouteImportDialog = ({ onClose }: RouteImportDialogProps) => {
     const layout = useScreenLayout();
     const isCompact = layout === 'compact';
-    const { logError,logEvent } = useLogging('RouteImportDialog');
+    const { logError, logEvent } = useLogging('RouteImportDialog');
     const { pickFile } = useFilePicker();
 
     const [displayProps, setDisplayProps] = useState<ExtendedImportDisplayProps>(() =>
@@ -185,7 +184,7 @@ export const RouteImportDialog = ({ onClose }: RouteImportDialogProps) => {
 
     const onAddGpx = useCallback(async () => {
         try {
-            const fileInfo = await pickFile({extensions:['gpx','xml']});
+            const fileInfo = await pickFile({ extensions: ['gpx', 'xml'] });
             if (!fileInfo) return;
 
             setIsSingleImporting(true);
@@ -219,7 +218,7 @@ export const RouteImportDialog = ({ onClose }: RouteImportDialogProps) => {
         try {
             const result = await getUIBinding().selectDirectory();
             if (result.canceled || !result.selected) {
-                logEvent({message:'cancelled directory selection', eventSource:'user'})
+                logEvent({ message: 'cancelled directory selection', eventSource: 'user' });
                 return;
             }
 
@@ -282,7 +281,7 @@ export const RouteImportDialog = ({ onClose }: RouteImportDialogProps) => {
         cleanUpObservers();
     });
 
-    const { phase } = displayProps??{};
+    const { phase } = displayProps ?? {};
 
     // Non-dismissable during active processing phases
     const isDismissable = !isSingleImporting && phase !== 'scanning' && phase !== 'parsing' && phase !== 'ingesting';
@@ -361,8 +360,7 @@ export const RouteImportDialog = ({ onClose }: RouteImportDialogProps) => {
         onSelectFolder,
     ]);
 
-    logEvent({message:'render RouteImportDialog', displayProps})
-    
+    logEvent({ message: 'render RouteImportDialog', displayProps });
 
     return (
         <ErrorBoundary>

--- a/src/components/RouteImportDialog/RouteImportDialogView.test.tsx
+++ b/src/components/RouteImportDialog/RouteImportDialogView.test.tsx
@@ -120,6 +120,20 @@ describe('RouteImportDialogView', () => {
         );
     });
 
+    it('renders result phase with noRoutesFound in compact layout without crashing', () => {
+        render(
+            <RouteImportDialogView
+                {...defaultProps}
+                compact={true}
+                displayProps={{
+                    ...defaultProps.displayProps,
+                    phase: 'result',
+                    noRoutesFound: true,
+                }}
+            />
+        );
+    });
+
     it('renders result phase with generic error without crashing', () => {
         render(
             <RouteImportDialogView

--- a/src/components/RouteImportDialog/RouteImportDialogView.test.tsx
+++ b/src/components/RouteImportDialog/RouteImportDialogView.test.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import { RouteImportDialogView } from './RouteImportDialogView';
-import { RouteImportDialogViewProps } from './types';
+import { RouteImportDialogViewProps, ExtendedImportDisplayProps } from './types';
 
 const defaultProps: RouteImportDialogViewProps = {
     compact: false,
     displayProps: {
         phase: 'landing',
         routes: [],
-    },
+    } as ExtendedImportDisplayProps,
     selectedIds: [],
     isSingleImporting: false,
     title: 'Import Routes',
@@ -102,6 +102,32 @@ describe('RouteImportDialogView', () => {
                     ...defaultProps.displayProps,
                     phase: 'result',
                     resultSuccess: { routeName: 'Test Route' },
+                }}
+            />
+        );
+    });
+
+    it('renders result phase with noRoutesFound without crashing', () => {
+        render(
+            <RouteImportDialogView
+                {...defaultProps}
+                displayProps={{
+                    ...defaultProps.displayProps,
+                    phase: 'result',
+                    noRoutesFound: true,
+                }}
+            />
+        );
+    });
+
+    it('renders result phase with generic error without crashing', () => {
+        render(
+            <RouteImportDialogView
+                {...defaultProps}
+                displayProps={{
+                    ...defaultProps.displayProps,
+                    phase: 'result',
+                    error: 'no file found',
                 }}
             />
         );

--- a/src/components/RouteImportDialog/RouteImportDialogView.tsx
+++ b/src/components/RouteImportDialog/RouteImportDialogView.tsx
@@ -38,6 +38,7 @@ export const RouteImportDialogView = ({
         completionSummary,
         resultSuccess,
         error,
+        noRoutesFound,
     } = displayProps;
 
     const renderContent = () => {
@@ -106,6 +107,7 @@ export const RouteImportDialogView = ({
                         success={resultSuccess != null}
                         routeName={resultSuccess?.routeName}
                         error={error}
+                        noRoutesFound={noRoutesFound}
                     />
                 );
 

--- a/src/components/RouteImportDialog/types.ts
+++ b/src/components/RouteImportDialog/types.ts
@@ -5,9 +5,13 @@ export interface RouteImportDialogProps {
     onClose: () => void;
 }
 
+export interface ExtendedImportDisplayProps extends ImportDisplayProps {
+    noRoutesFound?: boolean;
+}
+
 export interface RouteImportDialogViewProps {
     compact: boolean;
-    displayProps: ImportDisplayProps;
+    displayProps: ExtendedImportDisplayProps;
     selectedIds: string[];
     isSingleImporting: boolean;
     title: string;

--- a/src/components/RouteImportDialog/views/ResultView.tsx
+++ b/src/components/RouteImportDialog/views/ResultView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, Platform } from 'react-native';
 import { colors, textSizes } from '../../../theme';
 import { Icon } from '../../Icon';
 
@@ -8,6 +8,7 @@ interface ResultViewProps {
     success: boolean;
     routeName?: string;
     error?: string;
+    noRoutesFound?: boolean;
 }
 
 export const ResultView = ({ 
@@ -15,12 +16,19 @@ export const ResultView = ({
     success, 
     routeName, 
     error, 
+    noRoutesFound,
 }: ResultViewProps) => {
     const statusColor = success ? colors.success : colors.error;
-    const title = success ? 'Import Successful' : 'Import Failed';
+    let title = success ? 'Import Successful' : 'Import Failed';
     
     let message: string;
-    if (success) {
+    if (noRoutesFound) {
+        title = 'No Routes Found';
+        message = 'Please select a directory that contains files in supported formats (EPM, RLV, XML).';
+        if (Platform.OS === 'ios') {
+            message += '\n\nNote: NAS is not yet supported. Please copy files to iCloud Drive or On My iPhone first.';
+        }
+    } else if (success) {
         message = routeName
             ? `Route "${routeName}" has been added.`
             : 'The route has been added to your library.';


### PR DESCRIPTION
Closes #298

This PR implements a dedicated result screen when a library scan returns zero supported files. This provides actionable guidance, especially on iOS where NAS shares currently return empty results.

### Changes:
- Extended `ImportDisplayProps` locally to include `noRoutesFound` flag.
- Updated `RouteImportDialog` to transition to result phase if scan returns empty array.
- Updated `ResultView` to display specific heading and guidance for the no-routes-found state.
- Added iOS-specific guidance for NAS shares.
- Updated action buttons in the no-routes-found state to allow picking a different folder.
- Added test cases for the new result view variants.