### PR TITLE
Add fetch binding for Overpass requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "axios": "^1.17.0",
         "events": "^3.3.0",
         "gd-eventlog": "^0.1.27",
-        "incyclist-services": "^1.7.73",
+        "incyclist-services": "^1.7.75",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
         "react": "^19.2.4",
@@ -11721,9 +11721,9 @@
       }
     },
     "node_modules/incyclist-devices": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/incyclist-devices/-/incyclist-devices-3.0.22.tgz",
-      "integrity": "sha512-KD0WU0BSSnyHRQ4Ab/YJlV4j2Y4W+uZnohXygiTNFBWFHgyBvPXuK7mCdxu5jN3QjMxpD5ng5vd1Y5HrAVRV4g==",
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/incyclist-devices/-/incyclist-devices-3.0.23.tgz",
+      "integrity": "sha512-A+pspH6YaEjMhIhFcVD81wiOGDvrwhnC2brtohXamE2etnQUHRl7KbJKGWzbzFpgvc5luwd9Pgt6jiqEG/kYgw==",
       "dependencies": {
         "@protobuf-ts/runtime": "^2.11.1",
         "@serialport/bindings-interface": "^1.2.2",
@@ -11739,13 +11739,13 @@
       }
     },
     "node_modules/incyclist-services": {
-      "version": "1.7.73",
-      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.73.tgz",
-      "integrity": "sha512-ONJ6AQJtCpP3VfyqbaqdNdvOwMyP2KUat1vwOzthl5myBi+gIf7nf0AFGamLsFp8XxoxDpUX2SNsnABrLAd21w==",
+      "version": "1.7.75",
+      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.75.tgz",
+      "integrity": "sha512-MLc+fA09xLP1Zc9VKxlOrL79uLjqdOpEr/P9YDovrNSbtghEkgqjrTBcLYBG2I7nUVVSPRYfYSxWgmhofJPHFw==",
       "dependencies": {
         "@garmin/fitsdk": "^21.200.0",
         "axios": "^1.15.2",
-        "incyclist-devices": "^3.0.22",
+        "incyclist-devices": "^3.0.23",
         "promise.any": "^2.0.6",
         "semver": "^7.7.4",
         "tcx-builder": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "axios": "^1.17.0",
     "events": "^3.3.0",
     "gd-eventlog": "^0.1.27",
-    "incyclist-services": "^1.7.73",
+    "incyclist-services": "^1.7.75",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "react": "^19.2.4",

--- a/src/bindings/factory.ts
+++ b/src/bindings/factory.ts
@@ -13,6 +13,7 @@ import { getVideoBinding } from "./video"
 import { getRepositoryBinding } from "./db"
 import { getFileLoaderBinding } from "./loader"
 import { getCryptoBinding } from "./crypto"
+import { getFetchBinding } from "./fetch"
 import { getFormBinding } from './form';
 import { MobileDownloadManager } from './download';
 
@@ -43,6 +44,7 @@ export const initBindings = async  ()=> {
     bindings.db = getRepositoryBinding()
     bindings.loader = getFileLoaderBinding()
     bindings.crypto = getCryptoBinding()
+    bindings.fetch = getFetchBinding()
     bindings.form = getFormBinding()
     bindings.downloadManager = new MobileDownloadManager()
 

--- a/src/bindings/fetch/index.test.ts
+++ b/src/bindings/fetch/index.test.ts
@@ -1,0 +1,69 @@
+import { FetchBinding } from './index';
+
+describe('FetchBinding', () => {
+    let binding: FetchBinding;
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+        binding = new FetchBinding();
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        jest.restoreAllMocks();
+    });
+
+    const mockFetchResponse = (props: { ok?: boolean; status?: number; statusText?: string; headers?: [string, string][]; text?: string }) => {
+        const headers = new Map(props.headers ?? []);
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: props.ok ?? true,
+            status: props.status ?? 200,
+            statusText: props.statusText ?? 'OK',
+            headers: { forEach: (cb: (value: string, key: string) => void) => headers.forEach((v, k) => cb(v, k)) },
+            text: jest.fn().mockResolvedValue(props.text ?? ''),
+        });
+    };
+
+    test('issues a GET by default and maps the response', async () => {
+        mockFetchResponse({ status: 200, statusText: 'OK', headers: [['content-type', 'application/json']], text: '{"a":1}' });
+
+        const res = await binding.fetch('https://overpass.example/api/interpreter');
+
+        expect(global.fetch).toHaveBeenCalledWith('https://overpass.example/api/interpreter', {
+            method: 'GET',
+            headers: undefined,
+            body: undefined,
+        });
+        expect(res).toEqual({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            headers: { 'content-type': 'application/json' },
+            data: '{"a":1}',
+        });
+    });
+
+    test('passes method, headers and body through to fetch', async () => {
+        mockFetchResponse({ ok: false, status: 400, statusText: 'Bad Request' });
+
+        const res = await binding.fetch('https://overpass.example/api/interpreter', {
+            method: 'POST',
+            headers: { 'User-Agent': 'Incyclist/1.0', Referer: 'https://incyclist.com' },
+            body: 'query-data',
+        });
+
+        expect(global.fetch).toHaveBeenCalledWith('https://overpass.example/api/interpreter', {
+            method: 'POST',
+            headers: { 'User-Agent': 'Incyclist/1.0', Referer: 'https://incyclist.com' },
+            body: 'query-data',
+        });
+        expect(res.ok).toBe(false);
+        expect(res.status).toBe(400);
+    });
+
+    test('rejects when fetch itself rejects', async () => {
+        global.fetch = jest.fn().mockRejectedValue(new Error('network down'));
+
+        await expect(binding.fetch('https://overpass.example/api/interpreter')).rejects.toThrow('network down');
+    });
+});

--- a/src/bindings/fetch/index.ts
+++ b/src/bindings/fetch/index.ts
@@ -1,0 +1,31 @@
+import type { IFetchBinding, IFetchRequestInit, IFetchResponse } from 'incyclist-services';
+
+/**
+ * React Native's fetch is backed by native networking (OkHttp/NSURLSession), not a
+ * browser engine, so it does not enforce the forbidden-header/referrer-policy rules
+ * that block setting Referer/User-Agent from a page - see the desktop binding
+ * (mobile/../desktop/src/features/fetch/feature.js) for why that binding is needed there.
+ */
+export class FetchBinding implements IFetchBinding {
+    async fetch(url: string, init?: IFetchRequestInit): Promise<IFetchResponse> {
+        const response = await fetch(url, {
+            method: init?.method ?? 'GET',
+            headers: init?.headers,
+            body: init?.body,
+        });
+
+        const data = await response.text();
+        const headers: Record<string, string> = {};
+        response.headers.forEach((value, key) => { headers[key] = value });
+
+        return {
+            ok: response.ok,
+            status: response.status,
+            statusText: response.statusText,
+            headers,
+            data,
+        };
+    }
+}
+
+export const getFetchBinding = () => new FetchBinding();


### PR DESCRIPTION
## Summary
- Adds `src/bindings/fetch/index.ts`, wrapping React Native's native `fetch` directly - RN's networking is backed by native OkHttp/NSURLSession rather than a browser engine, so it doesn't enforce the forbidden-header/referrer-policy restrictions that required a native-module/IPC approach on desktop.
- Wires it into `src/bindings/factory.ts` as `bindings.fetch`, so `services`' `OverpassApi` can use it for country-lookup-style Overpass queries on mobile (e.g. resolving the country of a GPX track).

Companion PRs:
- incyclist/desktop#feat/overpass-referrer-fix (Electron `net.request()` implementation, IPC-exposed)
- incyclist/services#feat/overpass-referrer-fix (`IFetchBinding` + `OverpassApi` wiring)
- incyclist/web-ui#feat/overpass-referrer-fix (binding wiring)

## Test plan
- [x] `npx tsc --noEmit -p .` (verified locally against a fresh `services` build; will fully resolve once `incyclist-services` publishes the new binding and this repo bumps its pin)
- [x] `npx jest src/bindings/fetch` (3 tests passing)
- [x] Full mobile suite (56 suites / 260 tests) still passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)