### PR TITLE
Storybook prototype: Workouts list screen (session 4.1)

### DIFF
--- a/src/components/GroupPicker/GroupPicker.test.tsx
+++ b/src/components/GroupPicker/GroupPicker.test.tsx
@@ -39,6 +39,11 @@ describe('GroupPicker', () => {
         expect(onValueChange).toHaveBeenCalledWith('FTP Builder');
     });
 
+    it('does not offer "+ New" when allowNew is false', () => {
+        const { queryByText } = render(<GroupPicker {...baseProps} allowNew={false} />);
+        expect(queryByText('+ New')).toBeNull();
+    });
+
     it('reveals a text input after tapping "+ New", and commits a typed name on submit', () => {
         const onValueChange = jest.fn();
         const { getByText, getByPlaceholderText } = render(

--- a/src/components/GroupPicker/GroupPicker.tsx
+++ b/src/components/GroupPicker/GroupPicker.tsx
@@ -28,15 +28,16 @@ const NEW_GROUP_OPTION = '+ New';
  * group lists.
  */
 export const GroupPicker = (props: GroupPickerProps) => {
-    const { label, groups, value, disabled = false, onValueChange } = props;
+    const { label, groups, value, disabled = false, allowNew = true, onValueChange } = props;
     const [isEditing, setIsEditing] = useState(false);
     const [newGroup, setNewGroup] = useState('');
     const { logEvent } = useLogging('GroupPicker');
 
     // The current value is always offered as an option, even when it isn't
     // (yet) one of the known groups — e.g. a just-typed new name before it's persisted.
-    const options = groups.includes(value) || !value ? groups : [...groups, value];
-    const useChips = options.length <= GROUP_CHIP_THRESHOLD;
+    const known = groups.includes(value) || !value ? groups : [...groups, value];
+    const options = allowNew ? [...known, NEW_GROUP_OPTION] : known;
+    const useChips = known.length <= GROUP_CHIP_THRESHOLD;
 
     // No manual logEvent here — ChipSelect/SingleSelect already log
     // 'option selected' for every tap, including NEW_GROUP_OPTION.
@@ -84,7 +85,7 @@ export const GroupPicker = (props: GroupPickerProps) => {
                 <ChipSelect
                     label={label ?? ''}
                     labelWidth={label ? 100 : 0}
-                    options={[...options, NEW_GROUP_OPTION]}
+                    options={options}
                     selected={value}
                     disabled={disabled}
                     onValueChange={handleSelect}
@@ -92,7 +93,7 @@ export const GroupPicker = (props: GroupPickerProps) => {
             ) : (
                 <SingleSelect
                     label={label ?? 'Group'}
-                    options={[...options, NEW_GROUP_OPTION]}
+                    options={options}
                     selected={value}
                     disabled={disabled}
                     onValueChange={handleSelect}

--- a/src/components/GroupPicker/types.ts
+++ b/src/components/GroupPicker/types.ts
@@ -3,5 +3,9 @@ export interface GroupPickerProps {
     groups: string[]; // existing group/category names
     value: string; // current value — may or may not be one of `groups` (a not-yet-committed new name)
     disabled?: boolean;
+    // Offer the "+ New" free-text option (default true — the import/details
+    // dialog contract). false for pure-selection contexts, e.g. the Workouts
+    // list screen's group filter, where a not-yet-existing group is meaningless.
+    allowNew?: boolean;
     onValueChange: (group: string) => void;
 }

--- a/src/pages/WorkoutsPage/WorkoutsListPrototype.stories.tsx
+++ b/src/pages/WorkoutsPage/WorkoutsListPrototype.stories.tsx
@@ -103,11 +103,14 @@ const MOCK_CONTENT: MockContent = {
 const ALL_GROUPS = 'All';
 
 /**
- * Slim Upcoming-Training row per HLD §5: "compact rows (name, date badge,
- * duration)" — deliberately graph-less and ~half the height of a full
- * `WorkoutItemView` row, so the collapsed section leaves room for library rows
- * even on the phone frame. `isToday` = informational highlight only (§3.1),
- * tap opens details like every other row (§11.3 — no quick-start button).
+ * Slim Upcoming-Training row — HLD §5's "compact rows (name, date badge,
+ * duration)", used on phone (compact) only: graph-less and ~half the height of
+ * a full `WorkoutItemView` row, so the collapsed section leaves room for
+ * library rows above the fold. Tablets keep the full `WorkoutItemView` (incl.
+ * the graph, i.e. the exact training setup) — height isn't scarce there
+ * (review round 2, 2026-07-19). `isToday` = informational highlight only
+ * (§3.1), tap opens details like every other row (§11.3 — no quick-start
+ * button).
  */
 interface ScheduledRowProps {
     item: MockScheduledRow;
@@ -227,9 +230,26 @@ const WorkoutsListPrototypeView = (props: WorkoutsListPrototypeProps) => {
                                         <Text style={styles.sectionCount}>({upcoming.items.length})</Text>
                                     </TouchableOpacity>
 
-                                    {upcomingRows.map((item) => (
-                                        <ScheduledRow key={item.id} item={item} onOpenDetails={onOpenDetails} />
-                                    ))}
+                                    {upcomingRows.map((item) =>
+                                        compact ? (
+                                            <ScheduledRow key={item.id} item={item} onOpenDetails={onOpenDetails} />
+                                        ) : (
+                                            <WorkoutItemView
+                                                key={item.id}
+                                                id={item.id}
+                                                title={item.title}
+                                                group="Scheduled"
+                                                duration={item.duration}
+                                                selected={item.selected}
+                                                canDelete={false}
+                                                plan={item.plan}
+                                                scheduledLabel={dateLabel(item)}
+                                                isToday={item.isToday}
+                                                onOpenDetails={onOpenDetails}
+                                                onDelete={onDelete}
+                                            />
+                                        )
+                                    )}
 
                                     {showToggle && (
                                         <TouchableOpacity onPress={() => setExpanded(!expanded)} activeOpacity={0.7}>

--- a/src/pages/WorkoutsPage/WorkoutsListPrototype.stories.tsx
+++ b/src/pages/WorkoutsPage/WorkoutsListPrototype.stories.tsx
@@ -59,7 +59,7 @@ const day = (offset: number): Date => {
 const dateLabel = (item: MockScheduledRow): string =>
     item.isToday
         ? 'Today'
-        : item.date.toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+        : item.date.toLocaleDateString('de-DE', { weekday: 'short', day: '2-digit', month: '2-digit' });
 
 const mockScheduled = (n: number): MockScheduledRow[] =>
     [
@@ -101,6 +101,36 @@ const MOCK_CONTENT: MockContent = {
 // ---------------------------------------------------------------------------
 
 const ALL_GROUPS = 'All';
+
+/**
+ * Slim Upcoming-Training row per HLD §5: "compact rows (name, date badge,
+ * duration)" — deliberately graph-less and ~half the height of a full
+ * `WorkoutItemView` row, so the collapsed section leaves room for library rows
+ * even on the phone frame. `isToday` = informational highlight only (§3.1),
+ * tap opens details like every other row (§11.3 — no quick-start button).
+ */
+interface ScheduledRowProps {
+    item: MockScheduledRow;
+    onOpenDetails: (id: string) => void;
+}
+
+const ScheduledRow = ({ item, onOpenDetails }: ScheduledRowProps) => (
+    <TouchableOpacity
+        style={[styles.slimRow, item.isToday && styles.slimRowToday]}
+        onPress={() => onOpenDetails(item.id)}
+        activeOpacity={0.9}
+    >
+        <View style={[styles.dateBadge, item.isToday && styles.dateBadgeToday]}>
+            <Text style={[styles.dateBadgeText, item.isToday && styles.dateBadgeTextToday]}>
+                {dateLabel(item)}
+            </Text>
+        </View>
+        <Text style={styles.slimTitle} numberOfLines={1}>
+            {item.title}
+        </Text>
+        <Text style={styles.slimDuration}>{item.duration}</Text>
+    </TouchableOpacity>
+);
 
 interface WorkoutsListPrototypeProps {
     data: MockContent;
@@ -175,15 +205,6 @@ const WorkoutsListPrototypeView = (props: WorkoutsListPrototypeProps) => {
                         </View>
                     </View>
 
-                    <View style={styles.filterArea}>
-                        <ChipSelect
-                            label="Group"
-                            options={[ALL_GROUPS, ...data.groups.available]}
-                            selected={group ?? ALL_GROUPS}
-                            onValueChange={handleGroup}
-                        />
-                    </View>
-
                     {data.isEmpty ? (
                         <View style={styles.center}>
                             <Text style={styles.emptyText}>No workouts found</Text>
@@ -207,31 +228,33 @@ const WorkoutsListPrototypeView = (props: WorkoutsListPrototypeProps) => {
                                     </TouchableOpacity>
 
                                     {upcomingRows.map((item) => (
-                                        <WorkoutItemView
-                                            key={item.id}
-                                            id={item.id}
-                                            title={item.title}
-                                            group="Scheduled"
-                                            duration={item.duration}
-                                            selected={item.selected}
-                                            canDelete={false}
-                                            plan={item.plan}
-                                            scheduledLabel={dateLabel(item)}
-                                            isToday={item.isToday}
-                                            onOpenDetails={onOpenDetails}
-                                            onDelete={onDelete}
-                                        />
+                                        <ScheduledRow key={item.id} item={item} onOpenDetails={onOpenDetails} />
                                     ))}
 
                                     {showToggle && (
                                         <TouchableOpacity onPress={() => setExpanded(!expanded)} activeOpacity={0.7}>
                                             <Text style={styles.showAllText}>
-                                                {hiddenCount > 0 ? `Show all (${upcoming.items.length})` : 'Show less'}
+                                                {hiddenCount > 0 ? `Show ${hiddenCount} more` : 'Show less'}
                                             </Text>
                                         </TouchableOpacity>
                                     )}
 
                                     <View style={styles.sectionDivider} />
+                                </View>
+                            )}
+
+                            {/* Group filter opens the library block — it only
+                                filters the flat list (Upcoming is never
+                                group-filtered, §12), so it must not sit above
+                                the Upcoming section. */}
+                            {data.groups.available.length > 0 && (
+                                <View style={styles.filterArea}>
+                                    <ChipSelect
+                                        label="Group"
+                                        options={[ALL_GROUPS, ...data.groups.available]}
+                                        selected={group ?? ALL_GROUPS}
+                                        onValueChange={handleGroup}
+                                    />
                                 </View>
                             )}
 
@@ -431,6 +454,51 @@ const styles = StyleSheet.create({
     sectionCount: {
         color: colors.text,
         opacity: 0.6,
+        fontSize: textSizes.smallText,
+    },
+    slimRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+        backgroundColor: colors.listItemBackground,
+        marginVertical: 2,
+        marginHorizontal: 12,
+        borderRadius: 6,
+        paddingHorizontal: 8,
+        paddingVertical: 6,
+    },
+    slimRowToday: {
+        borderLeftWidth: 3,
+        borderLeftColor: colors.buttonPrimary,
+    },
+    dateBadge: {
+        minWidth: 72,
+        alignItems: 'center',
+        paddingHorizontal: 8,
+        paddingVertical: 2,
+        borderRadius: 10,
+        backgroundColor: 'rgba(255,255,255,0.1)',
+    },
+    dateBadgeToday: {
+        backgroundColor: colors.buttonPrimary,
+    },
+    dateBadgeText: {
+        color: colors.text,
+        fontSize: textSizes.tinyText,
+        fontWeight: '600',
+    },
+    dateBadgeTextToday: {
+        color: colors.background,
+    },
+    slimTitle: {
+        flex: 1,
+        color: colors.text,
+        fontSize: textSizes.smallText,
+        fontWeight: 'bold',
+    },
+    slimDuration: {
+        color: colors.text,
+        opacity: 0.8,
         fontSize: textSizes.smallText,
     },
     showAllText: {

--- a/src/pages/WorkoutsPage/WorkoutsListPrototype.stories.tsx
+++ b/src/pages/WorkoutsPage/WorkoutsListPrototype.stories.tsx
@@ -8,7 +8,7 @@ import type {
     WorkoutListContentProps,
     WorkoutListItemProps,
 } from 'incyclist-services';
-import { ChipSelect, MainBackground, TNavigationItem, WorkoutItemView } from '../../components';
+import { GroupPicker, MainBackground, TNavigationItem, WorkoutItemView } from '../../components';
 import { NavigationBarView } from '../../components/NavigationBar/NavigationBarView';
 import { NavigationBarViewCompact } from '../../components/NavigationBar/NavigationBarViewCompact';
 import { Icon } from '../../components/Icon';
@@ -246,13 +246,18 @@ const WorkoutsListPrototypeView = (props: WorkoutsListPrototypeProps) => {
                             {/* Group filter opens the library block — it only
                                 filters the flat list (Upcoming is never
                                 group-filtered, §12), so it must not sit above
-                                the Upcoming section. */}
+                                the Upcoming section. GroupPicker (not raw
+                                ChipSelect): it falls back to a SingleSelect
+                                dropdown past 5 options, so many groups can't
+                                overflow the chip row. allowNew=false — you
+                                can't filter by a group that doesn't exist. */}
                             {data.groups.available.length > 0 && (
                                 <View style={styles.filterArea}>
-                                    <ChipSelect
+                                    <GroupPicker
                                         label="Group"
-                                        options={[ALL_GROUPS, ...data.groups.available]}
-                                        selected={group ?? ALL_GROUPS}
+                                        groups={[ALL_GROUPS, ...data.groups.available]}
+                                        value={group ?? ALL_GROUPS}
+                                        allowNew={false}
                                         onValueChange={handleGroup}
                                     />
                                 </View>
@@ -337,6 +342,28 @@ export const SingleUpcomingEntry: Story = {
     decorators: [TABLET_7],
     args: {
         data: { ...MOCK_CONTENT, upcoming: mockUpcoming(1) },
+        compact: false,
+        navIconSize: 38,
+    },
+};
+
+/**
+ * More than GroupPicker's 5-option chip threshold: the filter row falls back
+ * to the SingleSelect dropdown instead of overflowing the chip row.
+ */
+export const ManyGroups: Story = {
+    decorators: [TABLET_7],
+    args: {
+        data: {
+            ...MOCK_CONTENT,
+            groups: {
+                available: [
+                    'My Workouts', 'FTP Builder', 'Zwift Academy 2021',
+                    'Climbing Prep', 'Base Season', 'Sprint Work', 'Recovery',
+                ],
+                selected: null,
+            },
+        },
         compact: false,
         navIconSize: 38,
     },

--- a/src/pages/WorkoutsPage/WorkoutsListPrototype.stories.tsx
+++ b/src/pages/WorkoutsPage/WorkoutsListPrototype.stories.tsx
@@ -1,0 +1,460 @@
+import React, { useState } from 'react';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import type {
+    ScheduledWorkoutItemProps,
+    UpcomingTrainingProps,
+    WorkoutListContentProps,
+    WorkoutListItemProps,
+} from 'incyclist-services';
+import { ChipSelect, MainBackground, TNavigationItem, WorkoutItemView } from '../../components';
+import { NavigationBarView } from '../../components/NavigationBar/NavigationBarView';
+import { NavigationBarViewCompact } from '../../components/NavigationBar/NavigationBarViewCompact';
+import { Icon } from '../../components/Icon';
+import { WorkoutGraphPlan } from '../../components/WorkoutGraph';
+import { MOCK_PLAN, MOCK_PLAN_SHORT } from '../../components/WorkoutGraph/WorkoutGraph.mock';
+import { colors, textSizes } from '../../theme';
+
+/**
+ * Session 4.1 — visual layout checkpoint for the Workouts list screen
+ * (workout-mobile-hld.md §5, workout-list-page-service-design.md §4).
+ *
+ * This is a PROTOTYPE assembled inside the story file: it composes the real
+ * `WorkoutItemView`/`WorkoutGraph`/`ChipSelect`/`NavigationBar` components into
+ * the `WorkoutsPage`/`WorkoutsTable` layout, driven by hand-authored mock data.
+ * No real service, no real navigation — the real page wiring is session 5.2
+ * (`WorkoutsTable`/`WorkoutsPage` against `WorkoutListPageService`).
+ *
+ * Mock shapes mirror `WorkoutListContentProps` (design doc §4) with
+ * `workout: Workout` replaced by a ready-made `plan: WorkoutGraphPlan` — the
+ * same substitution `WorkoutItemDisplayProps` makes (see WorkoutItem/types.ts)
+ * while `getWorkoutGraphSeries()` lives in services session 2.2.
+ *
+ * NOTE (§11.3): today's Upcoming row deliberately has NO direct Start button —
+ * that idea was rejected on review (2026-07-19): the post-pairing prompt covers
+ * the fast path, and a quick-start button doesn't survive Phase 2's
+ * "start with route". Today's row is tapped exactly like any other row.
+ */
+
+type MockScheduledRow = Omit<ScheduledWorkoutItemProps, 'workout'> & { plan: WorkoutGraphPlan };
+type MockWorkoutRow = Omit<WorkoutListItemProps, 'workout'> & { plan: WorkoutGraphPlan };
+type MockUpcoming = Omit<UpcomingTrainingProps, 'items'> & { items: MockScheduledRow[] };
+type MockContent = Omit<WorkoutListContentProps, 'upcoming' | 'workouts'> & {
+    upcoming: MockUpcoming | null;
+    workouts: MockWorkoutRow[];
+};
+
+// ---------------------------------------------------------------------------
+// Mock data
+// ---------------------------------------------------------------------------
+
+const day = (offset: number): Date => {
+    const d = new Date();
+    d.setDate(d.getDate() + offset);
+    return d;
+};
+
+/** Story-local stand-in for the smart `WorkoutItem`'s formatDateTime call. */
+const dateLabel = (item: MockScheduledRow): string =>
+    item.isToday
+        ? 'Today'
+        : item.date.toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+
+const mockScheduled = (n: number): MockScheduledRow[] =>
+    [
+        { id: 'sched-1', title: 'Sweet Spot 3x12', date: day(0), duration: '60min', isToday: true, selected: false, plan: MOCK_PLAN },
+        { id: 'sched-2', title: 'VO2 Max Repeats', date: day(2), duration: '35min', isToday: false, selected: false, plan: MOCK_PLAN_SHORT },
+        { id: 'sched-3', title: 'Endurance + Bursts', date: day(4), duration: '75min', isToday: false, selected: false, plan: MOCK_PLAN },
+        { id: 'sched-4', title: 'Recovery Spin', date: day(6), duration: '30min', isToday: false, selected: false, plan: MOCK_PLAN_SHORT },
+    ].slice(0, n);
+
+const mockUpcoming = (entries: number): MockUpcoming => ({
+    items: mockScheduled(entries),
+    collapsedCount: 2,
+    todayId: 'sched-1',
+});
+
+const MOCK_WORKOUTS: MockWorkoutRow[] = [
+    { id: 'w-1', title: '3x VO2 Max Intervals', group: 'FTP Builder', duration: '35min', selected: false, canDelete: true, plan: MOCK_PLAN },
+    { id: 'w-2', title: 'Sweet Spot Base', group: 'FTP Builder', duration: '60min', selected: false, canDelete: true, plan: MOCK_PLAN },
+    { id: 'w-3', title: 'Recovery Spin', group: 'My Workouts', duration: '10min', selected: false, canDelete: true, plan: MOCK_PLAN_SHORT },
+    { id: 'w-4', title: 'Threshold Progression', group: 'My Workouts', duration: '45min', selected: false, canDelete: true, plan: MOCK_PLAN },
+    { id: 'w-5', title: 'Extended Endurance with Cooldown', group: 'Zwift Academy 2021', duration: '90min', selected: false, canDelete: true, plan: MOCK_PLAN },
+    { id: 'w-6', title: 'Anaerobic Capacity', group: 'Zwift Academy 2021', duration: '25min', selected: false, canDelete: true, plan: MOCK_PLAN_SHORT },
+    { id: 'w-7', title: 'Tempo Blocks', group: 'FTP Builder', duration: '50min', selected: false, canDelete: true, plan: MOCK_PLAN },
+    { id: 'w-8', title: 'Openers', group: 'My Workouts', duration: '20min', selected: false, canDelete: true, plan: MOCK_PLAN_SHORT },
+];
+
+const MOCK_CONTENT: MockContent = {
+    pageType: 'list',
+    loading: false,
+    upcoming: mockUpcoming(4),
+    groups: { available: ['My Workouts', 'FTP Builder', 'Zwift Academy 2021'], selected: null },
+    workouts: MOCK_WORKOUTS,
+    selectedId: null,
+    isEmpty: false,
+};
+
+// ---------------------------------------------------------------------------
+// Prototype view
+// ---------------------------------------------------------------------------
+
+const ALL_GROUPS = 'All';
+
+interface WorkoutsListPrototypeProps {
+    data: MockContent;
+    compact: boolean;
+    /** Vertical-nav icon size — the smart NavigationBar derives it from the window height (height/16, max 64). */
+    navIconSize?: number;
+    /** Start with the Upcoming section already expanded past `collapsedCount`. */
+    initiallyExpanded?: boolean;
+    onNavigate: (item: TNavigationItem) => void;
+    onImport: () => void;
+    onOpenDetails: (id: string) => void;
+    onDelete: (id: string) => void;
+    onSelectGroup: (group: string | null) => void;
+}
+
+const WorkoutsListPrototypeView = (props: WorkoutsListPrototypeProps) => {
+    const { data, compact, navIconSize = 50, initiallyExpanded, onNavigate, onImport, onOpenDetails, onDelete, onSelectGroup } = props;
+
+    // The real service returns `workouts` already filtered by `groups.selected`
+    // (design doc §12) — local filter state here only makes the chips
+    // interactive inside the story.
+    const [group, setGroup] = useState<string | null>(data.groups.selected);
+    // Two independent mechanisms per HLD §5: the chevron collapses the whole
+    // section to its header; "Show all (N)" expands past `collapsedCount`.
+    const [sectionCollapsed, setSectionCollapsed] = useState(false);
+    const [expanded, setExpanded] = useState(!!initiallyExpanded);
+
+    const workouts = group ? data.workouts.filter((w) => w.group === group) : data.workouts;
+
+    const upcoming = data.upcoming;
+    const upcomingRows = upcoming && !sectionCollapsed
+        ? (expanded ? upcoming.items : upcoming.items.slice(0, upcoming.collapsedCount))
+        : [];
+    const hiddenCount = upcoming ? upcoming.items.length - upcomingRows.length : 0;
+    const showToggle = !!upcoming && !sectionCollapsed && upcoming.items.length > upcoming.collapsedCount;
+
+    const handleGroup = (value: string) => {
+        const selected = value === ALL_GROUPS ? null : value;
+        setGroup(selected);
+        onSelectGroup(selected);
+    };
+
+    return (
+        <MainBackground>
+            <View style={[styles.container, compact && styles.containerCompact]}>
+                {/* Pure nav views, not the smart NavigationBar — it picks its
+                    layout from the real browser window (useScreenLayout), which
+                    would ignore the fixed device frame. */}
+                <View style={[styles.navColumn, compact ? styles.navColumnCompact : styles.navColumnNormal]}>
+                    {compact ? (
+                        <NavigationBarViewCompact selected="workouts" onClick={onNavigate} showExit={false} />
+                    ) : (
+                        <NavigationBarView
+                            selected="workouts"
+                            onClick={onNavigate}
+                            iconSize={navIconSize}
+                            navWidth={150}
+                            showExit={false}
+                        />
+                    )}
+                </View>
+
+                <View style={styles.contentColumn}>
+                    <View style={styles.header}>
+                        <View style={styles.headerSide} />
+                        <Text style={styles.headerTitle}>WORKOUTS</Text>
+                        <View style={styles.headerSide}>
+                            <TouchableOpacity style={styles.importButton} onPress={onImport} activeOpacity={0.7}>
+                                <Icon name="import-route" size={20} color={colors.buttonPrimary} />
+                                <Text style={styles.importButtonText}>Import Workouts</Text>
+                            </TouchableOpacity>
+                        </View>
+                    </View>
+
+                    <View style={styles.filterArea}>
+                        <ChipSelect
+                            label="Group"
+                            options={[ALL_GROUPS, ...data.groups.available]}
+                            selected={group ?? ALL_GROUPS}
+                            onValueChange={handleGroup}
+                        />
+                    </View>
+
+                    {data.isEmpty ? (
+                        <View style={styles.center}>
+                            <Text style={styles.emptyText}>No workouts found</Text>
+                        </View>
+                    ) : (
+                        <ScrollView style={styles.listArea}>
+                            {upcoming && (
+                                <View style={styles.upcomingSection}>
+                                    <TouchableOpacity
+                                        style={styles.sectionHeader}
+                                        onPress={() => setSectionCollapsed(!sectionCollapsed)}
+                                        activeOpacity={0.7}
+                                    >
+                                        <Icon
+                                            name={sectionCollapsed ? 'chevron-down' : 'chevron-up'}
+                                            size={16}
+                                            color={colors.text}
+                                        />
+                                        <Text style={styles.sectionTitle}>Upcoming Training</Text>
+                                        <Text style={styles.sectionCount}>({upcoming.items.length})</Text>
+                                    </TouchableOpacity>
+
+                                    {upcomingRows.map((item) => (
+                                        <WorkoutItemView
+                                            key={item.id}
+                                            id={item.id}
+                                            title={item.title}
+                                            group="Scheduled"
+                                            duration={item.duration}
+                                            selected={item.selected}
+                                            canDelete={false}
+                                            plan={item.plan}
+                                            scheduledLabel={dateLabel(item)}
+                                            isToday={item.isToday}
+                                            onOpenDetails={onOpenDetails}
+                                            onDelete={onDelete}
+                                        />
+                                    ))}
+
+                                    {showToggle && (
+                                        <TouchableOpacity onPress={() => setExpanded(!expanded)} activeOpacity={0.7}>
+                                            <Text style={styles.showAllText}>
+                                                {hiddenCount > 0 ? `Show all (${upcoming.items.length})` : 'Show less'}
+                                            </Text>
+                                        </TouchableOpacity>
+                                    )}
+
+                                    <View style={styles.sectionDivider} />
+                                </View>
+                            )}
+
+                            {workouts.map((item) => (
+                                <WorkoutItemView
+                                    key={item.id}
+                                    {...item}
+                                    onOpenDetails={onOpenDetails}
+                                    onDelete={onDelete}
+                                />
+                            ))}
+                        </ScrollView>
+                    )}
+                </View>
+            </View>
+        </MainBackground>
+    );
+};
+
+// ---------------------------------------------------------------------------
+// Stories — fixed device frames (app is landscape-locked, see Loader.tsx)
+// ---------------------------------------------------------------------------
+
+/**
+ * Unlike the usual page-story decorator (`useWindowDimensions` + minHeight /
+ * minWidth filling the browser window), the checkpoint needs deterministic
+ * sizes — each story renders inside a fixed-dp device frame instead.
+ */
+const deviceFrame = (width: number, height: number) =>
+    function DeviceFrame(Story: React.ComponentType) {
+        return (
+            <View style={[styles.deviceFrame, { width, height }]}>
+                <Story />
+            </View>
+        );
+    };
+
+const TABLET_10 = deviceFrame(1280, 800);
+const TABLET_7 = deviceFrame(1024, 600);
+const PHONE = deviceFrame(800, 360); // height < 420 -> compact nav (RoutesPage breakpoint)
+
+const meta: Meta<typeof WorkoutsListPrototypeView> = {
+    title: 'Pages/WorkoutsPage/ListPrototype',
+    component: WorkoutsListPrototypeView,
+    args: {
+        onNavigate: fn(),
+        onImport: fn(),
+        onOpenDetails: fn(),
+        onDelete: fn(),
+        onSelectGroup: fn(),
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof WorkoutsListPrototypeView>;
+
+export const Tablet10: Story = {
+    decorators: [TABLET_10],
+    args: { data: MOCK_CONTENT, compact: false, navIconSize: 50 },
+};
+
+export const Tablet7: Story = {
+    decorators: [TABLET_7],
+    args: { data: MOCK_CONTENT, compact: false, navIconSize: 38 },
+};
+
+export const Phone: Story = {
+    decorators: [PHONE],
+    args: { data: MOCK_CONTENT, compact: true },
+};
+
+export const PhoneUpcomingExpanded: Story = {
+    decorators: [PHONE],
+    args: { data: MOCK_CONTENT, compact: true, initiallyExpanded: true },
+};
+
+/** 1 entry <= collapsedCount: the "Show all (N)" toggle must not appear. */
+export const SingleUpcomingEntry: Story = {
+    decorators: [TABLET_7],
+    args: {
+        data: { ...MOCK_CONTENT, upcoming: mockUpcoming(1) },
+        compact: false,
+        navIconSize: 38,
+    },
+};
+
+/** `upcoming: null` = no scheduled workouts -> the whole section is hidden. */
+export const NoUpcoming: Story = {
+    decorators: [PHONE],
+    args: {
+        data: { ...MOCK_CONTENT, upcoming: null },
+        compact: true,
+    },
+};
+
+export const EmptyState: Story = {
+    decorators: [TABLET_7],
+    args: {
+        data: {
+            ...MOCK_CONTENT,
+            upcoming: null,
+            groups: { available: [], selected: null },
+            workouts: [],
+            isEmpty: true,
+        },
+        compact: false,
+        navIconSize: 38,
+    },
+};
+
+const styles = StyleSheet.create({
+    deviceFrame: {
+        alignSelf: 'flex-start',
+        overflow: 'hidden',
+        borderWidth: 1,
+        borderColor: 'rgba(255,255,255,0.25)',
+    },
+    container: {
+        flex: 1,
+        flexDirection: 'row',
+    },
+    containerCompact: {
+        flexDirection: 'column',
+    },
+    navColumn: {
+        flexDirection: 'column',
+        alignSelf: 'stretch',
+    },
+    navColumnNormal: {
+        width: 150,
+    },
+    navColumnCompact: {
+        height: 56,
+        width: '100%',
+    },
+    contentColumn: {
+        flex: 1,
+        flexDirection: 'column',
+        overflow: 'hidden',
+    },
+    header: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        paddingHorizontal: 12,
+        paddingVertical: 8,
+    },
+    headerTitle: {
+        color: colors.text,
+        fontSize: textSizes.pageTitle,
+        fontWeight: '700',
+        textAlign: 'center',
+    },
+    headerSide: {
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'flex-end',
+    },
+    importButton: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 6,
+        paddingHorizontal: 12,
+        paddingVertical: 8,
+        borderRadius: 8,
+        borderWidth: 1,
+        borderColor: colors.buttonPrimary,
+    },
+    importButtonText: {
+        color: colors.buttonPrimary,
+        fontSize: textSizes.normalText,
+        fontWeight: '500',
+    },
+    filterArea: {
+        paddingHorizontal: 12,
+    },
+    listArea: {
+        flex: 1,
+    },
+    upcomingSection: {},
+    sectionHeader: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 6,
+        paddingHorizontal: 12,
+        paddingVertical: 6,
+    },
+    sectionTitle: {
+        color: colors.text,
+        fontSize: textSizes.smallText,
+        fontWeight: '700',
+        textTransform: 'uppercase',
+        letterSpacing: 0.5,
+    },
+    sectionCount: {
+        color: colors.text,
+        opacity: 0.6,
+        fontSize: textSizes.smallText,
+    },
+    showAllText: {
+        color: colors.buttonPrimary,
+        fontSize: textSizes.smallText,
+        fontWeight: '600',
+        paddingHorizontal: 16,
+        paddingVertical: 4,
+    },
+    sectionDivider: {
+        borderBottomWidth: 1,
+        borderBottomColor: 'rgba(255,255,255,0.12)',
+        marginHorizontal: 12,
+        marginVertical: 8,
+    },
+    center: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        padding: 20,
+    },
+    emptyText: {
+        color: colors.text,
+        fontSize: textSizes.noDataText,
+        textAlign: 'center',
+    },
+});

--- a/src/pages/WorkoutsPage/WorkoutsListPrototype.stories.tsx
+++ b/src/pages/WorkoutsPage/WorkoutsListPrototype.stories.tsx
@@ -291,6 +291,10 @@ const WorkoutsListPrototypeView = (props: WorkoutsListPrototypeProps) => {
                                     onDelete={onDelete}
                                 />
                             ))}
+
+                            {workouts.length === 0 && (
+                                <Text style={styles.noMatchText}>No workouts in this group</Text>
+                            )}
                         </ScrollView>
                     )}
                 </View>
@@ -477,8 +481,16 @@ const styles = StyleSheet.create({
         fontSize: textSizes.normalText,
         fontWeight: '500',
     },
+    // zIndex lifts the whole filter row above the workout-row siblings that
+    // follow it — RN-web gives every View `z-index:0`, so SingleSelect's
+    // dropdown (zIndex 1000) is trapped inside this wrapper's stacking context
+    // and would otherwise paint UNDER later rows. Its existing consumers
+    // (RouteDetailsDialog, GearSettings) never hit this because nothing
+    // overlapping follows the picker inside those dialogs. The real
+    // WorkoutsTable (session 5.1) needs the same zIndex on its filter row.
     filterArea: {
         paddingHorizontal: 12,
+        zIndex: 10,
     },
     listArea: {
         flex: 1,
@@ -560,6 +572,13 @@ const styles = StyleSheet.create({
         borderBottomColor: 'rgba(255,255,255,0.12)',
         marginHorizontal: 12,
         marginVertical: 8,
+    },
+    noMatchText: {
+        color: colors.text,
+        opacity: 0.7,
+        fontSize: textSizes.normalText,
+        textAlign: 'center',
+        paddingVertical: 24,
     },
     center: {
         flex: 1,


### PR DESCRIPTION
## Summary
Visual layout checkpoint for the Workouts list screen (workout-mobile-hld.md §5, workout-list-page-service-design.md §4). Assembles the real `WorkoutItemView`/`WorkoutGraph`/`GroupPicker`/`NavigationBarView(-Compact)` components into the `WorkoutsPage` layout inside fixed device frames, driven by hand-authored mock `WorkoutListContentProps`-shaped data (`workout: Workout` swapped for `plan: WorkoutGraphPlan`, same substitution as `WorkoutItemDisplayProps`). No real service, no real navigation — sign-off gate before session 5.1 builds the real page.

## What changed
- New story `src/pages/WorkoutsPage/WorkoutsListPrototype.stories.tsx` (`Pages/WorkoutsPage/ListPrototype`), 8 variants: **Tablet10** (1280×800), **Tablet7** (1024×600), **Phone** (800×360, compact top nav), **PhoneUpcomingExpanded**, **SingleUpcomingEntry**, **ManyGroups** (SingleSelect fallback), **NoUpcoming**, **EmptyState**
- Upcoming Training is the first block of one continuous ScrollView; chevron collapses the section, "Show N more"/"Show less" expands past `collapsedCount` (2); today's row gets the `isToday` highlight only. Rows are **responsive**: full `WorkoutItemView` incl. the training graph on tablets, **slim rows** ("name, date badge, duration" — graph-less, ~half height) on phone where vertical space is scarce
- Per §11.3 (rejected 2026-07-19): **no** direct Start button on the today row — it is tapped like any other row
- `GroupPicker` gained `allowNew?: boolean` (default `true` — import/details dialog contract unchanged) + unit test; the filter row uses `allowNew={false}`
- Uses the pure view components: the smart `NavigationBar`/`WorkoutItem` size themselves from the real browser window / pull real services, which breaks inside a fixed frame

## Review round 1 (applied)
1. **Group filter moved below the Upcoming section** — it only filters the flat list (§12), sitting above Upcoming implied otherwise; hidden entirely on the empty state
2. **"Show all (4)" → "Show 2 more"** — N-as-total was confusing with 2 rows already visible. If accepted, HLD §5's literal "Show all (N)" wording needs a one-line touch-up at sign-off
3. **Phone fold fixed** — slim Upcoming rows leave the group filter and library rows visible below a collapsed 2-row section at 800×360
4. **Empty state** shows no group filter
5. **Filter row uses `GroupPicker`, not raw `ChipSelect`** — past 5 options it falls back to a `SingleSelect` dropdown, so many groups can't overflow the chip row (`ManyGroups` variant demonstrates)

## Review round 2 (applied)
- Slim Upcoming rows are now **phone-only**; tablets keep the full `WorkoutItemView` with the graph (the exact training setup) — height isn't scarce there. HLD §5's "compact rows" phrasing should be scoped to compact screens at sign-off.

## Review round 3 (applied)
- **ManyGroups dropdown painted under the list rows**: react-native-web gives every `View` `z-index: 0`, so each row is a stacking context and `SingleSelect`'s `zIndex: 1000` panel is trapped inside the filter wrapper — it can never overlay *later siblings*. Its existing consumers (`RouteDetailsDialog`, `GearSettings`) sit inside dialogs where nothing overlapping follows, so this never showed. Fix: `zIndex` on the filter-row wrapper. ⚠ **Session 5.1's real `WorkoutsTable` must replicate this** (explained in a comment in the story)
- Added an explicit **"No workouts in this group"** state when the selected group filter matches nothing (previously a silent blank area)

## Test plan
- `npx tsc --noEmit`, `npx eslint` clean; `npm test` 64 suites / 336 tests pass (incl. new `GroupPicker` `allowNew` test)
- All variants rendered and screenshotted headlessly (Playwright against `storybook dev`); interactions verified: expand/collapse, group chip filtering (Upcoming untouched, per HLD — no dedup), dropdown fallback with 8 groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)
