### PR TITLE
Update StreetView Codegen spec and JS wrapper with position prop, callbacks, and timeout props

### DIFF
--- a/src/components/StreetView/StreetView.test.tsx
+++ b/src/components/StreetView/StreetView.test.tsx
@@ -6,6 +6,8 @@ jest.mock('../../specs/StreetViewNativeComponent', () => 'StreetView');
 
 it('renders without crashing', () => {
     render(
-        <StreetView latitude={40.758} longitude={-73.9855} heading={0} />,
+        <StreetView
+            position={{ lat: 40.758, lng: -73.9855, heading: 0 }}
+        />,
     );
 });

--- a/src/components/StreetView/StreetView.tsx
+++ b/src/components/StreetView/StreetView.tsx
@@ -1,14 +1,64 @@
-import React from 'react';
-import { StyleSheet } from 'react-native';
+import React, { useCallback } from 'react';
+import { NativeSyntheticEvent, StyleSheet } from 'react-native';
 import StreetViewNativeComponent from '../../specs/StreetViewNativeComponent';
-import { StreetViewProps } from './types';
+import { StreetViewProps, StreetViewErrorReason } from './types';
 
 export const StreetView = (props: StreetViewProps) => {
-    const { style, ...rest } = props;
+    const {
+        position,
+        style,
+        readyTimeout,
+        positionTimeout,
+        onLicenseConsumed,
+        onLoaded,
+        onError,
+        onNoPanorama,
+        onPanoramaChanged,
+    } = props;
+
+    const handleLicenseConsumed = useCallback(() => {
+        onLicenseConsumed?.();
+    }, [onLicenseConsumed]);
+
+    const handleLoaded = useCallback(() => {
+        onLoaded?.();
+    }, [onLoaded]);
+
+    const handleNoPanorama = useCallback(() => {
+        onNoPanorama?.();
+    }, [onNoPanorama]);
+
+    const handlePanoramaChanged = useCallback(() => {
+        onPanoramaChanged?.();
+    }, [onPanoramaChanged]);
+
+    const handleNativeError = useCallback(
+        (event: NativeSyntheticEvent<{ reason: string }>) => {
+            onError?.(event.nativeEvent.reason as StreetViewErrorReason);
+        },
+        [onError],
+    );
+
     return (
         <StreetViewNativeComponent
-            {...rest}
-            style={[StyleSheet.absoluteFill, style]}
+            latitude={position?.lat ?? 0}
+            longitude={position?.lng ?? 0}
+            heading={position?.heading ?? 0}
+            readyTimeout={readyTimeout}
+            positionTimeout={positionTimeout}
+            onLicenseConsumed={handleLicenseConsumed}
+            onLoaded={handleLoaded}
+            onNoPanorama={handleNoPanorama}
+            onPanoramaChanged={handlePanoramaChanged}
+            onError={handleNativeError}
+            style={[styles.container, style]}
         />
     );
 };
+
+const styles = StyleSheet.create({
+    container: {
+        ...StyleSheet.absoluteFillObject,
+        margin: 1,
+    },
+});

--- a/src/components/StreetView/StreetView.tsx
+++ b/src/components/StreetView/StreetView.tsx
@@ -58,7 +58,7 @@ export const StreetView = (props: StreetViewProps) => {
 
 const styles = StyleSheet.create({
     container: {
-        ...StyleSheet.absoluteFillObject,
+        ...StyleSheet.absoluteFill,
         margin: 1,
     },
 });

--- a/src/components/StreetView/types.ts
+++ b/src/components/StreetView/types.ts
@@ -1,8 +1,21 @@
 import { StyleProp, ViewStyle } from 'react-native';
 
-export interface StreetViewProps {
-    latitude: number;
-    longitude: number;
+export interface IPosition {
+    lat: number;
+    lng: number;
     heading: number;
+}
+
+export type StreetViewErrorReason = 'unavailable' | 'unknown';
+
+export interface StreetViewProps {
+    position?: IPosition;
     style?: StyleProp<ViewStyle>;
+    readyTimeout?: number;
+    positionTimeout?: number;
+    onLicenseConsumed?: () => void;
+    onLoaded?: () => void;
+    onError?: (reason: StreetViewErrorReason) => void;
+    onNoPanorama?: () => void;
+    onPanoramaChanged?: () => void;
 }


### PR DESCRIPTION
Closes #314

Updates the `StreetView` component to align with the new Fabric Codegen spec:
- Replaces `latitude`/`longitude`/`heading` props with a single `position` prop of type `IPosition`.
- Adds timeout props: `readyTimeout` and `positionTimeout`.
- Adds event callback props: `onLicenseConsumed`, `onLoaded`, `onError`, `onNoPanorama`, and `onPanoramaChanged`.
- Implements `onError` unwrapping logic to provide the reason string directly to consumers.
- Ensures `margin: 1` is applied to the native component to prevent teardown visual bugs as per rule D.21.