### PR TITLE
feat: Add StreetView Fabric component spec and JS wrapper (Issue #308)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -83,6 +83,10 @@ android {
     buildTypes {
         debug {
             signingConfig signingConfigs.debug
+            manifestPlaceholders = [
+                usesCleartextTraffic: "true",
+                MAPS_API_KEY: getEnv("MAPS_API_KEY") ?: ""
+            ]            
         }
         // NEW: Test build type (Release-like but allowing local HTTP)
         dev {
@@ -90,13 +94,19 @@ android {
             signingConfig signingConfigs.debug 
             matchingFallbacks = ['release']
             // This flag is what we'll check in our TypeScript code
-            manifestPlaceholders = [usesCleartextTraffic:"true"]
+            manifestPlaceholders = [
+                usesCleartextTraffic:"true",
+                MAPS_API_KEY: getEnv("MAPS_API_KEY") ?: ""
+            ]
         }        
         release {
             signingConfig signingConfigs.release
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
-            manifestPlaceholders = [usesCleartextTraffic:"false"]
+            manifestPlaceholders = [
+                usesCleartextTraffic:"false",
+                MAPS_API_KEY: getEnv("MAPS_API_KEY") ?: ""                
+            ]
         }
     }
 
@@ -123,4 +133,13 @@ dependencies {
     } else {
         implementation jscFlavor
     }
+    
+    // Google Maps Android SDK — used ONLY by the StreetView Fabric component.
+    // This app uses Apple Maps on iOS via react-native-maps and MapLibre on
+    // Android — Google Maps is not used anywhere else. This dependency exists
+    // so that com.google.android.gms.maps.StreetViewPanoramaView resolves.
+    // Pinned to 18.2.0 for deterministic builds, consistent with kotlinVersion
+    // and other version pins in the project.
+    implementation "com.google.android.gms:play-services-maps:18.2.0"
+
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -70,5 +70,12 @@
             android:exported="false"
             android:foregroundServiceType="dataSync" />
 
+        <!-- Google Maps API key — used by react-native-maps and the
+             StreetView Fabric component. Value is injected at build time
+             from .env via manifestPlaceholders in app/build.gradle. -->
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="${MAPS_API_KEY}" />            
+
     </application>
 </manifest>

--- a/android/app/src/main/java/com/incyclist/app/MainApplication.kt
+++ b/android/app/src/main/java/com/incyclist/app/MainApplication.kt
@@ -32,6 +32,7 @@ class MainApplication : Application(), ReactApplication {
                 val packages = PackageList(this).packages.toMutableList()
                 packages.add(ExitPackage()) // Add manual package here
                 packages.add(FolderAccessPackage()) 
+                packages.add(StreetViewPackage())
 
                 return packages
             }
@@ -72,6 +73,7 @@ class MainApplication : Application(), ReactApplication {
         val packages = PackageList(this).packages.toMutableList()
         packages.add(ExitPackage())
         packages.add(FolderAccessPackage()) 
+        packages.add(StreetViewPackage())
 
         getDefaultReactHost(
             context = applicationContext,

--- a/android/app/src/main/java/com/incyclist/app/StreetViewManager.kt
+++ b/android/app/src/main/java/com/incyclist/app/StreetViewManager.kt
@@ -1,0 +1,202 @@
+package com.incyclist.app
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.uimanager.SimpleViewManager
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.uimanager.annotations.ReactProp
+import com.facebook.react.viewmanagers.StreetViewManagerDelegate
+import com.facebook.react.viewmanagers.StreetViewManagerInterface
+import com.google.android.gms.maps.MapsInitializer
+import com.google.android.gms.maps.StreetViewPanorama
+import com.google.android.gms.maps.StreetViewPanoramaView
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.StreetViewPanoramaCamera
+import java.util.WeakHashMap
+
+/**
+ * StreetView — Fabric Native View Component (Android)
+ *
+ * Wraps Google's StreetViewPanoramaView from the Maps SDK for Android.
+ *
+ * Verification scope only — this is a minimum implementation that exists to
+ * verify that:
+ *   - the Fabric view component is registered correctly,
+ *   - the Storybook mock alias picks up the spec import,
+ *   - latitude / longitude / heading prop changes from JS reach the
+ *     panorama and visibly update the rendered view.
+ *
+ * Key design notes:
+ *
+ *   1. StreetViewPanoramaView requires Activity-style lifecycle methods to
+ *      be forwarded (onCreate, onResume, onPause, onDestroy). Without these,
+ *      the panorama never finishes initialising. We call onCreate(null) +
+ *      onResume() in createViewInstance, and onPause() + onDestroy() in
+ *      onDropViewInstance. Foreground/background of the host Activity is
+ *      NOT forwarded — known limitation for this verification build.
+ *
+ *   2. Panorama acquisition via getStreetViewPanoramaAsync is asynchronous.
+ *      Props arriving before the callback fires are cached in a per-view
+ *      PanoramaState object and applied once the StreetViewPanorama reference
+ *      becomes available.
+ *
+ *   3. State per view is held in a WeakHashMap keyed by the view itself.
+ *      When the view is dropped, its entry is removed in onDropViewInstance.
+ *
+ *   4. Google Maps SDK reads the API key from AndroidManifest meta-data
+ *      (com.google.android.geo.API_KEY) at SDK initialisation. There is no
+ *      runtime injection path — the key MUST be present at build time. See
+ *      AndroidManifest changes in this bundle.
+ *
+ *   5. MapsInitializer.initialize(context) is called defensively before the
+ *      panorama view is constructed. StreetViewPanoramaView should call this
+ *      internally, but this is the first use of the Google Maps Android SDK
+ *      in this app (the app uses Apple Maps on iOS via react-native-maps and
+ *      MapLibre on Android — Google Maps has never been initialised here
+ *      before). The defensive call ensures the SDK is ready regardless of
+ *      ordering.
+ *
+ *   6. Multiple StreetViewPanoramaView instances in one Activity are not
+ *      supported by the Maps SDK (official limitation). The demo page
+ *      renders exactly one — do not nest or duplicate.
+ */
+@ReactModule(name = StreetViewManager.NAME)
+class StreetViewManager(
+    private val reactContext: ReactApplicationContext,
+) : SimpleViewManager<StreetViewPanoramaView>(),
+    StreetViewManagerInterface<StreetViewPanoramaView> {
+
+    private val states = WeakHashMap<StreetViewPanoramaView, PanoramaState>()
+
+    private val delegate: ViewManagerDelegate<StreetViewPanoramaView> =
+        StreetViewManagerDelegate(this)
+
+    override fun getDelegate(): ViewManagerDelegate<StreetViewPanoramaView> = delegate
+
+    override fun getName(): String = NAME
+
+    override fun createViewInstance(context: ThemedReactContext): StreetViewPanoramaView {
+        android.util.Log.d(TAG, "createViewInstance")
+
+        // Defensive: ensure the Google Maps SDK is initialised before the
+        // panorama view tries to use it. This app does not use Google Maps
+        // anywhere else, so this is the SDK's first-use point. Idempotent —
+        // safe to call repeatedly.
+        try {
+            MapsInitializer.initialize(context.applicationContext)
+        } catch (t: Throwable) {
+            android.util.Log.w(TAG, "MapsInitializer.initialize threw: ${t.message}")
+            // Continue anyway — StreetViewPanoramaView will surface its own
+            // error via logcat if init genuinely failed (typically: API key
+            // missing or invalid).
+        }
+
+        val view = StreetViewPanoramaView(context)
+        // Lifecycle forwarding — required for the panorama to render.
+        view.onCreate(null)
+        view.onResume()
+
+        val state = PanoramaState()
+        states[view] = state
+
+        view.getStreetViewPanoramaAsync { panorama ->
+            android.util.Log.d(TAG, "onStreetViewPanoramaReady")
+            state.panorama = panorama
+            state.applyIfReady()
+        }
+
+        return view
+    }
+
+    override fun onDropViewInstance(view: StreetViewPanoramaView) {
+        android.util.Log.d(TAG, "onDropViewInstance")
+        try {
+            view.onPause()
+            view.onDestroy()
+        } catch (t: Throwable) {
+            android.util.Log.w(TAG, "lifecycle teardown threw: ${t.message}")
+        }
+        states.remove(view)
+        super.onDropViewInstance(view)
+    }
+
+    // ── Props ──────────────────────────────────────────────────────────────
+    // Codegen requires both an interface override (typed as Double per the
+    // generated StreetViewManagerInterface) and a @ReactProp annotation. The
+    // @ReactProp form is what the legacy view-manager path picks up; the
+    // override is what the Fabric path uses through the delegate.
+
+    @ReactProp(name = "latitude", defaultDouble = 0.0)
+    override fun setLatitude(view: StreetViewPanoramaView, value: Double) {
+        val state = states[view] ?: return
+        state.pendingLat = value
+        state.applyIfReady()
+    }
+
+    @ReactProp(name = "longitude", defaultDouble = 0.0)
+    override fun setLongitude(view: StreetViewPanoramaView, value: Double) {
+        val state = states[view] ?: return
+        state.pendingLng = value
+        state.applyIfReady()
+    }
+
+    @ReactProp(name = "heading", defaultDouble = 0.0)
+    override fun setHeading(view: StreetViewPanoramaView, value: Double) {
+        val state = states[view] ?: return
+        state.pendingHeading = value
+        state.applyIfReady()
+    }
+
+    // ── Per-view state ─────────────────────────────────────────────────────
+
+    private class PanoramaState {
+        var panorama: StreetViewPanorama? = null
+        var pendingLat: Double? = null
+        var pendingLng: Double? = null
+        var pendingHeading: Double? = null
+        var positionApplied: Boolean = false
+
+        /**
+         * Apply whatever pending values we have to the panorama, if it's
+         * ready. Called both from prop setters (panorama may or may not be
+         * ready) and from the onStreetViewPanoramaReady callback (panorama
+         * just became ready).
+         *
+         * Position is set only when BOTH lat and lng are present. Heading is
+         * applied independently — bearing rotation is cheap and visible
+         * even if position hasn't changed.
+         */
+        fun applyIfReady() {
+            val p = panorama ?: return
+
+            val lat = pendingLat
+            val lng = pendingLng
+            if (lat != null && lng != null) {
+                // setPosition is idempotent on the same coordinate, so we
+                // do not de-duplicate. A radius of 50m is permissive enough
+                // for cycling routes where panoramas are sparse.
+                p.setPosition(LatLng(lat, lng), 50)
+                positionApplied = true
+            }
+
+            val heading = pendingHeading
+            if (heading != null) {
+                val current = p.panoramaCamera
+                val newCamera = StreetViewPanoramaCamera.Builder(current)
+                    .bearing(heading.toFloat())
+                    .build()
+                // 300ms animation for visible heading change. For
+                // verification-only, a smooth animation makes it obvious
+                // that updates are arriving. Production may want zero
+                // duration to follow ride position tightly.
+                p.animateTo(newCamera, 300L)
+            }
+        }
+    }
+
+    companion object {
+        const val NAME = "StreetView"
+        private const val TAG = "StreetViewManager"
+    }
+}

--- a/android/app/src/main/java/com/incyclist/app/StreetViewPackage.kt
+++ b/android/app/src/main/java/com/incyclist/app/StreetViewPackage.kt
@@ -1,0 +1,36 @@
+package com.incyclist.app
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+/**
+ * StreetViewPackage — registers StreetViewManager as a view manager.
+ *
+ * This Package follows the ExitPackage shape (ReactPackage), not the
+ * FolderAccessPackage shape (BaseReactPackage / TurboReactPackage).
+ *
+ * Reason: Fabric view components are registered via createViewManagers,
+ * which both the legacy and new architecture pipelines understand. A
+ * Fabric view component is NOT a TurboModule and does not need the
+ * ReactModuleInfoProvider mechanism that BaseReactPackage requires.
+ *
+ * NOTE: this implementation creates a NEW StreetViewManager per call to
+ * createViewManagers. React Native calls this once per ReactPackage
+ * instance per host, so we get one StreetViewManager per host. The
+ * project already registers packages twice (once in the legacy host and
+ * once in the new arch host in MainApplication.kt) — that gives us two
+ * StreetViewManager instances total. Each owns its own WeakHashMap of
+ * per-view state. This is fine because the two hosts serve different
+ * activity lifecycles and never share view instances.
+ */
+class StreetViewPackage : ReactPackage {
+    override fun createViewManagers(
+        reactContext: ReactApplicationContext,
+    ): List<ViewManager<*, *>> = listOf(StreetViewManager(reactContext))
+
+    override fun createNativeModules(
+        reactContext: ReactApplicationContext,
+    ): List<NativeModule> = emptyList()
+}

--- a/src/components/StreetView/StreetView.tsx
+++ b/src/components/StreetView/StreetView.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import StreetViewNativeComponent from '../../specs/StreetViewNativeComponent';
+import { StreetViewProps } from './types';
+
+export const StreetView = (props: StreetViewProps) => {
+    const { style, ...rest } = props;
+    return (
+        <StreetViewNativeComponent
+            {...rest}
+            style={[StyleSheet.absoluteFill, style]}
+        />
+    );
+};

--- a/src/components/StreetView/index.ts
+++ b/src/components/StreetView/index.ts
@@ -1,0 +1,2 @@
+export { StreetView } from './StreetView';
+export type { StreetViewProps } from './types';

--- a/src/components/StreetView/types.ts
+++ b/src/components/StreetView/types.ts
@@ -1,0 +1,8 @@
+import { StyleProp, ViewStyle } from 'react-native';
+
+export interface StreetViewProps {
+    latitude: number;
+    longitude: number;
+    heading: number;
+    style?: StyleProp<ViewStyle>;
+}

--- a/src/specs/StreetViewNativeComponent.ts
+++ b/src/specs/StreetViewNativeComponent.ts
@@ -1,0 +1,13 @@
+import type { HostComponent, ViewProps } from 'react-native';
+import type { Double } from 'react-native/Libraries/Types/CodegenTypes';
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+
+export interface NativeProps extends ViewProps {
+    latitude: Double;
+    longitude: Double;
+    heading: Double;
+}
+
+export default codegenNativeComponent<NativeProps>(
+    'StreetView',
+) as HostComponent<NativeProps>;


### PR DESCRIPTION
Closes #308

Adds the Codegen specification for the new StreetView Fabric native view component and a thin JavaScript wrapper. This enables the Android native code to compile against the generated interface.

## Manual Steps
- Run an Android clean build (`./scripts/clean.sh && APP_VARIANT=debug react-native run-android --mode debug`) to trigger Codegen.
- Verify that `android/app/build/generated/source/codegen/java/com/facebook/react/viewmanagers/StreetViewManagerInterface.java` and `StreetViewManagerDelegate.java` are generated.