### PR TITLE
Add StreetView demo page

### DIFF
--- a/android/app/src/main/java/com/incyclist/app/StreetViewManager.kt
+++ b/android/app/src/main/java/com/incyclist/app/StreetViewManager.kt
@@ -1,11 +1,18 @@
 package com.incyclist.app
 
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.annotations.ReactProp
+import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.uimanager.events.Event
+import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.viewmanagers.StreetViewManagerDelegate
 import com.facebook.react.viewmanagers.StreetViewManagerInterface
 import com.google.android.gms.maps.MapsInitializer
@@ -16,50 +23,71 @@ import com.google.android.gms.maps.model.StreetViewPanoramaCamera
 import java.util.WeakHashMap
 
 /**
- * StreetView — Fabric Native View Component (Android)
+ * StreetViewManager — Fabric Native View Component (Android)
  *
  * Wraps Google's StreetViewPanoramaView from the Maps SDK for Android.
  *
- * Verification scope only — this is a minimum implementation that exists to
- * verify that:
- *   - the Fabric view component is registered correctly,
- *   - the Storybook mock alias picks up the spec import,
- *   - latitude / longitude / heading prop changes from JS reach the
- *     panorama and visibly update the rendered view.
+ * ── Event contract ────────────────────────────────────────────────────────
  *
- * Key design notes:
+ * onLicenseConsumed   Fires once per component lifetime on the first
+ *                     OnStreetViewPanoramaChangeListener callback. This is
+ *                     the moment Google charges a Dynamic Street View SKU
+ *                     event. Never fires again after the first time.
  *
- *   1. StreetViewPanoramaView requires Activity-style lifecycle methods to
- *      be forwarded (onCreate, onResume, onPause, onDestroy). Without these,
- *      the panorama never finishes initialising. We call onCreate(null) +
- *      onResume() in createViewInstance, and onPause() + onDestroy() in
- *      onDropViewInstance. Foreground/background of the host Activity is
- *      NOT forwarded — known limitation for this verification build.
+ * onLoaded            Fires once per component lifetime immediately after
+ *                     onLicenseConsumed. Signals that the component has
+ *                     settled on its first rendered state (panorama visible
+ *                     or black screen if no imagery). Start overlay dismissal
+ *                     should wait for this event.
  *
- *   2. Panorama acquisition via getStreetViewPanoramaAsync is asynchronous.
- *      Props arriving before the callback fires are cached in a per-view
- *      PanoramaState object and applied once the StreetViewPanorama reference
- *      becomes available.
+ * onNoPanorama        Fires when OnStreetViewPanoramaChangeListener returns
+ *                     a null location — no Street View imagery at the
+ *                     requested position. Fires on initial load AND on
+ *                     subsequent position updates. The service layer decides
+ *                     UX (popup, pill, fallback to MapView). When onNoPanorama
+ *                     fires, the previous image remains visible; if this is
+ *                     the initial position, a black screen is shown.
  *
- *   3. State per view is held in a WeakHashMap keyed by the view itself.
- *      When the view is dropped, its entry is removed in onDropViewInstance.
+ * onPanoramaChanged   Fires when OnStreetViewPanoramaChangeListener returns
+ *                     a non-null location for a position update AFTER the
+ *                     initial onLoaded has fired. Used by the service to
+ *                     measure update round-trip time and throttle update rate.
+ *                     Does NOT fire on the initial load.
  *
- *   4. Google Maps SDK reads the API key from AndroidManifest meta-data
- *      (com.google.android.geo.API_KEY) at SDK initialisation. There is no
- *      runtime injection path — the key MUST be present at build time. See
- *      AndroidManifest changes in this bundle.
+ * onError             Fires when a timeout expires:
+ *                     - reason='unknown':     getStreetViewPanoramaAsync did
+ *                       not fire within readyTimeout ms. Likely: Google Play
+ *                       Services not installed or SDK init failure.
+ *                     - reason='unavailable': OnStreetViewPanoramaChangeListener
+ *                       did not fire within positionTimeout ms after setPosition.
+ *                       Likely: invalid API key or network failure.
+ *                     Fires throughout the component lifetime — the service
+ *                     layer decides whether to act on single vs recurring errors.
  *
- *   5. MapsInitializer.initialize(context) is called defensively before the
- *      panorama view is constructed. StreetViewPanoramaView should call this
- *      internally, but this is the first use of the Google Maps Android SDK
- *      in this app (the app uses Apple Maps on iOS via react-native-maps and
- *      MapLibre on Android — Google Maps has never been initialised here
- *      before). The defensive call ensures the SDK is ready regardless of
- *      ordering.
+ * ── Timeout props ────────────────────────────────────────────────────────
  *
- *   6. Multiple StreetViewPanoramaView instances in one Activity are not
- *      supported by the Maps SDK (official limitation). The demo page
- *      renders exactly one — do not nest or duplicate.
+ * readyTimeout        ms to wait for getStreetViewPanoramaAsync. Default 10000.
+ *                     Cancelled when panorama ready callback fires.
+ *                     Fires onError('unknown') on expiry.
+ *
+ * positionTimeout     ms to wait for OnStreetViewPanoramaChangeListener after
+ *                     setPosition. Default 2000. Cancelled the moment the
+ *                     change listener fires (null or non-null).
+ *                     Fires onError('unavailable') on expiry.
+ *                     Should be set below the position update interval.
+ *
+ * ── Teardown / black screen workaround ───────────────────────────────────
+ *
+ * If StreetViewPanoramaView occupies 100% of the Activity surface,
+ * onDestroy() corrupts the window compositor, leaving a black region on the
+ * next visible screen. The JS wrapper applies margin:1 by default so the
+ * view never owns the full surface. Do not remove this margin.
+ *
+ * ── Single-instance constraint ───────────────────────────────────────────
+ *
+ * The Maps SDK for Android does not support multiple StreetViewPanoramaView
+ * instances in one Activity. The demo page (and later GPXTourPage) must
+ * render exactly one StreetView at a time.
  */
 @ReactModule(name = StreetViewManager.NAME)
 class StreetViewManager(
@@ -68,41 +96,55 @@ class StreetViewManager(
     StreetViewManagerInterface<StreetViewPanoramaView> {
 
     private val states = WeakHashMap<StreetViewPanoramaView, PanoramaState>()
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     private val delegate: ViewManagerDelegate<StreetViewPanoramaView> =
         StreetViewManagerDelegate(this)
 
     override fun getDelegate(): ViewManagerDelegate<StreetViewPanoramaView> = delegate
-
     override fun getName(): String = NAME
 
     override fun createViewInstance(context: ThemedReactContext): StreetViewPanoramaView {
         android.util.Log.d(TAG, "createViewInstance")
 
-        // Defensive: ensure the Google Maps SDK is initialised before the
-        // panorama view tries to use it. This app does not use Google Maps
-        // anywhere else, so this is the SDK's first-use point. Idempotent —
-        // safe to call repeatedly.
         try {
             MapsInitializer.initialize(context.applicationContext)
         } catch (t: Throwable) {
             android.util.Log.w(TAG, "MapsInitializer.initialize threw: ${t.message}")
-            // Continue anyway — StreetViewPanoramaView will surface its own
-            // error via logcat if init genuinely failed (typically: API key
-            // missing or invalid).
         }
 
         val view = StreetViewPanoramaView(context)
-        // Lifecycle forwarding — required for the panorama to render.
+        view.visibility = View.INVISIBLE // black-screen workaround companion
         view.onCreate(null)
         view.onResume()
 
         val state = PanoramaState()
         states[view] = state
 
+        // Arm the ready timeout. Cancelled when getStreetViewPanoramaAsync fires.
+        val readyTimeoutRunnable = Runnable {
+            android.util.Log.d(TAG, "ready timeout expired")
+            emitError(view, "unknown")
+        }
+        state.readyTimeoutRunnable = readyTimeoutRunnable
+        mainHandler.postDelayed(readyTimeoutRunnable, state.readyTimeoutMs)
+
         view.getStreetViewPanoramaAsync { panorama ->
             android.util.Log.d(TAG, "onStreetViewPanoramaReady")
+
+            // Cancel ready timeout — SDK is functional.
+            state.readyTimeoutRunnable?.let { mainHandler.removeCallbacks(it) }
+            state.readyTimeoutRunnable = null
+
             state.panorama = panorama
+
+            // Listen for panorama location changes. This is the primary signal
+            // for all position-related events.
+            panorama.setOnStreetViewPanoramaChangeListener { location ->
+                handlePanoramaChange(view, state, location)
+            }
+
+            view.visibility = View.VISIBLE
             state.applyIfReady()
         }
 
@@ -111,7 +153,14 @@ class StreetViewManager(
 
     override fun onDropViewInstance(view: StreetViewPanoramaView) {
         android.util.Log.d(TAG, "onDropViewInstance")
+        val state = states[view]
+        if (state != null) {
+            // Cancel any pending timeouts to avoid firing events after teardown.
+            state.readyTimeoutRunnable?.let { mainHandler.removeCallbacks(it) }
+            state.positionTimeoutRunnable?.let { mainHandler.removeCallbacks(it) }
+        }
         try {
+            view.visibility = View.INVISIBLE
             view.onPause()
             view.onDestroy()
         } catch (t: Throwable) {
@@ -121,11 +170,40 @@ class StreetViewManager(
         super.onDropViewInstance(view)
     }
 
-    // ── Props ──────────────────────────────────────────────────────────────
-    // Codegen requires both an interface override (typed as Double per the
-    // generated StreetViewManagerInterface) and a @ReactProp annotation. The
-    // @ReactProp form is what the legacy view-manager path picks up; the
-    // override is what the Fabric path uses through the delegate.
+    // ── Panorama change handler ────────────────────────────────────────────
+
+    private fun handlePanoramaChange(
+        view: StreetViewPanoramaView,
+        state: PanoramaState,
+        location: com.google.android.gms.maps.model.StreetViewPanoramaLocation?,
+    ) {
+        // Cancel the position timeout — the SDK acknowledged the position
+        // request, regardless of whether imagery was found.
+        state.positionTimeoutRunnable?.let { mainHandler.removeCallbacks(it) }
+        state.positionTimeoutRunnable = null
+
+        val hasImagery = location != null
+
+        if (!state.licenseConsumed) {
+            // First change event ever — emit license + loaded, then conditionally
+            // noPanorama. onPanoramaChanged does NOT fire on initial load.
+            state.licenseConsumed = true
+            emitEvent(view, EVENT_LICENSE_CONSUMED, null)
+            emitEvent(view, EVENT_LOADED, null)
+            if (!hasImagery) {
+                emitEvent(view, EVENT_NO_PANORAMA, null)
+            }
+        } else {
+            // Subsequent position updates.
+            if (hasImagery) {
+                emitEvent(view, EVENT_PANORAMA_CHANGED, null)
+            } else {
+                emitEvent(view, EVENT_NO_PANORAMA, null)
+            }
+        }
+    }
+
+    // ── Props ─────────────────────────────────────────────────────────────
 
     @ReactProp(name = "latitude", defaultDouble = 0.0)
     override fun setLatitude(view: StreetViewPanoramaView, value: Double) {
@@ -148,37 +226,74 @@ class StreetViewManager(
         state.applyIfReady()
     }
 
-    // ── Per-view state ─────────────────────────────────────────────────────
+    @ReactProp(name = "readyTimeout", defaultDouble = DEFAULT_READY_TIMEOUT_MS.toDouble())
+    override fun setReadyTimeout(view: StreetViewPanoramaView, value: Double) {
+        val state = states[view] ?: return
+        state.readyTimeoutMs = value.toLong()
+        // If the ready timeout runnable is still pending, reschedule it with
+        // the new value. This handles the case where the prop arrives before
+        // the panorama is ready.
+        state.readyTimeoutRunnable?.let {
+            mainHandler.removeCallbacks(it)
+            mainHandler.postDelayed(it, state.readyTimeoutMs)
+        }
+    }
 
-    private class PanoramaState {
+    @ReactProp(name = "positionTimeout", defaultDouble = DEFAULT_POSITION_TIMEOUT_MS.toDouble())
+    override fun setPositionTimeout(view: StreetViewPanoramaView, value: Double) {
+        val state = states[view] ?: return
+        state.positionTimeoutMs = value.toLong()
+        // No rescheduling needed — positionTimeout is read on the next
+        // setPosition call.
+    }
+
+    // ── Per-view state ────────────────────────────────────────────────────
+
+    private inner class PanoramaState {
         var panorama: StreetViewPanorama? = null
         var pendingLat: Double? = null
         var pendingLng: Double? = null
         var pendingHeading: Double? = null
-        var positionApplied: Boolean = false
+
+        // Timeout configuration — overridable via props.
+        var readyTimeoutMs: Long = DEFAULT_READY_TIMEOUT_MS
+        var positionTimeoutMs: Long = DEFAULT_POSITION_TIMEOUT_MS
+
+        // Pending timeout runnables. Held so they can be cancelled.
+        var readyTimeoutRunnable: Runnable? = null
+        var positionTimeoutRunnable: Runnable? = null
+
+        // Whether the first OnStreetViewPanoramaChangeListener has fired.
+        // Controls onLicenseConsumed / onLoaded emission (once only) and
+        // whether subsequent changes emit onPanoramaChanged vs initial events.
+        var licenseConsumed: Boolean = false
 
         /**
-         * Apply whatever pending values we have to the panorama, if it's
-         * ready. Called both from prop setters (panorama may or may not be
-         * ready) and from the onStreetViewPanoramaReady callback (panorama
-         * just became ready).
+         * Apply pending lat/lng/heading to the panorama if it is ready.
+         * Called from prop setters (panorama may not be ready yet) and from
+         * the getStreetViewPanoramaAsync callback (panorama just became ready).
          *
-         * Position is set only when BOTH lat and lng are present. Heading is
-         * applied independently — bearing rotation is cheap and visible
-         * even if position hasn't changed.
+         * Position timeout is armed on each setPosition call and cancelled
+         * when OnStreetViewPanoramaChangeListener fires.
          */
         fun applyIfReady() {
             val p = panorama ?: return
+            val lat = pendingLat ?: return
+            val lng = pendingLng ?: return
 
-            val lat = pendingLat
-            val lng = pendingLng
-            if (lat != null && lng != null) {
-                // setPosition is idempotent on the same coordinate, so we
-                // do not de-duplicate. A radius of 50m is permissive enough
-                // for cycling routes where panoramas are sparse.
-                p.setPosition(LatLng(lat, lng), 50)
-                positionApplied = true
+            // Arm (or re-arm) the position timeout before calling setPosition.
+            positionTimeoutRunnable?.let { mainHandler.removeCallbacks(it) }
+            val timeoutRunnable = Runnable {
+                android.util.Log.d(TAG, "position timeout expired")
+                // Find the view associated with this state to emit the event.
+                val view = states.entries.firstOrNull { it.value === this }?.key
+                    ?: return@Runnable
+                emitError(view, "unavailable")
             }
+            positionTimeoutRunnable = timeoutRunnable
+            mainHandler.postDelayed(timeoutRunnable, positionTimeoutMs)
+
+            p.setPosition(LatLng(lat, lng), 50)
 
             val heading = pendingHeading
             if (heading != null) {
@@ -186,17 +301,56 @@ class StreetViewManager(
                 val newCamera = StreetViewPanoramaCamera.Builder(current)
                     .bearing(heading.toFloat())
                     .build()
-                // 300ms animation for visible heading change. For
-                // verification-only, a smooth animation makes it obvious
-                // that updates are arriving. Production may want zero
-                // duration to follow ride position tightly.
+                // 300ms animation — smooth enough for verification; production
+                // wiring may want 0ms to track position tightly.
                 p.animateTo(newCamera, 300L)
             }
         }
     }
 
+    // ── Event emission helpers ────────────────────────────────────────────
+
+    private fun emitError(view: StreetViewPanoramaView, reason: String) {
+        val payload = Arguments.createMap().apply {
+            putString("reason", reason)
+        }
+        emitEvent(view, EVENT_ERROR, payload)
+    }
+
+    private fun emitEvent(
+        view: StreetViewPanoramaView,
+        eventName: String,
+        payload: com.facebook.react.bridge.WritableMap?,
+    ) {
+        val context = view.context as? ThemedReactContext ?: return
+        try {
+            val surfaceId = UIManagerHelper.getSurfaceId(context)
+            val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, view.id)
+            val finalPayload = payload ?: Arguments.createMap()
+            eventDispatcher?.dispatchEvent(
+                object : Event<Nothing>(surfaceId, view.id) {
+                    override fun getEventName() = eventName
+                    override fun getEventData() = finalPayload
+                }
+            )
+        } catch (t: Throwable) {
+            android.util.Log.w(TAG, "emitEvent $eventName threw: ${t.message}")
+        }
+    }
+
+
     companion object {
         const val NAME = "StreetView"
         private const val TAG = "StreetViewManager"
+
+        private const val DEFAULT_READY_TIMEOUT_MS = 10_000L
+        private const val DEFAULT_POSITION_TIMEOUT_MS = 2_000L
+
+        // Event name constants — must match the prop names in the Codegen spec.
+        private const val EVENT_LICENSE_CONSUMED = "onLicenseConsumed"
+        private const val EVENT_LOADED           = "onLoaded"
+        private const val EVENT_NO_PANORAMA      = "onNoPanorama"
+        private const val EVENT_PANORAMA_CHANGED = "onPanoramaChanged"
+        private const val EVENT_ERROR            = "onError"
     }
 }

--- a/src/pages/RootNavigator/RootNavigator.tsx
+++ b/src/pages/RootNavigator/RootNavigator.tsx
@@ -9,10 +9,11 @@ import { RidePage } from '../RidePage';
 import { VideoDemoPage } from '../VideoDemo/RidePage';
 import { NotImplementedPage } from '../NotImplemented/NotImplementedPage';
 import { ActivitiesPage } from '../ActivitiesPage';
+import { StreetViewDemoPage } from '../StreetViewDemo';
 
 const Stack = createNativeStackNavigator();
 
-const WorkoutsPage = ()=> <NotImplementedPage selected='workouts'/>
+const WorkoutsPage = () => <StreetViewDemoPage />;
 
 export const RootNavigator = () => {
 

--- a/src/pages/StreetViewDemo/StreetViewDemoPage.tsx
+++ b/src/pages/StreetViewDemo/StreetViewDemoPage.tsx
@@ -1,7 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { StyleSheet, View, Text } from 'react-native';
 import { StreetView } from '../../components/StreetView';
 import { colors, textSizes } from '../../theme';
+import { Button } from '../../components';
+import { getRidePageService  } from 'incyclist-services';
 
 const COORDINATES = [
     { lat: 40.758, lng: -73.9855, heading: 0,   label: 'Times Square N' },
@@ -13,13 +15,22 @@ const COORDINATES = [
 
 export const StreetViewDemoPage = () => {
     const [index, setIndex] = useState(0);
+    const service = getRidePageService() as any
 
     useEffect(() => {
         const interval = setInterval(() => {
             setIndex((prev) => (prev + 1) % COORDINATES.length);
         }, 3000);
-        return () => clearInterval(interval);
+        return () => { 
+            console.log('# stop interval')
+            clearInterval(interval)
+        };
     }, []);
+
+    const onBack = useCallback(()=> {
+        service.moveToPreviousPage()
+
+    },[service])
 
     const current = COORDINATES[index];
 
@@ -37,6 +48,9 @@ export const StreetViewDemoPage = () => {
                 <Text style={styles.text}>Lat: {current.lat}</Text>
                 <Text style={styles.text}>Lng: {current.lng}</Text>
                 <Text style={styles.text}>Heading: {current.heading}</Text>
+            </View>
+            <View style={styles.button}>
+                <Button label='Back' onClick={onBack} />
             </View>
         </View>
     );
@@ -57,6 +71,12 @@ const styles = StyleSheet.create({
         backgroundColor: 'rgba(0,0,0,0.45)',
         padding: 10,
         borderRadius: 4,
+        zIndex: 10,
+    },
+    button: {
+        position: 'absolute',
+        top: 20,
+        right: 20,
         zIndex: 10,
     },
     text: {

--- a/src/pages/StreetViewDemo/StreetViewDemoPage.tsx
+++ b/src/pages/StreetViewDemo/StreetViewDemoPage.tsx
@@ -4,6 +4,7 @@ import { StreetView } from '../../components/StreetView';
 import { colors, textSizes } from '../../theme';
 import { Button } from '../../components';
 import { getRidePageService  } from 'incyclist-services';
+import { sleep } from '../../utils/timers';
 
 const COORDINATES = [
     { lat: 40.758, lng: -73.9855, heading: 0,   label: 'Times Square N' },
@@ -16,6 +17,7 @@ const COORDINATES = [
 export const StreetViewDemoPage = () => {
     const [index, setIndex] = useState(0);
     const service = getRidePageService() as any
+    const [showStreetView, setShowStreetView] = useState(true); 
 
     useEffect(() => {
         const interval = setInterval(() => {
@@ -27,8 +29,18 @@ export const StreetViewDemoPage = () => {
         };
     }, []);
 
+    useEffect(() => {
+        return () => {
+            console.log('# demo page unmounting');
+        };
+    }, []);
+
     const onBack = useCallback(()=> {
-        service.moveToPreviousPage()
+        setShowStreetView(false)
+        sleep(1000).then( ()=> {
+            service.moveToPreviousPage()
+        })
+        
 
     },[service])
 
@@ -36,12 +48,12 @@ export const StreetViewDemoPage = () => {
 
     return (
         <View style={styles.container}>
-            <StreetView
+            {showStreetView && <StreetView
                 latitude={current.lat}
                 longitude={current.lng}
                 heading={current.heading}
                 style={styles.streetView}
-            />
+            />}
             <View style={styles.overlay}>
                 <Text style={styles.text}>Index: {index}</Text>
                 <Text style={styles.text}>Label: {current.label}</Text>
@@ -60,6 +72,7 @@ const styles = StyleSheet.create({
     container: {
         flex: 1,
         backgroundColor: colors.background,
+        margin:1
     },
     streetView: {
         flex: 1,

--- a/src/pages/StreetViewDemo/StreetViewDemoPage.tsx
+++ b/src/pages/StreetViewDemo/StreetViewDemoPage.tsx
@@ -1,0 +1,66 @@
+import React, { useState, useEffect } from 'react';
+import { StyleSheet, View, Text } from 'react-native';
+import { StreetView } from '../../components/StreetView';
+import { colors, textSizes } from '../../theme';
+
+const COORDINATES = [
+    { lat: 40.758, lng: -73.9855, heading: 0,   label: 'Times Square N' },
+    { lat: 40.758, lng: -73.9855, heading: 90,  label: 'Times Square E' },
+    { lat: 40.758, lng: -73.9855, heading: 180, label: 'Times Square S' },
+    { lat: 51.5055, lng: -0.0754, heading: 0,   label: 'Tower Bridge N' },
+    { lat: 51.5055, lng: -0.0754, heading: 270, label: 'Tower Bridge W' },
+];
+
+export const StreetViewDemoPage = () => {
+    const [index, setIndex] = useState(0);
+
+    useEffect(() => {
+        const interval = setInterval(() => {
+            setIndex((prev) => (prev + 1) % COORDINATES.length);
+        }, 3000);
+        return () => clearInterval(interval);
+    }, []);
+
+    const current = COORDINATES[index];
+
+    return (
+        <View style={styles.container}>
+            <StreetView
+                latitude={current.lat}
+                longitude={current.lng}
+                heading={current.heading}
+                style={styles.streetView}
+            />
+            <View style={styles.overlay}>
+                <Text style={styles.text}>Index: {index}</Text>
+                <Text style={styles.text}>Label: {current.label}</Text>
+                <Text style={styles.text}>Lat: {current.lat}</Text>
+                <Text style={styles.text}>Lng: {current.lng}</Text>
+                <Text style={styles.text}>Heading: {current.heading}</Text>
+            </View>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        backgroundColor: colors.background,
+    },
+    streetView: {
+        flex: 1,
+    },
+    overlay: {
+        position: 'absolute',
+        top: 20,
+        left: 20,
+        backgroundColor: 'rgba(0,0,0,0.45)',
+        padding: 10,
+        borderRadius: 4,
+        zIndex: 10,
+    },
+    text: {
+        color: colors.text,
+        fontSize: textSizes.smallText,
+    },
+});

--- a/src/pages/StreetViewDemo/index.ts
+++ b/src/pages/StreetViewDemo/index.ts
@@ -1,0 +1,1 @@
+export { StreetViewDemoPage } from './StreetViewDemoPage';

--- a/src/specs/StreetViewNativeComponent.ts
+++ b/src/specs/StreetViewNativeComponent.ts
@@ -1,11 +1,19 @@
-import type { HostComponent, ViewProps } from 'react-native';
-import type { Double } from 'react-native/Libraries/Types/CodegenTypes';
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import type { CodegenTypes, HostComponent, ViewProps } from 'react-native';
+import { codegenNativeComponent } from 'react-native';
+
+type OnErrorEvent = { reason: string };
 
 export interface NativeProps extends ViewProps {
-    latitude: Double;
-    longitude: Double;
-    heading: Double;
+    latitude: CodegenTypes.Double;
+    longitude: CodegenTypes.Double;
+    heading: CodegenTypes.Double;
+    readyTimeout?: CodegenTypes.Double;
+    positionTimeout?: CodegenTypes.Double;
+    onLicenseConsumed?: CodegenTypes.BubblingEventHandler<{}> | null;
+    onLoaded?: CodegenTypes.BubblingEventHandler<{}> | null;
+    onNoPanorama?: CodegenTypes.BubblingEventHandler<{}> | null;
+    onPanoramaChanged?: CodegenTypes.BubblingEventHandler<{}> | null;
+    onError?: CodegenTypes.BubblingEventHandler<OnErrorEvent> | null;
 }
 
 export default codegenNativeComponent<NativeProps>(


### PR DESCRIPTION
Closes #310

This PR introduces a temporary `StreetViewDemoPage` used for end-to-end verification of the native Street View component integration. 

Key changes:
- Created `StreetViewDemoPage` which cycles through a set of coordinates every 3 seconds.
- Included a status overlay to monitor JS state updates (index, lat/lng, heading).
- Temporarily mapped the `workouts` route in `RootNavigator` to this demo page for device testing.

## Manual Steps
- Launch the app on a physical device or emulator with native Street View support.
- Tap the 'workouts' item in the navigation bar.
- Verify that the Street View panorama updates its position and heading every 3 seconds in sync with the overlay data.