### PR TITLE
feat(WorkoutGraph): strip + detail modes spike (session 1.3)

### DIFF
--- a/src/components/ActivityGraph/ActivityGraphView.tsx
+++ b/src/components/ActivityGraph/ActivityGraphView.tsx
@@ -198,8 +198,13 @@ export const ActivityGraphView = React.memo( ({
         return ticks;
     };
 
+    // Flatten to a single object: react-native-svg's web <Svg> pushes an array
+    // `style` prop through unflattened, which React 19's DOM renderer rejects with
+    // "Indexed property setter is not supported" (worked under React 18).
+    const svgStyle = StyleSheet.flatten([styles.svg, style]);
+
     return (
-        <Svg width={width} height={height} style={[styles.svg, style]}>
+        <Svg width={width} height={height} style={svgStyle}>
             <G translate={`${margins.left}, ${margins.top}`}>
                 {renderElevation()}
                 {series.map((s: ActivityGraphSeries) => renderSeries(s))}

--- a/src/components/WorkoutGraph/WorkoutGraph.stories.tsx
+++ b/src/components/WorkoutGraph/WorkoutGraph.stories.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { WorkoutGraphView } from './WorkoutGraphView';
+import { MOCK_PLAN, MOCK_PLAN_SHORT } from './mockData';
+import { colors } from '../../theme/colors';
+
+/**
+ * Session-1.3 spike stories. Proves the SVG rendering approach across the two
+ * modes in scope: `strip` (list-row thumbnail — bars only, no FTP line, no axes)
+ * and `detail` (full — bars + FTP reference line + light axes). `live` mode is
+ * deferred to session 3.1.
+ *
+ * Stories drive the pure WorkoutGraphView with explicit pixel sizes (the smart
+ * WorkoutGraph wrapper's onLayout measurement doesn't resolve under the
+ * react-native-web Storybook renderer, matching how ActivityGraphPreview stories
+ * are written).
+ */
+const meta: Meta<typeof WorkoutGraphView> = {
+    title: 'Components/WorkoutGraph',
+    component: WorkoutGraphView,
+    decorators: [
+        (Story) => (
+            <View style={styles.decorator}>
+                <Story />
+            </View>
+        ),
+    ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof WorkoutGraphView>;
+
+/** strip mode — as embedded in a WorkoutItem list row. */
+export const Strip: Story = {
+    args: {
+        mode: 'strip',
+        plan: MOCK_PLAN,
+        width: 350,
+        height: 44,
+    },
+};
+
+/** strip mode at a small / short-workout size. */
+export const StripShort: Story = {
+    args: {
+        mode: 'strip',
+        plan: MOCK_PLAN_SHORT,
+        width: 220,
+        height: 36,
+    },
+};
+
+/** detail mode — as shown in the WorkoutDetailsDialog. */
+export const Detail: Story = {
+    args: {
+        mode: 'detail',
+        plan: MOCK_PLAN,
+        width: 360,
+        height: 200,
+    },
+};
+
+/** detail mode, FTP line above every bar (verifies clamp when ftp > yMax bars). */
+export const DetailLowIntensity: Story = {
+    args: {
+        mode: 'detail',
+        plan: MOCK_PLAN_SHORT,
+        width: 360,
+        height: 200,
+    },
+};
+
+/**
+ * Side-by-side render of a mocked WorkoutItem row: name + a strip graph, showing
+ * how the thumbnail reads at row scale next to text.
+ */
+export const InListRow: Story = {
+    render: () => (
+        <View style={styles.row}>
+            <View style={styles.rowText}>
+                <Text style={styles.rowTitle}>VO2 Max Builder</Text>
+                <Text style={styles.rowSub}>35 min · Intervals</Text>
+            </View>
+            <View style={styles.rowGraph}>
+                <WorkoutGraphView mode="strip" plan={MOCK_PLAN} width={160} height={40} />
+            </View>
+        </View>
+    ),
+};
+
+const styles = StyleSheet.create({
+    decorator: {
+        width: 420,
+        minHeight: 120,
+        padding: 16,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: colors.background,
+    },
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        width: 380,
+        padding: 12,
+        borderRadius: 8,
+        backgroundColor: colors.listItemBackground,
+    },
+    rowText: {
+        flex: 1,
+    },
+    rowTitle: {
+        color: colors.text,
+        fontSize: 15,
+        fontWeight: '600',
+    },
+    rowSub: {
+        color: colors.text,
+        opacity: 0.7,
+        fontSize: 12,
+        marginTop: 2,
+    },
+    rowGraph: {
+        width: 160,
+    },
+});

--- a/src/components/WorkoutGraph/WorkoutGraph.tsx
+++ b/src/components/WorkoutGraph/WorkoutGraph.tsx
@@ -1,0 +1,61 @@
+import React, { useCallback, useState } from 'react';
+import { View, StyleSheet, LayoutChangeEvent } from 'react-native';
+import { WorkoutGraphView } from './WorkoutGraphView';
+import type { WorkoutGraphProps } from './types';
+
+/**
+ * Smart wrapper for WorkoutGraph. Measures its own width (and height, unless a
+ * fixed `height` is supplied — e.g. thumbnail rows in `strip` mode) via
+ * onLayout, then hands concrete pixel dimensions to the pure WorkoutGraphView.
+ * Same measure-then-render pattern as ActivityGraph.
+ *
+ * Consumers that already know their pixel box (list rows, Storybook) can use
+ * WorkoutGraphView directly; this wrapper exists for flex-sized containers such
+ * as the details dialog and the (future) ride screen.
+ */
+export const WorkoutGraph = ({
+    mode,
+    plan,
+    actuals,
+    showAxes,
+    showFtpLine,
+    height,
+    style,
+}: WorkoutGraphProps) => {
+    const [layout, setLayout] = useState({ width: 0, height: 0 });
+
+    const onLayout = useCallback((e: LayoutChangeEvent) => {
+        const { width, height: h } = e.nativeEvent.layout;
+        setLayout(prev =>
+            prev.width === width && prev.height === h ? prev : { width, height: h }
+        );
+    }, []);
+
+    const resolvedHeight = height ?? layout.height;
+    const containerStyle = height !== undefined ? [styles.fixed, { height }, style] : [styles.flex, style];
+
+    return (
+        <View style={containerStyle} onLayout={onLayout}>
+            {layout.width > 0 && resolvedHeight > 0 && (
+                <WorkoutGraphView
+                    width={layout.width}
+                    height={resolvedHeight}
+                    mode={mode}
+                    plan={plan}
+                    actuals={actuals}
+                    showAxes={showAxes}
+                    showFtpLine={showFtpLine}
+                />
+            )}
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    flex: {
+        flex: 1,
+    },
+    fixed: {
+        width: '100%',
+    },
+});

--- a/src/components/WorkoutGraph/WorkoutGraphView.test.tsx
+++ b/src/components/WorkoutGraph/WorkoutGraphView.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { WorkoutGraphView } from './WorkoutGraphView';
+import { MOCK_PLAN, MOCK_PLAN_SHORT } from './mockData';
+import type { WorkoutGraphPlan } from './types';
+
+const EMPTY_PLAN: WorkoutGraphPlan = {
+    bars: [],
+    ftp: 230,
+    ftpLine: 230,
+    domain: { x: [0, 0], y: [0, 0] },
+};
+
+describe('WorkoutGraphView', () => {
+    it('renders strip mode with zone bars', () => {
+        const { toJSON } = render(
+            <WorkoutGraphView mode="strip" plan={MOCK_PLAN} width={350} height={44} />
+        );
+        expect(toJSON()).not.toBeNull();
+    });
+
+    it('renders detail mode (bars + FTP line + axes)', () => {
+        const { toJSON } = render(
+            <WorkoutGraphView mode="detail" plan={MOCK_PLAN} width={360} height={200} />
+        );
+        expect(toJSON()).not.toBeNull();
+    });
+
+    it('draws one Rect per plan bar', () => {
+        const { UNSAFE_root } = render(
+            <WorkoutGraphView mode="strip" plan={MOCK_PLAN} width={350} height={44} />
+        );
+        // react-native-svg mocks render as host components named 'RNSVGRect'
+        const rects = UNSAFE_root.findAll(
+            node => typeof node.type === 'string' && node.type.includes('Rect')
+        );
+        expect(rects.length).toBe(MOCK_PLAN.bars.length);
+    });
+
+    it('renders nothing for zero width', () => {
+        const { toJSON } = render(
+            <WorkoutGraphView mode="detail" plan={MOCK_PLAN} width={0} height={200} />
+        );
+        expect(toJSON()).toBeNull();
+    });
+
+    it('handles an empty plan without throwing', () => {
+        const { toJSON } = render(
+            <WorkoutGraphView mode="detail" plan={EMPTY_PLAN} width={360} height={200} />
+        );
+        expect(toJSON()).not.toBeNull();
+    });
+
+    it('respects explicit showFtpLine / showAxes overrides', () => {
+        const { toJSON } = render(
+            <WorkoutGraphView
+                mode="strip"
+                plan={MOCK_PLAN_SHORT}
+                width={360}
+                height={200}
+                showFtpLine
+                showAxes
+            />
+        );
+        expect(toJSON()).not.toBeNull();
+    });
+});

--- a/src/components/WorkoutGraph/WorkoutGraphView.tsx
+++ b/src/components/WorkoutGraph/WorkoutGraphView.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { Svg, G, Rect, Line, Text as SvgText } from 'react-native-svg';
+import type { WorkoutGraphViewProps, WorkoutGraphPlan } from './types';
+import { domainToPixel, zoneFill } from './utils';
+import { colors } from '../../theme';
+
+/**
+ * Static zone-bar layer. Split into its own memoized component so that when the
+ * live overlay (session 3.1) re-renders at 1 Hz, these bars — which only change
+ * on skip/load events — are skipped by React reconciliation entirely. Keyed on
+ * the `plan` reference + plot size; the service delivers a fresh `plan` object
+ * only when the bars actually change (on `page-update`), never per telemetry tick.
+ */
+const PlanBars = React.memo(({
+    plan,
+    plotWidth,
+    plotHeight,
+}: {
+    plan: WorkoutGraphPlan;
+    plotWidth: number;
+    plotHeight: number;
+}) => {
+    const [xMin, xMax] = plan.domain.x;
+    const [yMin, yMax] = plan.domain.y;
+
+    return (
+        <>
+            {plan.bars.map((bar, i) => {
+                const left = domainToPixel(bar.x0, xMin, xMax, 0, plotWidth);
+                const right = domainToPixel(bar.x, xMin, xMax, 0, plotWidth);
+                const top = domainToPixel(bar.y, yMin, yMax, plotHeight, 0);
+                const bottom = domainToPixel(bar.y0, yMin, yMax, plotHeight, 0);
+                const w = Math.max(0.5, right - left);
+                const h = Math.max(0.5, bottom - top);
+                return (
+                    <Rect
+                        key={`bar-${i}`}
+                        x={left}
+                        y={top}
+                        width={w}
+                        height={h}
+                        fill={zoneFill(bar.zone)}
+                    />
+                );
+            })}
+        </>
+    );
+});
+
+const formatTime = (sec: number): string => {
+    const m = Math.floor(sec / 60);
+    const s = Math.floor(sec % 60);
+    return `${m}:${String(s).padStart(2, '0')}`;
+};
+
+/**
+ * Pure, presized WorkoutGraph renderer. Draws the zone-colored plan bars for
+ * every mode; `detail` adds an FTP reference line and light axes. `live`-mode
+ * actuals (grey power area + HR line + position marker) are intentionally NOT
+ * drawn by this spike — the prop exists so session 3.1 slots the overlay in
+ * above the memoized PlanBars without touching this contract.
+ */
+export const WorkoutGraphView = React.memo((props: WorkoutGraphViewProps) => {
+    const {
+        width,
+        height,
+        mode,
+        plan,
+        showAxes,
+        showFtpLine,
+        axisFontSize = 10,
+        style,
+    } = props;
+
+    if (width <= 0 || height <= 0 || !plan) return null;
+
+    const isDetail = mode === 'detail';
+    const axes = showAxes ?? isDetail;
+    const ftpLine = showFtpLine ?? isDetail;
+
+    const margins = {
+        top: axes ? 8 : 0,
+        bottom: axes ? 20 : 0,
+        left: axes ? 34 : 0,
+        right: axes ? 6 : 0,
+    };
+
+    const plotWidth = width - margins.left - margins.right;
+    const plotHeight = height - margins.top - margins.bottom;
+    if (plotWidth <= 0 || plotHeight <= 0) return null;
+
+    const [xMin, xMax] = plan.domain.x;
+    const [yMin, yMax] = plan.domain.y;
+
+    const renderFtpLine = () => {
+        if (!ftpLine || plan.ftpLine <= yMin || plan.ftpLine >= yMax) return null;
+        const y = domainToPixel(plan.ftpLine, yMin, yMax, plotHeight, 0);
+        return (
+            <G>
+                <Line
+                    x1={0}
+                    y1={y}
+                    x2={plotWidth}
+                    y2={y}
+                    stroke={colors.text}
+                    strokeWidth={1}
+                    strokeDasharray="4 3"
+                    opacity={0.7}
+                />
+                <SvgText
+                    x={plotWidth - 2}
+                    y={y - 3}
+                    fill={colors.text}
+                    fontSize={axisFontSize}
+                    fontWeight="600"
+                    textAnchor="end"
+                >
+                    {`FTP ${Math.round(plan.ftpLine)}W`}
+                </SvgText>
+            </G>
+        );
+    };
+
+    const renderYAxis = () => {
+        if (!axes) return null;
+        const ticks = [];
+        const count = 3;
+        for (let i = 0; i < count; i++) {
+            const val = yMin + (i * (yMax - yMin)) / (count - 1);
+            const y = domainToPixel(val, yMin, yMax, plotHeight, 0);
+            let textY = y + 4;
+            if (i === count - 1) textY = y + 9; // top tick sits below the line
+            else if (i === 0) textY = y - 2;    // bottom tick sits above the axis
+            ticks.push(
+                <SvgText
+                    key={`y-${i}`}
+                    x={-4}
+                    y={textY}
+                    fill={colors.text}
+                    fontSize={axisFontSize}
+                    fontWeight="600"
+                    textAnchor="end"
+                >
+                    {`${Math.round(val)}`}
+                </SvgText>
+            );
+        }
+        return ticks;
+    };
+
+    const renderXAxis = () => {
+        if (!axes || xMax <= xMin) return null;
+        const ticks = [];
+        const count = 4;
+        for (let i = 0; i < count; i++) {
+            const val = xMin + (i * (xMax - xMin)) / (count - 1);
+            const x = domainToPixel(val, xMin, xMax, 0, plotWidth);
+            let textAnchor: 'start' | 'middle' | 'end' = 'middle';
+            if (i === 0) textAnchor = 'start';
+            else if (i === count - 1) textAnchor = 'end';
+            ticks.push(
+                <SvgText
+                    key={`x-${i}`}
+                    x={x}
+                    y={plotHeight + 14}
+                    fill={colors.text}
+                    fontSize={axisFontSize}
+                    fontWeight="600"
+                    textAnchor={textAnchor}
+                >
+                    {formatTime(val)}
+                </SvgText>
+            );
+        }
+        return ticks;
+    };
+
+    // NOTE: react-native-svg's web build (elements/Svg.js) pushes the raw `style`
+    // prop into its rootStyles array unflattened — passing an ARRAY here produces a
+    // nested array that React DOM rejects with "Indexed property setter is not
+    // supported". Flatten to a single object so only plain objects reach the <svg>.
+    const svgStyle = StyleSheet.flatten([styles.svg, style]);
+
+    return (
+        <Svg width={width} height={height} style={svgStyle}>
+            <G translate={`${margins.left}, ${margins.top}`}>
+                <PlanBars plan={plan} plotWidth={plotWidth} plotHeight={plotHeight} />
+                {renderFtpLine()}
+                {renderYAxis()}
+                {renderXAxis()}
+            </G>
+        </Svg>
+    );
+}, (prev, next) =>
+    prev.width === next.width &&
+    prev.height === next.height &&
+    prev.mode === next.mode &&
+    prev.plan === next.plan &&
+    prev.actuals === next.actuals &&
+    prev.showAxes === next.showAxes &&
+    prev.showFtpLine === next.showFtpLine
+);
+
+const styles = StyleSheet.create({
+    svg: {
+        backgroundColor: 'transparent',
+    },
+});

--- a/src/components/WorkoutGraph/WorkoutGraphView.tsx
+++ b/src/components/WorkoutGraph/WorkoutGraphView.tsx
@@ -26,16 +26,19 @@ const PlanBars = React.memo(({
 
     return (
         <>
-            {plan.bars.map((bar, i) => {
+            {plan.bars.map((bar) => {
                 const left = domainToPixel(bar.x0, xMin, xMax, 0, plotWidth);
                 const right = domainToPixel(bar.x, xMin, xMax, 0, plotWidth);
                 const top = domainToPixel(bar.y, yMin, yMax, plotHeight, 0);
                 const bottom = domainToPixel(bar.y0, yMin, yMax, plotHeight, 0);
                 const w = Math.max(0.5, right - left);
                 const h = Math.max(0.5, bottom - top);
+                // Stable key from the bar's time span (each bar is a unique,
+                // non-overlapping segment) — not the array index. Matters for
+                // live mode, where bars are inserted/removed on skip-back.
                 return (
                     <Rect
-                        key={`bar-${i}`}
+                        key={`bar-${bar.x0}-${bar.x}`}
                         x={left}
                         y={top}
                         width={w}

--- a/src/components/WorkoutGraph/index.ts
+++ b/src/components/WorkoutGraph/index.ts
@@ -1,4 +1,7 @@
 export * from './types';
-export * from './utils';
 export * from './WorkoutGraphView';
 export * from './WorkoutGraph';
+// Note: ./utils (domainToPixel/zoneFill/maxBarPower) and ./mockData are
+// intentionally not re-exported — they are internal helpers/fixtures. This
+// mirrors ElevationGraph's barrel and keeps domainToPixel out of the shared
+// component surface (where it would clash with ActivityGraph's copy).

--- a/src/components/WorkoutGraph/index.ts
+++ b/src/components/WorkoutGraph/index.ts
@@ -1,0 +1,4 @@
+export * from './types';
+export * from './utils';
+export * from './WorkoutGraphView';
+export * from './WorkoutGraph';

--- a/src/components/WorkoutGraph/mockData.ts
+++ b/src/components/WorkoutGraph/mockData.ts
@@ -1,0 +1,69 @@
+import { WorkoutGraphActuals, WorkoutGraphPlan, WorkoutGraphPlanBar } from './types';
+
+/**
+ * Hand-authored mock data conforming to the real `workout-ride-page-service-design.md`
+ * §3.1 shapes. Stands in for the not-yet-existing `getWorkoutGraphSeries()` generator
+ * so the session-1.3 spike (strip/detail modes) can be exercised in Storybook/tests.
+ *
+ * Represents a ~35-minute structured session at FTP 230 W:
+ *   warmup ramp -> endurance -> tempo -> 3x VO2 (on/off) -> cooldown ramp.
+ * Includes single-value steps (y0=0) and banded ramp steps (y0>0) so both
+ * rectangle shapes are covered. Watts are absolute (already FTP-resolved).
+ */
+
+const FTP = 230;
+
+// zone thresholds (matching getZoneColor): 1<=55% 2<=75% 3<=90% 4<=105% 5<=120% 6<=150% 7>150%
+const MOCK_BARS: WorkoutGraphPlanBar[] = [
+    // warmup ramp 120 -> 175 W  (banded step, y0 > 0)
+    { x0: 0,    x: 300,  y: 175, y0: 120, zone: 2 },
+    // endurance 160 W
+    { x0: 300,  x: 600,  y: 160, y0: 0,   zone: 2 },
+    // tempo 200 W
+    { x0: 600,  x: 900,  y: 200, y0: 0,   zone: 3 },
+    // 3x VO2:  3min @ 280 W (on) / 2min @ 130 W (off)
+    { x0: 900,  x: 1080, y: 280, y0: 0,   zone: 6 },
+    { x0: 1080, x: 1200, y: 130, y0: 0,   zone: 2 },
+    { x0: 1200, x: 1380, y: 280, y0: 0,   zone: 6 },
+    { x0: 1380, x: 1500, y: 130, y0: 0,   zone: 2 },
+    { x0: 1500, x: 1680, y: 280, y0: 0,   zone: 6 },
+    { x0: 1680, x: 1800, y: 130, y0: 0,   zone: 2 },
+    // cooldown ramp 150 -> 100 W (banded step, y0 > 0)
+    { x0: 1800, x: 2100, y: 150, y0: 100, zone: 1 },
+];
+
+const maxPower = MOCK_BARS.reduce((m, b) => Math.max(m, b.y), 0);
+
+export const MOCK_PLAN: WorkoutGraphPlan = {
+    bars: MOCK_BARS,
+    ftp: FTP,
+    ftpLine: FTP,
+    domain: {
+        x: [0, 2100],
+        y: [0, Math.round(maxPower * 1.1)],
+    },
+};
+
+/** A short, flat-ish workout to exercise the strip thumbnail at small sizes. */
+export const MOCK_PLAN_SHORT: WorkoutGraphPlan = {
+    bars: [
+        { x0: 0,   x: 120, y: 150, y0: 0, zone: 2 },
+        { x0: 120, x: 240, y: 240, y0: 0, zone: 4 },
+        { x0: 240, x: 360, y: 150, y0: 0, zone: 2 },
+        { x0: 360, x: 480, y: 300, y0: 0, zone: 7 },
+        { x0: 480, x: 600, y: 120, y0: 0, zone: 1 },
+    ],
+    ftp: FTP,
+    ftpLine: FTP,
+    domain: { x: [0, 600], y: [0, 330] },
+};
+
+/**
+ * Mock actuals for the (deferred) live overlay — provided now only so session
+ * 3.1 has a ready shape to render. Not consumed by strip/detail.
+ */
+export const MOCK_ACTUALS: WorkoutGraphActuals = {
+    power: Array.from({ length: 60 }, (_, i) => ({ x: i * 15, y: 150 + Math.round(Math.sin(i / 4) * 60) })),
+    heartrate: Array.from({ length: 60 }, (_, i) => ({ x: i * 15, y: 120 + Math.round(i / 2) })),
+    position: 900,
+};

--- a/src/components/WorkoutGraph/types.ts
+++ b/src/components/WorkoutGraph/types.ts
@@ -1,0 +1,102 @@
+import { StyleProp, ViewStyle } from 'react-native';
+
+/**
+ * Data shapes consumed by the WorkoutGraph component.
+ *
+ * These mirror `workout-ride-page-service-design.md` §3.1 exactly. They are
+ * defined locally for the session-1.3 spike because the shared
+ * `getWorkoutGraphSeries()` generator (services §7 #1) does not exist yet.
+ * Once session 2.2 lands, these should be re-exported from `incyclist-services`
+ * and the local copies deleted — the field names/units are chosen to match so
+ * the swap is a pure import change.
+ *
+ * The zone-coloring / step-to-bar math lives in `services`; this component is
+ * pure rendering and does NO FTP math — bars already carry absolute Watts.
+ */
+
+export type WorkoutGraphMode = 'strip' | 'detail' | 'live';
+
+/** A single (time, value) sample — Watts for power, bpm for heartrate. */
+export interface WorkoutGraphPoint {
+    x: number; // elapsed activity time (s)
+    y: number; // value — Watts for power, bpm for heartrate
+}
+
+/**
+ * One zone-colored bar of the (current) workout. Mirrors web-ui getDataSeries()
+ * output with absValues:true — absolute Watts, already resolved against FTP.
+ * This is a rectangle series (react-vis VerticalRectSeries equivalent): each
+ * bar spans [x0,x] horizontally and [y0,y] vertically.
+ */
+export interface WorkoutGraphPlanBar {
+    x0: number;   // bar start   (elapsed time, s)
+    x: number;    // bar end     (elapsed time, s)
+    y: number;    // top power    (W) — max of the band, or the ramp value
+    y0: number;   // bottom power (W) — min of the band; 0 for single-value steps
+    zone: number; // 1..7 -> WORKOUT_ZONE_COLORS[zone]  (0 = uncolored)
+}
+
+export interface WorkoutGraphPlan {
+    bars: WorkoutGraphPlanBar[]; // whole workout, zone-colored, absolute Watts
+    ftp: number;                 // FTP the bars were resolved with
+    ftpLine: number;             // W value of the FTP reference line (= ftp)
+    domain: {
+        x: [number, number];     // [0, maxX]
+        y: [number, number];     // [0, max(bar power, recorded power) * headroom]
+    };
+}
+
+/**
+ * Actuals + position marker for `live` mode. Not rendered by the session-1.3
+ * spike (strip/detail only) — present here so the type surface is stable for
+ * session 3.1, which adds the high-frequency overlay.
+ */
+export interface WorkoutGraphActuals {
+    power: WorkoutGraphPoint[];     // recorded power over the ridden span (grey filled area)
+    heartrate: WorkoutGraphPoint[]; // recorded HR over the ridden span (line); may be empty
+    position: number;               // current elapsed activity time (s) — marker x & plan/actual split
+}
+
+/**
+ * Zone palette — indexed 0..7. Index 0 ('white') is uncolored; 1..7 are the
+ * existing web-ui `zoneColor` values (identical to ActivityGraph's getZoneColor
+ * thresholds). Lives in `services` once §7 #2 lands; local copy for the spike.
+ */
+export const WORKOUT_ZONE_COLORS: readonly string[] = [
+    'white',   // 0 - uncolored
+    '#7f7f7f', // 1 - grey   (<= 55% FTP)
+    '#338cff', // 2 - blue   (<= 75%)
+    '#59bf59', // 3 - green  (<= 90%)
+    '#ffcc3f', // 4 - yellow (<= 105%)
+    '#ff6639', // 5 - orange (<= 120%)
+    '#ff330c', // 6 - red    (<= 150%)
+    '#ea39ff', // 7 - magenta(> 150%)
+];
+
+/** Props for the pure, presized WorkoutGraphView (SVG renderer). */
+export interface WorkoutGraphViewProps {
+    width: number;
+    height: number;
+    mode: WorkoutGraphMode;
+    plan: WorkoutGraphPlan;
+    /** live-mode overlay — ignored by strip/detail (session 3.1). */
+    actuals?: WorkoutGraphActuals | null;
+    /** Override axis visibility. Defaults: strip=false, detail=true. */
+    showAxes?: boolean;
+    /** Override FTP reference line. Defaults: strip=false, detail=true. */
+    showFtpLine?: boolean;
+    axisFontSize?: number;
+    style?: StyleProp<ViewStyle>;
+}
+
+/** Props for the smart WorkoutGraph wrapper (measures its own width/height). */
+export interface WorkoutGraphProps {
+    mode: WorkoutGraphMode;
+    plan: WorkoutGraphPlan;
+    actuals?: WorkoutGraphActuals | null;
+    showAxes?: boolean;
+    showFtpLine?: boolean;
+    /** Fixed height (e.g. strip rows). When omitted the wrapper measures it. */
+    height?: number;
+    style?: StyleProp<ViewStyle>;
+}

--- a/src/components/WorkoutGraph/utils.ts
+++ b/src/components/WorkoutGraph/utils.ts
@@ -1,0 +1,32 @@
+import { WORKOUT_ZONE_COLORS, WorkoutGraphPlanBar } from './types';
+
+/**
+ * Linear map of a domain value into a pixel coordinate. Identical contract to
+ * ActivityGraph's domainToPixel — duplicated locally to keep the WorkoutGraph
+ * spike self-contained; a shared graph-utils extraction is out of scope here.
+ */
+export const domainToPixel = (
+    value: number,
+    domainMin: number,
+    domainMax: number,
+    pixelMin: number,
+    pixelMax: number
+): number => {
+    if (domainMax === domainMin) return pixelMin;
+    return pixelMin + ((value - domainMin) / (domainMax - domainMin)) * (pixelMax - pixelMin);
+};
+
+/** Resolve a bar's zone index to a fill color, clamping out-of-range indices. */
+export const zoneFill = (zone: number): string => {
+    if (!Number.isFinite(zone) || zone < 1 || zone >= WORKOUT_ZONE_COLORS.length) {
+        return WORKOUT_ZONE_COLORS[1]; // fall back to grey rather than 'white'
+    }
+    return WORKOUT_ZONE_COLORS[zone];
+};
+
+/**
+ * Derive the y-domain top from the bars when the caller hasn't supplied one
+ * (defensive — the service always sets domain.y, but stories/tests may not).
+ */
+export const maxBarPower = (bars: WorkoutGraphPlanBar[]): number =>
+    bars.reduce((m, b) => Math.max(m, b.y), 0);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -15,6 +15,7 @@ export type * from './NavigationBar/types'
 export * from './Icon';
 export * from './Dynamic'
 export * from './ElevationGraph'
+export * from './WorkoutGraph'
 export * from './RideDashboard'
 export * from './Video'
 export * from './StartRideDisplay'


### PR DESCRIPTION
## Summary

Session 1.3 of the mobile workout feature — an RN-compatible `WorkoutGraph` spike replacing web-ui's `react-vis` graph (which doesn't run in React Native). Renders pre-generated zone-colored `WorkoutGraphPlanBar[]` data; the zone-coloring math is a separate, already-resolved `services` concern (session 2.2). Scope here is **`strip`** (list-row thumbnail) and **`detail`** (full + FTP line) modes; `live` mode is deferred to session 3.1.

**No new library** — `react-native-svg` (^15.15.3) is already a dependency, matching the existing `ActivityGraph`/`ElevationGraph` precedent.

## What changed

- **`src/components/WorkoutGraph/`** (new)
  - `WorkoutGraphView` — pure, presized, `React.memo`'d SVG renderer. One `<Rect>` per plan bar (handles single-value `y0=0` and banded ramp `y0>0` steps). `detail` adds a dashed FTP reference line + light axes.
  - Static bars isolated in a separately-memoized `PlanBars` layer keyed on the `plan` reference, so the future 1 Hz `live` overlay (3.1) won't re-reconcile them.
  - `WorkoutGraph` — smart `onLayout` wrapper.
  - Data shapes mirror `workout-ride-page-service-design.md` §3.1 verbatim, defined locally until `getWorkoutGraphSeries()` lands (session 2.2), then swapped for an `incyclist-services` import.
  - Hand-authored mock data, Storybook stories, view unit tests.
- **`ActivityGraphView.tsx`** — flatten the `<Svg>` style array. Same regression the WorkoutGraph fix addresses: React 19's stricter DOM renderer rejects the nested array react-native-svg's web `<Svg>` builds from an array `style` prop (`Indexed property setter is not supported`); React 18 tolerated it. Exposed by this branch's react 18→19 / react-native-web 0.19→0.21 upgrade. `ElevationGraphView` uses `StyleSheet.absoluteFill` (a plain object) and needs no fix.

## Test plan

- `npx jest src/components/WorkoutGraph src/components/ActivityGraph` — 18 tests green (incl. one-`<Rect>`-per-bar assertion).
- `npx eslint` + `tsc --noEmit` clean on changed files.
- Storybook: `Components/WorkoutGraph` renders `strip`/`detail`/in-list-row; `Components/ActivityGraph` renders again (was crashing under React 19).

## Notes

- Design note lives at `mobile/internal/designs/workout-graph-component-design.md` (gitignored, not in this PR) — covers the SVG approach, rejected alternatives, and 1 Hz `live`-mode performance characteristics.
- `live` mode, actuals overlay + position marker, and actuals downsampling are deferred to session 3.1.