### PR TITLE
feat: add SecureImage component for iOS security-scoped access

### DIFF
--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.test.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.test.tsx
@@ -62,6 +62,13 @@ jest.mock('../ActivityGraph', () => ({
     ActivityGraph: 'ActivityGraph',
 }));
 
+jest.mock('../SecureImage', () => ({
+    SecureImage: ({ source, ...props }: any) => {
+        const { Image } = require('react-native');
+        return <Image source={source} {...props} />;
+    },
+}));
+
 const MOCK_ACTIVITY = {
     id: '1',
     title: 'Test Ride',

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet, Image, TouchableOpacity, ScrollView, useWindowDimensions } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView, useWindowDimensions } from 'react-native';
 import { formatTime, useUnitConverter } from 'incyclist-services';
 import { Dialog } from '../Dialog';
 import { FreeMap } from '../FreeMap';
@@ -8,6 +8,7 @@ import { ActivitySummaryDialogViewProps, isFormattedNumber } from './types';
 import { colors, textSizes } from '../../theme';
 import { useScreenLayout } from '../../hooks';
 import { ErrorBoundary } from '../ErrorBoundary';
+import { SecureImage } from '../SecureImage';
 
 const safeNum = (v: any): number | undefined => {
     try {
@@ -216,7 +217,7 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
             {showMap ? (
                 <FreeMap points={mapPoints} style={styles.map} />
             ) : preview ? (
-                <Image source={{ uri: preview }} style={styles.previewImage} resizeMode="cover" />
+                <SecureImage source={{ uri: preview }} style={styles.previewImage} resizeMode="cover" />
             ) : (
                 <View style={styles.emptyPreview} />
             )}

--- a/src/components/RouteDetailsDialog/RouteDetailsView.test.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.test.tsx
@@ -31,6 +31,13 @@ jest.mock('../DownloadModal', () => {
     };
 });
 
+jest.mock('../SecureImage', () => ({
+    SecureImage: ({ source, ...props }: any) => {
+        const { Image } = require('react-native');
+        return <Image source={source} {...props} />;
+    },
+}));
+
 const MOCK_SETTINGS = {
     startPos: { value: 0, unit: 'km' },
     realityFactor: 100,

--- a/src/components/RouteDetailsDialog/RouteDetailsView.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.tsx
@@ -3,7 +3,6 @@ import {
     View,
     Text,
     StyleSheet,
-    Image,
     ActivityIndicator,
     useWindowDimensions,
 } from 'react-native';
@@ -19,6 +18,7 @@ import { EditNumber } from '../EditNumber';
 import { ChipSelect } from '../ChipSelect';
 import { SingleSelect } from '../SingleSelect';
 import { DownloadModalView } from '../DownloadModal';
+import { SecureImage } from '../SecureImage';
 
 const SEGMENT_CHIP_THRESHOLD = 5;
 
@@ -162,7 +162,7 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
     const renderPreview = () => {
         if (loading) return <ActivityIndicator color={colors.text} />;
         if (previewUrl) {
-            return <Image source={{ uri: previewUrl }} style={styles.fullMedia} resizeMode="cover" />;
+            return <SecureImage source={{ uri: previewUrl }} style={styles.fullMedia} resizeMode="cover" />;
         }
         return <Text style={styles.placeholderText}>No preview available</Text>;
     };

--- a/src/components/RouteItem/RouteItemView.tsx
+++ b/src/components/RouteItem/RouteItemView.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { View, Text, StyleSheet, Image, TouchableOpacity, ActivityIndicator, Platform } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Platform } from 'react-native';
 import { RouteItemViewProps } from './types';
 import { colors } from '../../theme';
 import { getFlagEmoji } from '../../utils/flags';
 import { FreeMap } from '../FreeMap';
 import { ElevationGraph } from '../ElevationGraph';
 import { Icon } from '../Icon';
+import { SecureImage } from '../SecureImage';
 
 // Conditional import to prevent Storybook Vite from crashing
 let Swipeable: any = View;
@@ -45,7 +46,7 @@ export const RouteItemView = (props: RouteItemViewProps) => {
     const renderMedia = () => {
 
         if (hasVideo && previewUrl) {
-            return <Image source={{ uri: previewUrl }} style={styles.media} resizeMode="cover" />;
+            return <SecureImage source={{ uri: previewUrl }} style={styles.media} resizeMode="cover" />;
         }
 
         if (points && points.length > 0) {

--- a/src/components/SecureImage/SecureImage.test.tsx
+++ b/src/components/SecureImage/SecureImage.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import { Platform } from 'react-native';
 import { render, act } from '@testing-library/react-native';
 import { SecureImage } from './SecureImage';
 import { getFileSystemBinding } from '../../bindings/fs';
 
-jest.mock('react-native/Libraries/Utilities/Platform', () => ({
-    OS: 'ios',
-    select: jest.fn(),
+jest.mock('react-native', () => ({
+    ...jest.requireActual('react-native'),
+    Platform: { OS: 'ios', select: jest.fn((spec: any) => spec.ios) },
 }));
 
 jest.mock('../../bindings/fs', () => ({
@@ -22,6 +23,9 @@ describe('SecureImage', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        jest.replaceProperty(Platform, 'OS', 'ios');
+        (Platform.select as jest.Mock).mockImplementation((spec: any) => spec.ios);
+
         mockFS = {
             requestAccess: jest.fn().mockResolvedValue(true),
             releaseAccess: jest.fn().mockResolvedValue(true),
@@ -79,5 +83,14 @@ describe('SecureImage', () => {
 
         unmount();
         expect(mockFS.releaseAccess).not.toHaveBeenCalled();
+    });
+
+    it('renders Image directly on Android (no gate)', () => {
+        jest.replaceProperty(Platform, 'OS', 'android');
+        (Platform.select as jest.Mock).mockImplementation((spec: any) => spec.android);
+        
+        const { toJSON } = render(<SecureImage source={MOCK_FILE_SOURCE} />);
+        expect(toJSON()).not.toBeNull();
+        expect(mockFS.requestAccess).not.toHaveBeenCalled();
     });
 });

--- a/src/components/SecureImage/SecureImage.test.tsx
+++ b/src/components/SecureImage/SecureImage.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+import { SecureImage } from './SecureImage';
+import { getFileSystemBinding } from '../../bindings/fs';
+
+jest.mock('react-native/Libraries/Utilities/Platform', () => ({
+    OS: 'ios',
+    select: jest.fn(),
+}));
+
+jest.mock('../../bindings/fs', () => ({
+    getFileSystemBinding: jest.fn(),
+}));
+
+// Mock constants
+const MOCK_HTTPS_SOURCE = { uri: 'https://example.com/preview.jpg' };
+const MOCK_FILE_SOURCE = { uri: 'file:///private/var/mobile/Containers/Shared/AppGroup/test/preview.png' };
+const MOCK_BUNDLED = 123;
+
+describe('SecureImage', () => {
+    let mockFS: any;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockFS = {
+            requestAccess: jest.fn().mockResolvedValue(true),
+            releaseAccess: jest.fn().mockResolvedValue(true),
+        };
+        (getFileSystemBinding as jest.Mock).mockReturnValue(mockFS);
+    });
+
+    it('renders with https source (no gate)', () => {
+        const { toJSON } = render(<SecureImage source={MOCK_HTTPS_SOURCE} />);
+        expect(toJSON()).not.toBeNull();
+        expect(mockFS.requestAccess).not.toHaveBeenCalled();
+    });
+
+    it('renders with bundled asset (no gate)', () => {
+        const { toJSON } = render(<SecureImage source={MOCK_BUNDLED} />);
+        expect(toJSON()).not.toBeNull();
+        expect(mockFS.requestAccess).not.toHaveBeenCalled();
+    });
+
+    it('renders null before access on iOS file:// source', async () => {
+        let resolveAccess: (v: boolean) => void = () => {};
+        const accessPromise = new Promise<boolean>((resolve) => {
+            resolveAccess = resolve;
+        });
+        mockFS.requestAccess.mockReturnValue(accessPromise);
+
+        const { toJSON } = render(<SecureImage source={MOCK_FILE_SOURCE} />);
+        
+        // Should be null initially
+        expect(toJSON()).toBeNull();
+        expect(mockFS.requestAccess).toHaveBeenCalledWith(MOCK_FILE_SOURCE.uri);
+
+        await act(async () => {
+            resolveAccess(true);
+        });
+
+        // Now it should render
+        expect(toJSON()).not.toBeNull();
+    });
+
+    it('calls releaseAccess on unmount only when grant was acquired', async () => {
+        const { unmount } = render(<SecureImage source={MOCK_FILE_SOURCE} />);
+        
+        await act(async () => {}); // flush promise
+
+        unmount();
+        expect(mockFS.releaseAccess).toHaveBeenCalledWith(MOCK_FILE_SOURCE.uri);
+    });
+
+    it('does not call releaseAccess if grant was not acquired', async () => {
+        mockFS.requestAccess.mockResolvedValue(false);
+        const { unmount } = render(<SecureImage source={MOCK_FILE_SOURCE} />);
+        
+        await act(async () => {});
+
+        unmount();
+        expect(mockFS.releaseAccess).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/SecureImage/SecureImage.test.tsx
+++ b/src/components/SecureImage/SecureImage.test.tsx
@@ -4,11 +4,6 @@ import { render, act } from '@testing-library/react-native';
 import { SecureImage } from './SecureImage';
 import { getFileSystemBinding } from '../../bindings/fs';
 
-jest.mock('react-native', () => ({
-    ...jest.requireActual('react-native'),
-    Platform: { OS: 'ios', select: jest.fn((spec: any) => spec.ios) },
-}));
-
 jest.mock('../../bindings/fs', () => ({
     getFileSystemBinding: jest.fn(),
 }));

--- a/src/components/SecureImage/SecureImage.test.tsx
+++ b/src/components/SecureImage/SecureImage.test.tsx
@@ -8,7 +8,6 @@ jest.mock('../../bindings/fs', () => ({
     getFileSystemBinding: jest.fn(),
 }));
 
-// Mock constants
 const MOCK_HTTPS_SOURCE = { uri: 'https://example.com/preview.jpg' };
 const MOCK_FILE_SOURCE = { uri: 'file:///private/var/mobile/Containers/Shared/AppGroup/test/preview.png' };
 const MOCK_BUNDLED = 123;
@@ -19,8 +18,6 @@ describe('SecureImage', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         jest.replaceProperty(Platform, 'OS', 'ios');
-        (Platform.select as jest.Mock).mockImplementation((spec: any) => spec.ios);
-
         mockFS = {
             requestAccess: jest.fn().mockResolvedValue(true),
             releaseAccess: jest.fn().mockResolvedValue(true),
@@ -48,8 +45,7 @@ describe('SecureImage', () => {
         mockFS.requestAccess.mockReturnValue(accessPromise);
 
         const { toJSON } = render(<SecureImage source={MOCK_FILE_SOURCE} />);
-        
-        // Should be null initially
+
         expect(toJSON()).toBeNull();
         expect(mockFS.requestAccess).toHaveBeenCalledWith(MOCK_FILE_SOURCE.uri);
 
@@ -57,14 +53,13 @@ describe('SecureImage', () => {
             resolveAccess(true);
         });
 
-        // Now it should render
         expect(toJSON()).not.toBeNull();
     });
 
     it('calls releaseAccess on unmount only when grant was acquired', async () => {
         const { unmount } = render(<SecureImage source={MOCK_FILE_SOURCE} />);
-        
-        await act(async () => {}); // flush promise
+
+        await act(async () => {});
 
         unmount();
         expect(mockFS.releaseAccess).toHaveBeenCalledWith(MOCK_FILE_SOURCE.uri);
@@ -73,7 +68,7 @@ describe('SecureImage', () => {
     it('does not call releaseAccess if grant was not acquired', async () => {
         mockFS.requestAccess.mockResolvedValue(false);
         const { unmount } = render(<SecureImage source={MOCK_FILE_SOURCE} />);
-        
+
         await act(async () => {});
 
         unmount();
@@ -82,8 +77,7 @@ describe('SecureImage', () => {
 
     it('renders Image directly on Android (no gate)', () => {
         jest.replaceProperty(Platform, 'OS', 'android');
-        (Platform.select as jest.Mock).mockImplementation((spec: any) => spec.android);
-        
+
         const { toJSON } = render(<SecureImage source={MOCK_FILE_SOURCE} />);
         expect(toJSON()).not.toBeNull();
         expect(mockFS.requestAccess).not.toHaveBeenCalled();

--- a/src/components/SecureImage/SecureImage.tsx
+++ b/src/components/SecureImage/SecureImage.tsx
@@ -1,0 +1,60 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Image, Platform, ImageProps } from 'react-native';
+import { getFileSystemBinding } from '../../bindings/fs';
+import { useUnmountEffect } from '../../hooks';
+
+export type SecureImageProps = ImageProps;
+
+/**
+ * SecureImage is a drop-in replacement for React Native's <Image> that handles
+ * iOS security-scoped access for file:// URIs.
+ *
+ * On iOS, when source.uri starts with 'file://', it requests access via the
+ * FileSystem binding before rendering the image, and releases access on unmount.
+ * On all other platforms or for non-file URIs, it renders the standard Image component.
+ */
+export const SecureImage = (props: SecureImageProps) => {
+    const { source } = props;
+
+    const uri = typeof source === 'object' && !Array.isArray(source)
+        ? (source as { uri?: string }).uri
+        : undefined;
+
+    const needsGate = Platform.OS === 'ios'
+        && typeof uri === 'string'
+        && uri.startsWith('file://');
+
+    const [hasAccess, setHasAccess] = useState(!needsGate);
+    const refHasGrant = useRef(false);
+    const refInitialized = useRef(false);
+
+    useEffect(() => {
+        if (refInitialized.current) {
+            return;
+        }
+        refInitialized.current = true;
+
+        if (needsGate && !hasAccess && typeof uri === 'string') {
+            getFileSystemBinding().requestAccess(uri)
+                .then((isGranted) => {
+                    if (isGranted) {
+                        setHasAccess(true);
+                        refHasGrant.current = true;
+                    }
+                });
+        }
+    }, [needsGate, hasAccess, uri]);
+
+    useUnmountEffect(() => {
+        if (refHasGrant.current && typeof uri === 'string') {
+            getFileSystemBinding().releaseAccess(uri);
+            refHasGrant.current = false;
+        }
+    });
+
+    if (!hasAccess) {
+        return null;
+    }
+
+    return <Image {...props} />;
+};

--- a/src/components/SecureImage/index.ts
+++ b/src/components/SecureImage/index.ts
@@ -1,0 +1,1 @@
+export * from './SecureImage';


### PR DESCRIPTION
Closes #300

This PR introduces the `SecureImage` component, which acts as a drop-in replacement for React Native's `<Image>`. It automatically handles iOS security-scoped access for `file://` URIs returned by the document picker, following the same pattern established in `Video.tsx`.

### Changes:
- Created `SecureImage` component with access gate logic for iOS file URIs.
- Implemented tests for `SecureImage` covering various source types and platform behaviors.
- Replaced `<Image>` with `<SecureImage>` in `ActivitySummaryDialogView`, `RouteDetailsView`, and `RouteItemView` for preview displays.