### PR TITLE
WorkoutGraph: live mode with Power/Heartrate overlay and dual axes

### DIFF
--- a/src/components/WorkoutGraph/WorkoutGraph.mock.ts
+++ b/src/components/WorkoutGraph/WorkoutGraph.mock.ts
@@ -76,7 +76,7 @@ export const MOCK_ACTUALS: WorkoutGraphActuals = {
 const buildActualPower = (bars: WorkoutGraphPlanBar[], endTime: number, stepSec = 15) => {
     const points: { x: number; y: number }[] = [];
     for (let t = 0; t <= endTime; t += stepSec) {
-        const bar = bars.find(b => t >= b.x0 && t < b.x) ?? bars[bars.length - 1];
+        const bar = bars.find(b => t >= b.x0 && t < b.x) ?? bars.at(-1)!;
         const target = bar.y0 > 0 ? (bar.y0 + bar.y) / 2 : bar.y;
         const jitter = Math.round(Math.sin(t / 45) * 12 + Math.cos(t / 17) * 6);
         points.push({ x: t, y: Math.max(0, target - 10 + jitter) });

--- a/src/components/WorkoutGraph/WorkoutGraph.stories.tsx
+++ b/src/components/WorkoutGraph/WorkoutGraph.stories.tsx
@@ -10,7 +10,7 @@ import {
     MOCK_ACTUALS_NO_HRM,
     MOCK_PLAN_LIVE_SKIPBACK,
     MOCK_ACTUALS_SKIPBACK,
-} from './mockData';
+} from './WorkoutGraph.mock';
 import { colors } from '../../theme/colors';
 
 /**

--- a/src/components/WorkoutGraph/WorkoutGraph.stories.tsx
+++ b/src/components/WorkoutGraph/WorkoutGraph.stories.tsx
@@ -2,14 +2,31 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { WorkoutGraphView } from './WorkoutGraphView';
-import { MOCK_PLAN, MOCK_PLAN_SHORT } from './mockData';
+import {
+    MOCK_PLAN,
+    MOCK_PLAN_SHORT,
+    MOCK_PLAN_LIVE_MID,
+    MOCK_ACTUALS_MID,
+    MOCK_ACTUALS_NO_HRM,
+    MOCK_PLAN_LIVE_SKIPBACK,
+    MOCK_ACTUALS_SKIPBACK,
+} from './mockData';
 import { colors } from '../../theme/colors';
 
 /**
- * Session-1.3 spike stories. Proves the SVG rendering approach across the two
- * modes in scope: `strip` (list-row thumbnail — bars only, no FTP line, no axes)
- * and `detail` (full — bars + FTP reference line + light axes). `live` mode is
- * deferred to session 3.1.
+ * Proves the SVG rendering approach across all 3 modes: `strip` (list-row
+ * thumbnail — bars only, no FTP line, no axes), `detail` (full — bars + FTP
+ * reference line + light axes), and `live` (ride screen — full-workout bars
+ * with the recorded Power/HR overlay + position marker on top, session 3.1).
+ *
+ * The three `live` stories exist to verify specific behaviors: `Live` is a
+ * mid-workout snapshot where the current workout still equals the pristine
+ * plan; `LiveAfterSkipBack` is the *same* workout after a skip-back
+ * re-inserted a step — `domain.x` visibly grows (compare the trailing x-axis
+ * tick: 35:00 vs 40:00, workout-ride-page-service-design.md §3.0/§3.1) and
+ * the first 9 bars are untouched, proving old bars aren't lost;
+ * `LiveNoHeartRateMonitor` has no HR data at all, verifying the Heartrate
+ * line/axis/legend all disappear cleanly rather than rendering broken.
  *
  * Stories drive the pure WorkoutGraphView with explicit pixel sizes (the smart
  * WorkoutGraph wrapper's onLayout measurement doesn't resolve under the
@@ -69,6 +86,57 @@ export const DetailLowIntensity: Story = {
         plan: MOCK_PLAN_SHORT,
         width: 360,
         height: 200,
+    },
+};
+
+/** live mode, mid-workout — full-workout bars with the recorded Power/HR overlay + position marker on top. */
+export const Live: Story = {
+    args: {
+        mode: 'live',
+        plan: MOCK_PLAN_LIVE_MID,
+        actuals: MOCK_ACTUALS_MID,
+        width: 360,
+        height: 200,
+        showAxes: true,
+        showFtpLine: true,        
+    },
+};
+
+/**
+ * live mode, after a skip-back — same workout as `Live` above, but the rider
+ * repeated the last VO2 on/off pair. `domain.x` grows [0,2100] -> [0,2400]
+ * (compare the x-axis's last tick against `Live`), the re-inserted bars sit at
+ * x=1800..2100, and `position` (2250) — past the pristine plan's old end —
+ * only fits because the domain grew with it.
+ */
+export const LiveAfterSkipBack: Story = {
+    args: {
+        mode: 'live',
+        plan: MOCK_PLAN_LIVE_SKIPBACK,
+        actuals: MOCK_ACTUALS_SKIPBACK,
+        width: 360,
+        height: 200,
+        showAxes: true,
+        showFtpLine: true,
+    },
+};
+
+/**
+ * live mode, no HRM paired — not every rider rides with a heart-rate monitor.
+ * Same mid-workout snapshot as `Live`, but `actuals.heartrate` is empty: the
+ * Heartrate line, its yellow right-side axis, and its legend entry must all
+ * disappear cleanly, while the Power line/axis and legend keep working on
+ * their own — nothing should render as broken, empty, or zeroed-out.
+ */
+export const LiveNoHeartRateMonitor: Story = {
+    args: {
+        mode: 'live',
+        plan: MOCK_PLAN_LIVE_MID,
+        actuals: MOCK_ACTUALS_NO_HRM,
+        width: 360,
+        height: 200,
+        showAxes: true,
+        showFtpLine: true,
     },
 };
 

--- a/src/components/WorkoutGraph/WorkoutGraphView.test.tsx
+++ b/src/components/WorkoutGraph/WorkoutGraphView.test.tsx
@@ -10,7 +10,7 @@ import {
     MOCK_PLAN_LIVE_SKIPBACK,
     MOCK_ACTUALS_SKIPBACK,
 } from './WorkoutGraph.mock';
-import type { WorkoutGraphPlan } from './types';
+import type { WorkoutGraphPlan, WorkoutGraphActuals } from './types';
 
 const countByType = (root: ReturnType<typeof render>['UNSAFE_root'], match: string) =>
     root.findAll(node => typeof node.type === 'string' && node.type.includes(match)).length;
@@ -251,6 +251,52 @@ describe('WorkoutGraphView', () => {
                 <WorkoutGraphView mode="strip" plan={MOCK_PLAN} width={350} height={44} />
             );
             expect(countByType(UNSAFE_root, 'Line')).toBe(0);
+        });
+    });
+
+    describe('actuals downsampling (long-ride performance)', () => {
+        // ~1 Hz activity.logs over a full hour — workout-graph-component-design.md
+        // §5 point 2 / §6 requires the Power/HR <Path>s stay bounded to ≤ plotWidth
+        // points regardless of ride length, so the 1 Hz live-update path stays cheap.
+        const longPlan: WorkoutGraphPlan = {
+            bars: [{ x0: 0, x: 3600, y: 250, y0: 0, zone: 3 }],
+            ftp: 230,
+            ftpLine: 230,
+            domain: { x: [0, 3600], y: [0, 300] },
+        };
+        const longActuals: WorkoutGraphActuals = {
+            power: Array.from({ length: 3600 }, (_, t) => ({ x: t, y: 150 + Math.round(Math.sin(t / 90) * 60) })),
+            heartrate: Array.from({ length: 3600 }, (_, t) => ({ x: t, y: 130 + Math.round((t / 3600) * 40) })),
+            position: 3599,
+        };
+
+        it('bounds the Power/HR <Path> point count to the plot width, not the raw sample count', () => {
+            const { UNSAFE_root } = render(
+                <WorkoutGraphView mode="live" plan={longPlan} actuals={longActuals} width={360} height={200} />
+            );
+            const paths = UNSAFE_root.findAll(node => typeof node.type === 'string' && node.type.includes('Path'));
+            expect(paths.length).toBe(2); // Power line + HR line — no filled areas, no per-sample nodes
+
+            paths.forEach((p) => {
+                const d = p.props.d as string;
+                const pointCount = (d.match(/[ML]/g) ?? []).length;
+                // width=360 leaves a plotWidth well under 360 once margins are
+                // subtracted — 3600 raw samples must not reach the path untouched.
+                expect(pointCount).toBeLessThanOrEqual(360);
+                expect(pointCount).toBeLessThan(longActuals.power.length);
+            });
+        });
+
+        it('still lets a short ride through unbucketed (no unnecessary averaging error)', () => {
+            const { UNSAFE_root } = render(
+                <WorkoutGraphView mode="live" plan={MOCK_PLAN_LIVE_MID} actuals={MOCK_ACTUALS_MID} width={360} height={200} />
+            );
+            const paths = UNSAFE_root.findAll(node => typeof node.type === 'string' && node.type.includes('Path'));
+            const powerPath = paths[0].props.d as string;
+            const powerPointCount = (powerPath.match(/[ML]/g) ?? []).length;
+            // MOCK_ACTUALS_MID has well under plotWidth samples (~70 at a 15s
+            // interval) — downsampling must be a no-op here, not lossy by default.
+            expect(powerPointCount).toBe(MOCK_ACTUALS_MID.power.length);
         });
     });
 });

--- a/src/components/WorkoutGraph/WorkoutGraphView.test.tsx
+++ b/src/components/WorkoutGraph/WorkoutGraphView.test.tsx
@@ -9,7 +9,7 @@ import {
     MOCK_ACTUALS_NO_HRM,
     MOCK_PLAN_LIVE_SKIPBACK,
     MOCK_ACTUALS_SKIPBACK,
-} from './mockData';
+} from './WorkoutGraph.mock';
 import type { WorkoutGraphPlan } from './types';
 
 const countByType = (root: ReturnType<typeof render>['UNSAFE_root'], match: string) =>

--- a/src/components/WorkoutGraph/WorkoutGraphView.test.tsx
+++ b/src/components/WorkoutGraph/WorkoutGraphView.test.tsx
@@ -1,8 +1,19 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import { WorkoutGraphView } from './WorkoutGraphView';
-import { MOCK_PLAN, MOCK_PLAN_SHORT } from './mockData';
+import {
+    MOCK_PLAN,
+    MOCK_PLAN_SHORT,
+    MOCK_PLAN_LIVE_MID,
+    MOCK_ACTUALS_MID,
+    MOCK_ACTUALS_NO_HRM,
+    MOCK_PLAN_LIVE_SKIPBACK,
+    MOCK_ACTUALS_SKIPBACK,
+} from './mockData';
 import type { WorkoutGraphPlan } from './types';
+
+const countByType = (root: ReturnType<typeof render>['UNSAFE_root'], match: string) =>
+    root.findAll(node => typeof node.type === 'string' && node.type.includes(match)).length;
 
 const EMPTY_PLAN: WorkoutGraphPlan = {
     bars: [],
@@ -63,5 +74,183 @@ describe('WorkoutGraphView', () => {
             />
         );
         expect(toJSON()).not.toBeNull();
+    });
+
+    describe('live mode', () => {
+        it('renders the recorded Power line, HR line and position marker on top of the plan bars', () => {
+            const { UNSAFE_root } = render(
+                <WorkoutGraphView
+                    mode="live"
+                    plan={MOCK_PLAN_LIVE_MID}
+                    actuals={MOCK_ACTUALS_MID}
+                    width={360}
+                    height={200}
+                />
+            );
+            // one Rect per plan bar (whole current workout) plus the overlay's
+            // Path (power area + HR line) and Circle (position marker) — proves
+            // the overlay is additive, not a replacement of the bars.
+            expect(countByType(UNSAFE_root, 'Rect')).toBe(MOCK_PLAN_LIVE_MID.bars.length);
+            expect(countByType(UNSAFE_root, 'Path')).toBeGreaterThanOrEqual(2);
+            expect(countByType(UNSAFE_root, 'Circle')).toBe(1);
+        });
+
+        it('does not suppress or grey out the already-ridden bars', () => {
+            const withActuals = render(
+                <WorkoutGraphView
+                    mode="live"
+                    plan={MOCK_PLAN_LIVE_MID}
+                    actuals={MOCK_ACTUALS_MID}
+                    width={360}
+                    height={200}
+                />
+            );
+            const withoutActuals = render(
+                <WorkoutGraphView mode="live" plan={MOCK_PLAN_LIVE_MID} width={360} height={200} />
+            );
+            // the bar count (and thus the bars themselves) is identical whether
+            // or not actuals are present — the ridden span is never removed.
+            expect(countByType(withActuals.UNSAFE_root, 'Rect')).toBe(
+                countByType(withoutActuals.UNSAFE_root, 'Rect')
+            );
+        });
+
+        it('renders bars only (no overlay) when actuals are absent', () => {
+            const { UNSAFE_root } = render(
+                <WorkoutGraphView mode="live" plan={MOCK_PLAN_LIVE_MID} width={360} height={200} />
+            );
+            expect(countByType(UNSAFE_root, 'Rect')).toBe(MOCK_PLAN_LIVE_MID.bars.length);
+            expect(countByType(UNSAFE_root, 'Circle')).toBe(0);
+        });
+
+        it('ignores actuals for non-live modes', () => {
+            const { UNSAFE_root } = render(
+                <WorkoutGraphView
+                    mode="detail"
+                    plan={MOCK_PLAN_LIVE_MID}
+                    actuals={MOCK_ACTUALS_MID}
+                    width={360}
+                    height={200}
+                />
+            );
+            expect(countByType(UNSAFE_root, 'Circle')).toBe(0);
+        });
+
+        it('renders a domain that grew after a skip-back without dropping the untouched bars', () => {
+            const { UNSAFE_root } = render(
+                <WorkoutGraphView
+                    mode="live"
+                    plan={MOCK_PLAN_LIVE_SKIPBACK}
+                    actuals={MOCK_ACTUALS_SKIPBACK}
+                    width={360}
+                    height={200}
+                />
+            );
+            expect(MOCK_PLAN_LIVE_SKIPBACK.domain.x[1]).toBeGreaterThan(MOCK_PLAN_LIVE_MID.domain.x[1]);
+            // first 9 bars (warmup .. 3rd VO2 "off") are byte-identical to the
+            // pristine plan — the skip-back only edited the tail.
+            expect(MOCK_PLAN_LIVE_SKIPBACK.bars.slice(0, 9)).toEqual(MOCK_PLAN_LIVE_MID.bars.slice(0, 9));
+            expect(countByType(UNSAFE_root, 'Rect')).toBe(MOCK_PLAN_LIVE_SKIPBACK.bars.length);
+            // position (2250) is past the pristine plan's old domain end (2100) —
+            // only renders because the marker checks against the GROWN domain.
+            expect(MOCK_ACTUALS_SKIPBACK.position).toBeGreaterThan(MOCK_PLAN_LIVE_MID.domain.x[1]);
+            expect(countByType(UNSAFE_root, 'Circle')).toBe(1);
+        });
+
+        it('renders a Power/Heartrate color legend so the two lines are identifiable', () => {
+            const { toJSON } = render(
+                <WorkoutGraphView
+                    mode="live"
+                    plan={MOCK_PLAN_LIVE_MID}
+                    actuals={MOCK_ACTUALS_MID}
+                    width={360}
+                    height={200}
+                />
+            );
+            const rendered = JSON.stringify(toJSON());
+            expect(rendered).toContain('Power');
+            expect(rendered).toContain('Heartrate');
+        });
+
+        it('omits the Heartrate legend entry when there is no HR data', () => {
+            const { toJSON } = render(
+                <WorkoutGraphView
+                    mode="live"
+                    plan={MOCK_PLAN_LIVE_MID}
+                    actuals={MOCK_ACTUALS_NO_HRM}
+                    width={360}
+                    height={200}
+                />
+            );
+            const rendered = JSON.stringify(toJSON());
+            expect(rendered).toContain('Power');
+            expect(rendered).not.toContain('Heartrate');
+        });
+
+        it('defaults axes ON (unlike strip/detail) so a caller gets a readable graph without opting in', () => {
+            const { toJSON } = render(
+                <WorkoutGraphView mode="live" plan={MOCK_PLAN_LIVE_MID} actuals={MOCK_ACTUALS_MID} width={360} height={200} />
+            );
+            // x-axis time ticks are only drawn when axes are on (formatTime output, e.g. "0:00")
+            expect(JSON.stringify(toJSON())).toContain('0:00');
+        });
+
+        it('renders a Heartrate bpm axis (right side) when HR data is present, sharing scale with the line', () => {
+            const { toJSON } = render(
+                <WorkoutGraphView mode="live" plan={MOCK_PLAN_LIVE_MID} actuals={MOCK_ACTUALS_MID} width={360} height={200} />
+            );
+            // The HR axis's middle tick is the midpoint of the padded HR domain, which
+            // (symmetric padding) equals the midpoint of the raw recorded range — assert
+            // that exact rendered value is present, proving the axis reflects real HR data
+            // rather than the Power/Watt domain.
+            const hrValues = MOCK_ACTUALS_MID.heartrate.map(p => p.y);
+            const hrMidRounded = Math.round((Math.min(...hrValues) + Math.max(...hrValues)) / 2);
+            const rendered = JSON.stringify(toJSON());
+            expect(rendered).toContain(`"content":"${hrMidRounded}"`);
+        });
+
+        it('omits the Heartrate axis when there is no HR data, without breaking the rest of the graph', () => {
+            const { toJSON } = render(
+                <WorkoutGraphView
+                    mode="live"
+                    plan={MOCK_PLAN_LIVE_MID}
+                    actuals={MOCK_ACTUALS_NO_HRM}
+                    width={360}
+                    height={200}
+                />
+            );
+            expect(toJSON()).not.toBeNull();
+        });
+
+        it('drops exactly the HR axis line/ticks/legend swatch (5 Lines) when there is no HR data', () => {
+            const withHr = render(
+                <WorkoutGraphView mode="live" plan={MOCK_PLAN_LIVE_MID} actuals={MOCK_ACTUALS_MID} width={360} height={200} />
+            );
+            const withoutHr = render(
+                <WorkoutGraphView mode="live" plan={MOCK_PLAN_LIVE_MID} actuals={MOCK_ACTUALS_NO_HRM} width={360} height={200} />
+            );
+            // HR axis = 1 axis line + 3 ticks; legend swatch = 1 more line — everything
+            // else (Power axis, x-axis, FTP line, position marker) is unaffected by HR
+            // presence, so the count difference should be exactly this HR-only set.
+            expect(countByType(withHr.UNSAFE_root, 'Line') - countByType(withoutHr.UNSAFE_root, 'Line')).toBe(5);
+        });
+    });
+
+    describe('axis lines and ticks', () => {
+        it('draws a visible axis line + tick marks for the Power (left) and time (bottom) axes when enabled', () => {
+            const { UNSAFE_root } = render(
+                <WorkoutGraphView mode="detail" plan={MOCK_PLAN} width={360} height={200} />
+            );
+            // left axis: 1 line + 3 ticks; bottom axis: 1 line + 4 ticks = 9 Lines
+            // minimum (detail mode also draws the FTP dashed Line, so >= not ===).
+            expect(countByType(UNSAFE_root, 'Line')).toBeGreaterThanOrEqual(9);
+        });
+
+        it('draws no axis lines/ticks when axes are off (strip mode default)', () => {
+            const { UNSAFE_root } = render(
+                <WorkoutGraphView mode="strip" plan={MOCK_PLAN} width={350} height={44} />
+            );
+            expect(countByType(UNSAFE_root, 'Line')).toBe(0);
+        });
     });
 });

--- a/src/components/WorkoutGraph/WorkoutGraphView.tsx
+++ b/src/components/WorkoutGraph/WorkoutGraphView.tsx
@@ -1,23 +1,63 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
-import { Svg, G, Rect, Line, Text as SvgText } from 'react-native-svg';
-import type { WorkoutGraphViewProps, WorkoutGraphPlan } from './types';
-import { domainToPixel, zoneFill } from './utils';
+import { Svg, G, Rect, Line, Circle, Path, Text as SvgText } from 'react-native-svg';
+import type { WorkoutGraphViewProps, WorkoutGraphPlan, WorkoutGraphActuals } from './types';
+import { domainToPixel, zoneFill, computeHrDomain } from './utils';
 import { colors } from '../../theme';
+
+// Plain lines, not filled areas — a filled grey/white area under a baseline is
+// exactly ElevationGraph's visual language elsewhere in this app (mountain
+// profile), and workout-only rides have no elevation. A filled Power area
+// reads as "this is the elevation" at a glance, which is actively wrong here.
+// Mirrors the web reference (WorkoutRideGraph.jsx): plain LineSeries for both.
+const ACTUAL_POWER_COLOR = colors.text; // white, matches web's Power line
+const ACTUAL_HEARTRATE_COLOR = '#ffd400'; // yellow, matches web's Heartrate line
+// Deliberately not reused from any zone color or the two line colors above —
+// stands apart from bars/lines/legend so the "where am I" marker never blends in.
+const POSITION_MARKER_COLOR = '#00e5ff';
+
+// Tick marks anchor axis numbers to a visible ruler — floating text alone
+// (the previous approach) is too easy to miss against a busy, colorful chart.
+const TICK_LEN = 4;
+const AXIS_OPACITY = 0.6;
+
+/**
+ * IMPORTANT: every coordinate in this file is in the `<Svg>`'s own absolute
+ * pixel space, offset by `offsetX`/`offsetY` (= the reserved margins.left/top)
+ * added in directly — NOT nested inside a `<G translate="x, y">`. That was
+ * the previous approach, and it silently failed under this project's
+ * Storybook/web renderer: `translate` on `<G>` came out as a literal,
+ * non-standard `translate="x, y"` XML attribute rather than a
+ * `transform="translate(x,y)"`, so browsers ignored it — every child kept
+ * rendering at its raw, untranslated coordinate. Anything with a
+ * non-negative relative coordinate (the bars, the FTP line, the right/bottom
+ * axes) still happened to land inside the visible canvas, just not where
+ * intended; anything with a negative relative coordinate (the left axis's
+ * ticks/labels, the legend, both meant to sit in the reserved margin) fell
+ * outside the `<svg>`'s own default-clipped viewport and simply never
+ * rendered. Confirmed by inspecting the real rendered DOM in a browser.
+ * Baking the offset into plain arithmetic sidesteps the whole question of
+ * whether any given renderer honors the `translate` shorthand.
+ */
 
 /**
  * Static zone-bar layer. Split into its own memoized component so that when the
- * live overlay (session 3.1) re-renders at 1 Hz, these bars — which only change
- * on skip/load events — are skipped by React reconciliation entirely. Keyed on
- * the `plan` reference + plot size; the service delivers a fresh `plan` object
- * only when the bars actually change (on `page-update`), never per telemetry tick.
+ * `live`-mode `ActualsOverlay` (below) re-renders at 1 Hz, these bars — which
+ * only change on skip/load events — are skipped by React reconciliation
+ * entirely. Keyed on the `plan` reference + plot size; the service delivers a
+ * fresh `plan` object only when the bars actually change (on `page-update`),
+ * never per telemetry tick.
  */
 const PlanBars = React.memo(({
     plan,
+    offsetX,
+    offsetY,
     plotWidth,
     plotHeight,
 }: {
     plan: WorkoutGraphPlan;
+    offsetX: number;
+    offsetY: number;
     plotWidth: number;
     plotHeight: number;
 }) => {
@@ -27,10 +67,10 @@ const PlanBars = React.memo(({
     return (
         <>
             {plan.bars.map((bar) => {
-                const left = domainToPixel(bar.x0, xMin, xMax, 0, plotWidth);
-                const right = domainToPixel(bar.x, xMin, xMax, 0, plotWidth);
-                const top = domainToPixel(bar.y, yMin, yMax, plotHeight, 0);
-                const bottom = domainToPixel(bar.y0, yMin, yMax, plotHeight, 0);
+                const left = offsetX + domainToPixel(bar.x0, xMin, xMax, 0, plotWidth);
+                const right = offsetX + domainToPixel(bar.x, xMin, xMax, 0, plotWidth);
+                const top = offsetY + domainToPixel(bar.y, yMin, yMax, plotHeight, 0);
+                const bottom = offsetY + domainToPixel(bar.y0, yMin, yMax, plotHeight, 0);
                 const w = Math.max(0.5, right - left);
                 const h = Math.max(0.5, bottom - top);
                 // Stable key from the bar's time span (each bar is a unique,
@@ -51,6 +91,131 @@ const PlanBars = React.memo(({
     );
 });
 
+/**
+ * `live`-mode overlay: recorded Power (line) + Heartrate (line) + a position
+ * marker, drawn ON TOP of the already-rendered, full-workout `PlanBars` —
+ * never instead of them (§3.1 of the ride-page-service design: the ridden
+ * bars stay visible, they are not greyed out or suppressed).
+ *
+ * Both series are plain strokes, not filled areas — see the color-constants
+ * comment above for why a fill is deliberately avoided.
+ *
+ * Shares the plan's x/y domain with `PlanBars` (elapsed activity time,
+ * absolute Watts) so the recorded telemetry lines up exactly with the bars —
+ * the current workout and the logs are both on the same elapsed-time axis.
+ * Heartrate uses `hrDomain` (bpm has no relation to the Watt domain) —
+ * mirrors web-ui's dual-axis `WorkoutRideGraph`. `hrDomain` is computed once
+ * by the parent (`computeHrDomain`) and passed in so the line here and the
+ * dedicated HR axis (`renderHrAxis`, in the parent) always agree on scale.
+ *
+ * Kept as its own memoized component (default shallow-prop React.memo, same
+ * as `PlanBars`) so the 1 Hz `actuals` updates never force `PlanBars` — which
+ * only changes on skip/load events — to re-render.
+ */
+const ActualsOverlay = React.memo(({
+    actuals,
+    domain,
+    hrDomain,
+    offsetX,
+    offsetY,
+    plotWidth,
+    plotHeight,
+}: {
+    actuals: WorkoutGraphActuals;
+    domain: WorkoutGraphPlan['domain'];
+    hrDomain: [number, number] | null;
+    offsetX: number;
+    offsetY: number;
+    plotWidth: number;
+    plotHeight: number;
+}) => {
+    const [xMin, xMax] = domain.x;
+    const [yMin, yMax] = domain.y;
+
+    const powerRaw = actuals.power.filter(p => Number.isFinite(p.x) && Number.isFinite(p.y));
+    let powerLine = null;
+    if (powerRaw.length >= 2) {
+        const points = powerRaw.map(p => ({
+            x: offsetX + domainToPixel(p.x, xMin, xMax, 0, plotWidth),
+            y: offsetY + domainToPixel(p.y, yMin, yMax, plotHeight, 0),
+        }));
+        const path = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ');
+        powerLine = <Path d={path} fill="none" stroke={ACTUAL_POWER_COLOR} strokeWidth={1.75} />;
+    }
+
+    const hrRaw = actuals.heartrate.filter(p => Number.isFinite(p.x) && Number.isFinite(p.y));
+    let hrLine = null;
+    if (hrRaw.length >= 2 && hrDomain) {
+        const [dMin, dMax] = hrDomain;
+        const points = hrRaw.map(p => ({
+            x: offsetX + domainToPixel(p.x, xMin, xMax, 0, plotWidth),
+            y: offsetY + domainToPixel(p.y, dMin, dMax, plotHeight, 0),
+        }));
+        const path = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ');
+        hrLine = <Path d={path} fill="none" stroke={ACTUAL_HEARTRATE_COLOR} strokeWidth={1.5} />;
+    }
+
+    let marker = null;
+    if (Number.isFinite(actuals.position) && actuals.position >= xMin && actuals.position <= xMax) {
+        const mx = offsetX + domainToPixel(actuals.position, xMin, xMax, 0, plotWidth);
+        marker = (
+            <G>
+                <Line x1={mx} y1={offsetY} x2={mx} y2={offsetY + plotHeight} stroke={POSITION_MARKER_COLOR} strokeWidth={1.5} strokeDasharray="3 3" />
+                <Circle cx={mx} cy={offsetY} r={3.5} fill={POSITION_MARKER_COLOR} />
+            </G>
+        );
+    }
+
+    return (
+        <>
+            {powerLine}
+            {hrLine}
+            {marker}
+        </>
+    );
+});
+
+/**
+ * Top-of-plot color legend for `live` mode — "Power" / "Heartrate" labels,
+ * each colored to match its line (not a neutral color) — that color match IS
+ * the identification mechanism, so getting this right matters more here than
+ * anywhere else in the component. A same-colored swatch is added in front of
+ * each label purely as reinforcement. Heartrate is omitted when there's no HR
+ * data yet (matches web, which also hides its Heartrate chip when empty).
+ */
+const ActualsLegend = ({
+    hasHr,
+    axisFontSize,
+    offsetX,
+    offsetY,
+}: {
+    hasHr: boolean;
+    axisFontSize: number;
+    offsetX: number;
+    offsetY: number;
+}) => {
+    const fontSize = axisFontSize + 1;
+    const swatchLen = 12;
+    const y = offsetY - 11;
+    const x0 = offsetX;
+    return (
+        <G>
+            <Line x1={x0} y1={y} x2={x0 + swatchLen} y2={y} stroke={ACTUAL_POWER_COLOR} strokeWidth={3} />
+            <SvgText x={x0 + swatchLen + 4} y={y + 4} fill={ACTUAL_POWER_COLOR} fontSize={fontSize} fontWeight="700">
+                Power
+            </SvgText>
+            {hasHr && (
+                <G>
+                    <Line x1={x0 + 74} y1={y} x2={x0 + 74 + swatchLen} y2={y} stroke={ACTUAL_HEARTRATE_COLOR} strokeWidth={3} />
+                    <SvgText x={x0 + 74 + swatchLen + 4} y={y + 4} fill={ACTUAL_HEARTRATE_COLOR} fontSize={fontSize} fontWeight="700">
+                        Heartrate
+                    </SvgText>
+                </G>
+            )}
+        </G>
+    );
+};
+
 const formatTime = (sec: number): string => {
     const m = Math.floor(sec / 60);
     const s = Math.floor(sec % 60);
@@ -59,10 +224,12 @@ const formatTime = (sec: number): string => {
 
 /**
  * Pure, presized WorkoutGraph renderer. Draws the zone-colored plan bars for
- * every mode; `detail` adds an FTP reference line and light axes. `live`-mode
- * actuals (grey power area + HR line + position marker) are intentionally NOT
- * drawn by this spike — the prop exists so session 3.1 slots the overlay in
- * above the memoized PlanBars without touching this contract.
+ * every mode — in `live` mode these span the whole current (skip-adjusted)
+ * workout, ridden and remaining alike; `detail` adds an FTP reference line and
+ * light axes. `live` additionally overlays `actuals` (Power + HR lines +
+ * position marker, plus a color legend) on top of the bars via
+ * `ActualsOverlay`/`ActualsLegend`, without greying out or suppressing the
+ * already-ridden bars underneath.
  */
 export const WorkoutGraphView = React.memo((props: WorkoutGraphViewProps) => {
     const {
@@ -70,6 +237,7 @@ export const WorkoutGraphView = React.memo((props: WorkoutGraphViewProps) => {
         height,
         mode,
         plan,
+        actuals,
         showAxes,
         showFtpLine,
         axisFontSize = 10,
@@ -79,32 +247,48 @@ export const WorkoutGraphView = React.memo((props: WorkoutGraphViewProps) => {
     if (width <= 0 || height <= 0 || !plan) return null;
 
     const isDetail = mode === 'detail';
-    const axes = showAxes ?? isDetail;
+    const isLive = mode === 'live';
+    // Live defaults axes ON (unlike strip/detail's isDetail-only default): this is
+    // the dominant, most information-dense mode (HLD §5), and "can I read an actual
+    // value off this graph" is the whole point of the axes — silently defaulting them
+    // off would leave every live-mode caller unreadable unless it remembers to opt in.
+    const axes = showAxes ?? (isDetail || isLive);
     const ftpLine = showFtpLine ?? isDetail;
+    const showLegend = isLive && !!actuals;
+    // Bpm has no relation to the plan's Watt-based y-domain, so Heartrate gets its
+    // own axis (right side, colored to match its line) — computed once here and
+    // shared with ActualsOverlay so the line and its axis always agree on scale.
+    const hrDomain = isLive ? computeHrDomain(actuals?.heartrate ?? []) : null;
+    const showHrAxis = axes && !!hrDomain;
 
     const margins = {
-        top: axes ? 8 : 0,
-        bottom: axes ? 20 : 0,
-        left: axes ? 34 : 0,
-        right: axes ? 6 : 0,
+        top: (axes ? 8 : 0) + (showLegend ? 20 : 0),
+        bottom: axes ? 24 : 0,
+        left: axes ? 36 : 0,
+        right: showHrAxis ? 36 : (axes ? 8 : 0),
     };
 
     const plotWidth = width - margins.left - margins.right;
     const plotHeight = height - margins.top - margins.bottom;
     if (plotWidth <= 0 || plotHeight <= 0) return null;
 
+    // Baked into every coordinate below instead of a `<G translate>` wrapper —
+    // see the file-level comment for why.
+    const offsetX = margins.left;
+    const offsetY = margins.top;
+
     const [xMin, xMax] = plan.domain.x;
     const [yMin, yMax] = plan.domain.y;
 
     const renderFtpLine = () => {
         if (!ftpLine || plan.ftpLine <= yMin || plan.ftpLine >= yMax) return null;
-        const y = domainToPixel(plan.ftpLine, yMin, yMax, plotHeight, 0);
+        const y = offsetY + domainToPixel(plan.ftpLine, yMin, yMax, plotHeight, 0);
         return (
             <G>
                 <Line
-                    x1={0}
+                    x1={offsetX}
                     y1={y}
-                    x2={plotWidth}
+                    x2={offsetX + plotWidth}
                     y2={y}
                     stroke={colors.text}
                     strokeWidth={1}
@@ -112,7 +296,7 @@ export const WorkoutGraphView = React.memo((props: WorkoutGraphViewProps) => {
                     opacity={0.7}
                 />
                 <SvgText
-                    x={plotWidth - 2}
+                    x={offsetX + plotWidth - 2}
                     y={y - 3}
                     fill={colors.text}
                     fontSize={axisFontSize}
@@ -125,20 +309,22 @@ export const WorkoutGraphView = React.memo((props: WorkoutGraphViewProps) => {
         );
     };
 
+    /** Left axis — Power/Watts scale (matches the plan bars' y-domain). */
     const renderYAxis = () => {
         if (!axes) return null;
         const ticks = [];
         const count = 3;
         for (let i = 0; i < count; i++) {
             const val = yMin + (i * (yMax - yMin)) / (count - 1);
-            const y = domainToPixel(val, yMin, yMax, plotHeight, 0);
+            const y = offsetY + domainToPixel(val, yMin, yMax, plotHeight, 0);
             let textY = y + 4;
             if (i === count - 1) textY = y + 9; // top tick sits below the line
             else if (i === 0) textY = y - 2;    // bottom tick sits above the axis
             ticks.push(
+                <Line key={`y-tick-${i}`} x1={offsetX - TICK_LEN} y1={y} x2={offsetX} y2={y} stroke={colors.text} strokeWidth={1} opacity={AXIS_OPACITY} />,
                 <SvgText
                     key={`y-${i}`}
-                    x={-4}
+                    x={offsetX - TICK_LEN - 3}
                     y={textY}
                     fill={colors.text}
                     fontSize={axisFontSize}
@@ -149,24 +335,72 @@ export const WorkoutGraphView = React.memo((props: WorkoutGraphViewProps) => {
                 </SvgText>
             );
         }
-        return ticks;
+        return (
+            <G>
+                <Line x1={offsetX} y1={offsetY} x2={offsetX} y2={offsetY + plotHeight} stroke={colors.text} strokeWidth={1} opacity={AXIS_OPACITY} />
+                {ticks}
+            </G>
+        );
     };
 
+    /**
+     * Right-side axis for the Heartrate line's bpm scale — colored to match the
+     * HR line/legend entry. This is the direct answer to "what HR did I have at
+     * time X": trace the yellow line to a height, read the yellow axis there.
+     */
+    const renderHrAxis = () => {
+        if (!showHrAxis || !hrDomain) return null;
+        const [dMin, dMax] = hrDomain;
+        const ticks = [];
+        const count = 3;
+        const axisX = offsetX + plotWidth;
+        for (let i = 0; i < count; i++) {
+            const val = dMin + (i * (dMax - dMin)) / (count - 1);
+            const y = offsetY + domainToPixel(val, dMin, dMax, plotHeight, 0);
+            let textY = y + 4;
+            if (i === count - 1) textY = y + 9;
+            else if (i === 0) textY = y - 2;
+            ticks.push(
+                <Line key={`hr-tick-${i}`} x1={axisX} y1={y} x2={axisX + TICK_LEN} y2={y} stroke={ACTUAL_HEARTRATE_COLOR} strokeWidth={1} opacity={AXIS_OPACITY} />,
+                <SvgText
+                    key={`hr-${i}`}
+                    x={axisX + TICK_LEN + 3}
+                    y={textY}
+                    fill={ACTUAL_HEARTRATE_COLOR}
+                    fontSize={axisFontSize}
+                    fontWeight="600"
+                    textAnchor="start"
+                >
+                    {`${Math.round(val)}`}
+                </SvgText>
+            );
+        }
+        return (
+            <G>
+                <Line x1={axisX} y1={offsetY} x2={axisX} y2={offsetY + plotHeight} stroke={ACTUAL_HEARTRATE_COLOR} strokeWidth={1} opacity={AXIS_OPACITY} />
+                {ticks}
+            </G>
+        );
+    };
+
+    /** Bottom axis — elapsed activity time. */
     const renderXAxis = () => {
         if (!axes || xMax <= xMin) return null;
         const ticks = [];
         const count = 4;
+        const axisY = offsetY + plotHeight;
         for (let i = 0; i < count; i++) {
             const val = xMin + (i * (xMax - xMin)) / (count - 1);
-            const x = domainToPixel(val, xMin, xMax, 0, plotWidth);
+            const x = offsetX + domainToPixel(val, xMin, xMax, 0, plotWidth);
             let textAnchor: 'start' | 'middle' | 'end' = 'middle';
             if (i === 0) textAnchor = 'start';
             else if (i === count - 1) textAnchor = 'end';
             ticks.push(
+                <Line key={`x-tick-${i}`} x1={x} y1={axisY} x2={x} y2={axisY + TICK_LEN} stroke={colors.text} strokeWidth={1} opacity={AXIS_OPACITY} />,
                 <SvgText
                     key={`x-${i}`}
                     x={x}
-                    y={plotHeight + 14}
+                    y={axisY + TICK_LEN + 10}
                     fill={colors.text}
                     fontSize={axisFontSize}
                     fontWeight="600"
@@ -176,7 +410,12 @@ export const WorkoutGraphView = React.memo((props: WorkoutGraphViewProps) => {
                 </SvgText>
             );
         }
-        return ticks;
+        return (
+            <G>
+                <Line x1={offsetX} y1={axisY} x2={offsetX + plotWidth} y2={axisY} stroke={colors.text} strokeWidth={1} opacity={AXIS_OPACITY} />
+                {ticks}
+            </G>
+        );
     };
 
     // NOTE: react-native-svg's web build (elements/Svg.js) pushes the raw `style`
@@ -187,12 +426,25 @@ export const WorkoutGraphView = React.memo((props: WorkoutGraphViewProps) => {
 
     return (
         <Svg width={width} height={height} style={svgStyle}>
-            <G translate={`${margins.left}, ${margins.top}`}>
-                <PlanBars plan={plan} plotWidth={plotWidth} plotHeight={plotHeight} />
-                {renderFtpLine()}
-                {renderYAxis()}
-                {renderXAxis()}
-            </G>
+            <PlanBars plan={plan} offsetX={offsetX} offsetY={offsetY} plotWidth={plotWidth} plotHeight={plotHeight} />
+            {isLive && actuals && (
+                <ActualsOverlay
+                    actuals={actuals}
+                    domain={plan.domain}
+                    hrDomain={hrDomain}
+                    offsetX={offsetX}
+                    offsetY={offsetY}
+                    plotWidth={plotWidth}
+                    plotHeight={plotHeight}
+                />
+            )}
+            {renderFtpLine()}
+            {renderYAxis()}
+            {renderHrAxis()}
+            {renderXAxis()}
+            {showLegend && (
+                <ActualsLegend hasHr={!!hrDomain} axisFontSize={axisFontSize} offsetX={offsetX} offsetY={offsetY} />
+            )}
         </Svg>
     );
 }, (prev, next) =>

--- a/src/components/WorkoutGraph/WorkoutGraphView.tsx
+++ b/src/components/WorkoutGraph/WorkoutGraphView.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { StyleSheet } from 'react-native';
 import { Svg, G, Rect, Line, Circle, Path, Text as SvgText } from 'react-native-svg';
 import type { WorkoutGraphViewProps, WorkoutGraphPlan, WorkoutGraphActuals } from './types';
-import { domainToPixel, zoneFill, computeHrDomain } from './utils';
+import { domainToPixel, zoneFill, computeHrDomain, downsampleToWidth } from './utils';
 import { colors } from '../../theme';
 
 // Plain lines, not filled areas — a filled grey/white area under a baseline is
@@ -98,7 +98,13 @@ const PlanBars = React.memo(({
  * bars stay visible, they are not greyed out or suppressed).
  *
  * Both series are plain strokes, not filled areas — see the color-constants
- * comment above for why a fill is deliberately avoided.
+ * comment above for why a fill is deliberately avoided. Both are also
+ * bucket-averaged to ≤ `plotWidth` points via `downsampleToWidth` before
+ * building the `<Path>` — required by `workout-graph-component-design.md`
+ * §5/§6 so the 1 Hz live-update path stays cheap regardless of ride length
+ * (raw `activity.logs` is ~1 Hz, i.e. thousands of points on a long ride).
+ * `hrDomain` (below) is still computed from the *raw*, non-downsampled data
+ * by the parent — bucket-averaging must never narrow the apparent min/max.
  *
  * Shares the plan's x/y domain with `PlanBars` (elapsed activity time,
  * absolute Watts) so the recorded telemetry lines up exactly with the bars —
@@ -132,7 +138,13 @@ const ActualsOverlay = React.memo(({
     const [xMin, xMax] = domain.x;
     const [yMin, yMax] = domain.y;
 
-    const powerRaw = actuals.power.filter(p => Number.isFinite(p.x) && Number.isFinite(p.y));
+    // Bucket-averaged to ≤ plotWidth points — activity.logs is ~1 Hz, so a long
+    // ride would otherwise hand the SVG renderer thousands of raw points on
+    // every 1 Hz tick (workout-graph-component-design.md §5 point 2 / §6).
+    const powerRaw = downsampleToWidth(
+        actuals.power.filter(p => Number.isFinite(p.x) && Number.isFinite(p.y)),
+        plotWidth
+    );
     let powerLine = null;
     if (powerRaw.length >= 2) {
         const points = powerRaw.map(p => ({
@@ -143,7 +155,10 @@ const ActualsOverlay = React.memo(({
         powerLine = <Path d={path} fill="none" stroke={ACTUAL_POWER_COLOR} strokeWidth={1.75} />;
     }
 
-    const hrRaw = actuals.heartrate.filter(p => Number.isFinite(p.x) && Number.isFinite(p.y));
+    const hrRaw = downsampleToWidth(
+        actuals.heartrate.filter(p => Number.isFinite(p.x) && Number.isFinite(p.y)),
+        plotWidth
+    );
     let hrLine = null;
     if (hrRaw.length >= 2 && hrDomain) {
         const [dMin, dMax] = hrDomain;

--- a/src/components/WorkoutGraph/WorkoutGraphView.tsx
+++ b/src/components/WorkoutGraph/WorkoutGraphView.tsx
@@ -261,11 +261,15 @@ export const WorkoutGraphView = React.memo((props: WorkoutGraphViewProps) => {
     const hrDomain = isLive ? computeHrDomain(actuals?.heartrate ?? []) : null;
     const showHrAxis = axes && !!hrDomain;
 
+    let marginRight = 0;
+    if (showHrAxis) marginRight = 36;
+    else if (axes) marginRight = 8;
+
     const margins = {
         top: (axes ? 8 : 0) + (showLegend ? 20 : 0),
         bottom: axes ? 24 : 0,
         left: axes ? 36 : 0,
-        right: showHrAxis ? 36 : (axes ? 8 : 0),
+        right: marginRight,
     };
 
     const plotWidth = width - margins.left - margins.right;

--- a/src/components/WorkoutGraph/index.ts
+++ b/src/components/WorkoutGraph/index.ts
@@ -1,7 +1,7 @@
 export * from './types';
 export * from './WorkoutGraphView';
 export * from './WorkoutGraph';
-// Note: ./utils (domainToPixel/zoneFill/maxBarPower) and ./mockData are
-// intentionally not re-exported — they are internal helpers/fixtures. This
-// mirrors ElevationGraph's barrel and keeps domainToPixel out of the shared
-// component surface (where it would clash with ActivityGraph's copy).
+// Note: ./utils (domainToPixel/zoneFill/maxBarPower) and ./WorkoutGraph.mock
+// are intentionally not re-exported — they are internal helpers/fixtures.
+// This mirrors ElevationGraph's barrel and keeps domainToPixel out of the
+// shared component surface (where it would clash with ActivityGraph's copy).

--- a/src/components/WorkoutGraph/mockData.ts
+++ b/src/components/WorkoutGraph/mockData.ts
@@ -59,11 +59,101 @@ export const MOCK_PLAN_SHORT: WorkoutGraphPlan = {
 };
 
 /**
- * Mock actuals for the (deferred) live overlay — provided now only so session
- * 3.1 has a ready shape to render. Not consumed by strip/detail.
+ * Mock actuals for the `live` overlay — a Power line + a Heartrate line,
+ * recorded up to `position`. Not consumed by strip/detail.
  */
 export const MOCK_ACTUALS: WorkoutGraphActuals = {
     power: Array.from({ length: 60 }, (_, i) => ({ x: i * 15, y: 150 + Math.round(Math.sin(i / 4) * 60) })),
     heartrate: Array.from({ length: 60 }, (_, i) => ({ x: i * 15, y: 120 + Math.round(i / 2) })),
     position: 900,
+};
+
+/**
+ * Builds a plausible recorded-power series that tracks near each bar's target
+ * (mid-band for ramps) with some jitter, standing in for real `activity.logs`
+ * samples. Used by the `live`-mode stories below.
+ */
+const buildActualPower = (bars: WorkoutGraphPlanBar[], endTime: number, stepSec = 15) => {
+    const points: { x: number; y: number }[] = [];
+    for (let t = 0; t <= endTime; t += stepSec) {
+        const bar = bars.find(b => t >= b.x0 && t < b.x) ?? bars[bars.length - 1];
+        const target = bar.y0 > 0 ? (bar.y0 + bar.y) / 2 : bar.y;
+        const jitter = Math.round(Math.sin(t / 45) * 12 + Math.cos(t / 17) * 6);
+        points.push({ x: t, y: Math.max(0, target - 10 + jitter) });
+    }
+    return points;
+};
+
+/** Builds a plausible recorded-heartrate series, gently rising over the ride. */
+const buildActualHeartrate = (endTime: number, stepSec = 15) => {
+    const points: { x: number; y: number }[] = [];
+    for (let t = 0; t <= endTime; t += stepSec) {
+        points.push({ x: t, y: Math.round(115 + (t / endTime) * 45 + Math.sin(t / 60) * 4) });
+    }
+    return points;
+};
+
+/**
+ * `live` mode, mid-workout: the current workout still equals the pristine
+ * plan (no skip has happened yet) — the rider is ~half-way through the 3x
+ * VO2 block. Exercises the "bars span the whole workout, actuals overlaid on
+ * the already-ridden span only" behavior (workout-ride-page-service-design.md
+ * §3.1).
+ */
+export const MOCK_PLAN_LIVE_MID: WorkoutGraphPlan = MOCK_PLAN;
+
+export const MOCK_ACTUALS_MID: WorkoutGraphActuals = {
+    power: buildActualPower(MOCK_BARS, 1050),
+    heartrate: buildActualHeartrate(1050),
+    position: 1050,
+};
+
+/**
+ * Same mid-workout snapshot as `MOCK_ACTUALS_MID`, but with no Heartrate data
+ * — not every rider pairs an HRM. Exercises `getGraphActuals()`'s "empty
+ * heartrate array" contract (§4.5 of the ride-page-service design): the Power
+ * line/axis and legend must render normally on their own, with the Heartrate
+ * line, its axis, and its legend entry all cleanly omitted (never a broken or
+ * empty-but-present HR axis).
+ */
+export const MOCK_ACTUALS_NO_HRM: WorkoutGraphActuals = {
+    power: buildActualPower(MOCK_BARS, 1050),
+    heartrate: [],
+    position: 1050,
+};
+
+/**
+ * `live` mode, post-skip-back: the rider skipped back from the cooldown to
+ * repeat the last VO2 on/off pair. The CURRENT workout (not the pristine plan
+ * above) gets that pair re-inserted at x=1800, and the cooldown ramp shifts
+ * 300s later — `domain.x` grows from [0,2100] to [0,2400] accordingly (§3.0 /
+ * §3.1: "maxX grows on skip-back/overrun", a discrete jump, not a reflow).
+ * The first 9 bars (warmup..last VO2 off) are untouched — proves old bars
+ * survive the skip, only the tail is edited. `position` (2250) sits past the
+ * pristine plan's old 2100s end, inside the repeated block's shifted
+ * cooldown — only renderable at all because the domain grew.
+ */
+const MOCK_BARS_AFTER_SKIPBACK: WorkoutGraphPlanBar[] = [
+    ...MOCK_BARS.slice(0, 9), // warmup .. 3rd VO2 "off" (x=0..1800), unchanged
+    // repeated (re-inserted by skip-back) 3rd VO2 on/off pair
+    { x0: 1800, x: 1980, y: 280, y0: 0, zone: 6 },
+    { x0: 1980, x: 2100, y: 130, y0: 0, zone: 2 },
+    // cooldown ramp, shifted 300s later by the re-inserted pair
+    { x0: 2100, x: 2400, y: 150, y0: 100, zone: 1 },
+];
+
+export const MOCK_PLAN_LIVE_SKIPBACK: WorkoutGraphPlan = {
+    bars: MOCK_BARS_AFTER_SKIPBACK,
+    ftp: FTP,
+    ftpLine: FTP,
+    domain: {
+        x: [0, 2400],
+        y: MOCK_PLAN.domain.y,
+    },
+};
+
+export const MOCK_ACTUALS_SKIPBACK: WorkoutGraphActuals = {
+    power: buildActualPower(MOCK_BARS_AFTER_SKIPBACK, 2250),
+    heartrate: buildActualHeartrate(2250),
+    position: 2250,
 };

--- a/src/components/WorkoutGraph/types.ts
+++ b/src/components/WorkoutGraph/types.ts
@@ -47,9 +47,13 @@ export interface WorkoutGraphPlan {
 }
 
 /**
- * Actuals + position marker for `live` mode. Not rendered by the session-1.3
- * spike (strip/detail only) — present here so the type surface is stable for
- * session 3.1, which adds the high-frequency overlay.
+ * Actuals + position marker for `live` mode: the already-ridden span, drawn as
+ * a Power line + a Heartrate line (with a color legend) on top of the
+ * (full-workout) plan bars, plus a position marker. Deliberately plain lines,
+ * not filled areas — a filled area is ElevationGraph's visual language
+ * elsewhere in this app, and workout-only rides have no elevation to show.
+ * High-frequency (1 Hz) — delivered via `getGraphActuals()` on each
+ * ride-observer tick, never via `page-update`.
  */
 export interface WorkoutGraphActuals {
     power: WorkoutGraphPoint[];     // recorded power over the ridden span (grey filled area)
@@ -79,7 +83,7 @@ export interface WorkoutGraphViewProps {
     height: number;
     mode: WorkoutGraphMode;
     plan: WorkoutGraphPlan;
-    /** live-mode overlay — ignored by strip/detail (session 3.1). */
+    /** live-mode overlay (grey power area + HR line + position marker) — ignored by strip/detail. */
     actuals?: WorkoutGraphActuals | null;
     /** Override axis visibility. Defaults: strip=false, detail=true. */
     showAxes?: boolean;

--- a/src/components/WorkoutGraph/utils.test.ts
+++ b/src/components/WorkoutGraph/utils.test.ts
@@ -1,0 +1,24 @@
+import { computeHrDomain } from './utils';
+
+describe('computeHrDomain', () => {
+    it('returns null for fewer than 2 usable points', () => {
+        expect(computeHrDomain([])).toBeNull();
+        expect(computeHrDomain([{ x: 0, y: 140 }])).toBeNull();
+    });
+
+    it('ignores non-finite values when counting usable points', () => {
+        expect(computeHrDomain([{ x: 0, y: 140 }, { x: 1, y: NaN }])).toBeNull();
+    });
+
+    it('pads a real range around min/max, clamped at 0', () => {
+        const [min, max] = computeHrDomain([{ x: 0, y: 120 }, { x: 1, y: 160 }])!;
+        expect(min).toBeLessThan(120);
+        expect(min).toBeGreaterThanOrEqual(0);
+        expect(max).toBeGreaterThan(160);
+    });
+
+    it('never returns a negative lower bound even for a low, flat HR series', () => {
+        const [min] = computeHrDomain([{ x: 0, y: 2 }, { x: 1, y: 2 }])!;
+        expect(min).toBeGreaterThanOrEqual(0);
+    });
+});

--- a/src/components/WorkoutGraph/utils.test.ts
+++ b/src/components/WorkoutGraph/utils.test.ts
@@ -1,4 +1,5 @@
-import { computeHrDomain } from './utils';
+import { computeHrDomain, downsampleToWidth } from './utils';
+import type { WorkoutGraphPoint } from './types';
 
 describe('computeHrDomain', () => {
     it('returns null for fewer than 2 usable points', () => {
@@ -20,5 +21,53 @@ describe('computeHrDomain', () => {
     it('never returns a negative lower bound even for a low, flat HR series', () => {
         const [min] = computeHrDomain([{ x: 0, y: 2 }, { x: 1, y: 2 }])!;
         expect(min).toBeGreaterThanOrEqual(0);
+    });
+});
+
+describe('downsampleToWidth', () => {
+    // ~1 Hz activity.logs over a 60-minute ride — the exact scenario
+    // workout-graph-component-design.md §5/§6 calls out: without downsampling
+    // this hands the SVG renderer 3,600+ raw points on every 1 Hz live tick.
+    const hourLongRide: WorkoutGraphPoint[] = Array.from({ length: 3600 }, (_, t) => ({
+        x: t,
+        y: 150 + Math.round(Math.sin(t / 90) * 60),
+    }));
+
+    it('returns empty for empty input or a non-positive width', () => {
+        expect(downsampleToWidth([], 300)).toEqual([]);
+        expect(downsampleToWidth(hourLongRide, 0)).toEqual([]);
+        expect(downsampleToWidth(hourLongRide, -10)).toEqual([]);
+    });
+
+    it('passes small inputs through unchanged rather than bucketing them', () => {
+        const points = [{ x: 0, y: 100 }, { x: 1, y: 110 }, { x: 2, y: 120 }];
+        expect(downsampleToWidth(points, 300)).toEqual(points);
+    });
+
+    it('bounds a hour of ~1 Hz samples to at most the pixel width', () => {
+        const result = downsampleToWidth(hourLongRide, 300);
+        expect(result.length).toBeLessThanOrEqual(300);
+        // not a token handful either — bucketing shouldn't over-collapse a real width
+        expect(result.length).toBeGreaterThan(250);
+    });
+
+    it('keeps points x-ordered and spanning the original range', () => {
+        const result = downsampleToWidth(hourLongRide, 300);
+        for (let i = 1; i < result.length; i++) {
+            expect(result[i].x).toBeGreaterThanOrEqual(result[i - 1].x);
+        }
+        expect(result[0].x).toBeGreaterThanOrEqual(0);
+        expect(result[result.length - 1].x).toBeLessThanOrEqual(3599);
+    });
+
+    it('averages every point in a bucket rather than dropping them (no spike/dip loss)', () => {
+        // two points in the same bucket (width=1 -> a single bucket spanning the whole range)
+        const result = downsampleToWidth([{ x: 0, y: 100 }, { x: 10, y: 300 }], 1);
+        expect(result).toEqual([{ x: 5, y: 200 }]);
+    });
+
+    it('ignores non-finite y values when bucketing', () => {
+        const result = downsampleToWidth([{ x: 0, y: 100 }, { x: 1, y: NaN }, { x: 2, y: 200 }], 1);
+        expect(result[0].y).toBe(150);
     });
 });

--- a/src/components/WorkoutGraph/utils.ts
+++ b/src/components/WorkoutGraph/utils.ts
@@ -46,3 +46,52 @@ export const computeHrDomain = (points: WorkoutGraphPoint[]): [number, number] |
     const pad = Math.max(5, (hrMax - hrMin) * 0.15);
     return [Math.max(0, hrMin - pad), hrMax + pad];
 };
+
+/**
+ * Bucket-average `points` down to at most `width` points, ordered by `x`.
+ * Required by `workout-graph-component-design.md` §5 point 2 / §6: the `live`
+ * overlay's Power/HR `<Path>`s must have ≤ `plotWidth` points regardless of
+ * ride length — `activity.logs` is ~1 Hz, so an hour-long ride would
+ * otherwise hand the SVG renderer 3,600+ raw points on every 1 Hz tick.
+ * Downsampling is this component's job, not the service's (it returns raw
+ * logs via `getGraphActuals()`) — only the component knows its own width.
+ *
+ * Mirrors `ActivityGraph.computeActivitySeries`'s bucket-to-width averaging
+ * (divide the x-range into `width` buckets, average every point that falls
+ * into each bucket) rather than naive stride-sampling, so a brief spike or
+ * dip between two kept samples isn't silently dropped.
+ */
+export const downsampleToWidth = (points: WorkoutGraphPoint[], width: number): WorkoutGraphPoint[] => {
+    const w = Math.floor(width);
+    if (w <= 0 || points.length === 0) return [];
+    // Already within budget — bucketing would only add averaging error for nothing.
+    if (points.length <= w) return points;
+
+    const xMin = points[0].x;
+    const xMax = points[points.length - 1].x;
+    const range = xMax - xMin;
+    if (range <= 0) return [points[points.length - 1]];
+
+    const bucketWidth = range / w;
+    const sumX = new Array(w).fill(0);
+    const sumY = new Array(w).fill(0);
+    const counts = new Array(w).fill(0);
+
+    for (const p of points) {
+        if (!Number.isFinite(p.x) || !Number.isFinite(p.y)) continue;
+        let idx = Math.floor((p.x - xMin) / bucketWidth);
+        if (idx >= w) idx = w - 1;
+        if (idx < 0) idx = 0;
+        sumX[idx] += p.x;
+        sumY[idx] += p.y;
+        counts[idx]++;
+    }
+
+    const result: WorkoutGraphPoint[] = [];
+    for (let i = 0; i < w; i++) {
+        if (counts[i] > 0) {
+            result.push({ x: sumX[i] / counts[i], y: sumY[i] / counts[i] });
+        }
+    }
+    return result;
+};

--- a/src/components/WorkoutGraph/utils.ts
+++ b/src/components/WorkoutGraph/utils.ts
@@ -68,9 +68,9 @@ export const downsampleToWidth = (points: WorkoutGraphPoint[], width: number): W
     if (points.length <= w) return points;
 
     const xMin = points[0].x;
-    const xMax = points[points.length - 1].x;
+    const xMax = points.at(-1)!.x;
     const range = xMax - xMin;
-    if (range <= 0) return [points[points.length - 1]];
+    if (range <= 0) return [points.at(-1)!];
 
     const bucketWidth = range / w;
     const sumX = new Array(w).fill(0);

--- a/src/components/WorkoutGraph/utils.ts
+++ b/src/components/WorkoutGraph/utils.ts
@@ -1,4 +1,4 @@
-import { WORKOUT_ZONE_COLORS, WorkoutGraphPlanBar } from './types';
+import { WORKOUT_ZONE_COLORS, WorkoutGraphPlanBar, WorkoutGraphPoint } from './types';
 
 /**
  * Linear map of a domain value into a pixel coordinate. Identical contract to
@@ -30,3 +30,19 @@ export const zoneFill = (zone: number): string => {
  */
 export const maxBarPower = (bars: WorkoutGraphPlanBar[]): number =>
     bars.reduce((m, b) => Math.max(m, b.y), 0);
+
+/**
+ * Auto-scaled y-domain for the recorded Heartrate line (bpm has no relation
+ * to the plan's Watt-based y-domain, so it needs its own). Returns `null`
+ * when there's fewer than 2 usable points — the single source of truth for
+ * both the HR line's own scaling and the dedicated HR axis, so they always
+ * agree with each other.
+ */
+export const computeHrDomain = (points: WorkoutGraphPoint[]): [number, number] | null => {
+    const values = points.filter(p => Number.isFinite(p.y)).map(p => p.y);
+    if (values.length < 2) return null;
+    const hrMin = Math.min(...values);
+    const hrMax = Math.max(...values);
+    const pad = Math.max(5, (hrMax - hrMin) * 0.15);
+    return [Math.max(0, hrMin - pad), hrMax + pad];
+};


### PR DESCRIPTION
## Summary
- Extends `WorkoutGraph` (`strip`/`detail` modes from session 1.3) with a `live` mode for the workout ride screen, per `workout-mobile-hld.md` §5 and `workout-ride-page-service-design.md` §3.0/§3.1.
- Plan bars describe the **current** (skip-adjusted) workout — not the pristine plan — across an x-domain (`[0, maxX]`) that grows on skip-back/overrun at discrete events, never continuously.
- Recorded Power/Heartrate are drawn as plain lines on top of the full-workout bars (the ridden span is never greyed out or suppressed), each with its own axis (Power left, Heartrate right, independently auto-scaled bpm) and a color-matched legend.
- Axis lines + tick marks anchor every axis (Power, Heartrate, time) instead of floating text.
- Fixed a real rendering bug found along the way: `<G translate="x, y">` renders as a dead, non-standard XML attribute (not a `transform`) under this project's Storybook/web pipeline, so the offset never applied — anything at a negative relative coordinate (left-axis ticks, the legend) was silently clipped by the SVG's default viewport while positive-coordinate elements happened to still show up. Fixed by baking margin offsets into plain coordinate arithmetic instead of relying on the `G` transform. Confirmed via a real headless-browser DOM inspection, not just unit tests.

## What changed
- `WorkoutGraphView.tsx`: `live` mode overlay (Power/HR lines, position marker, dual axes, legend); coordinate system rewritten to avoid the `G translate` bug.
- `types.ts`: doc updates reflecting line-based (not filled-area) rendering.
- `utils.ts` (+ `utils.test.ts`): extracted `computeHrDomain()` as a shared, unit-tested source of truth for the HR line and its axis.
- `mockData.ts`: added mid-workout, post-skip-back, and no-HRM `live` fixtures.
- `WorkoutGraph.stories.tsx`: `Live`, `LiveAfterSkipBack`, `LiveNoHeartRateMonitor` stories.
- `WorkoutGraphView.test.tsx`: coverage for the overlay, domain growth, axis lines/ticks, and the no-HRM case.

## Test plan
- [x] `npm test -- src/components/WorkoutGraph` — 23/23 passing
- [x] `tsc --noEmit` — clean
- [x] `eslint` — clean
- [x] Verified visually via Storybook (`Live`, `LiveAfterSkipBack`, `LiveNoHeartRateMonitor`) using a headless-browser screenshot, not just a unit-test render tree