### PR TITLE
refactor: WorkoutGraph shared data shapes from incyclist-services

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,10 @@ module.exports = {
   preset: 'react-native',
   setupFilesAfterEnv: ['./__tests__/jest.setup.ts'],
   testPathIgnorePatterns: ['/node_modules/', '__tests__/jest.setup.ts'],
+  transformIgnorePatterns: [
+    // RN preset default, plus ESM-only packages pulled in by incyclist-services
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|uuid|@garmin/fitsdk)/)',
+  ],
   moduleNameMapper: {
     '^react-native-linear-gradient$': '<rootDir>/__mocks__/react-native-linear-gradient.tsx',
     'react-native-maps': '<rootDir>/__mocks__/react-native-maps.tsx',

--- a/src/components/WorkoutGraph/types.ts
+++ b/src/components/WorkoutGraph/types.ts
@@ -1,18 +1,18 @@
 import { StyleProp, ViewStyle } from 'react-native';
+import { WorkoutGraphPlan, WorkoutGraphActuals } from 'incyclist-services';
 
 /**
- * Data shapes consumed by the WorkoutGraph component.
+ * View props for the WorkoutGraph component.
  *
- * These mirror `workout-ride-page-service-design.md` §3.1 exactly. They are
- * defined locally for the session-1.3 spike because the shared
- * `getWorkoutGraphSeries()` generator (services §7 #1) does not exist yet.
- * Once session 2.2 lands, these should be re-exported from `incyclist-services`
- * and the local copies deleted — the field names/units are chosen to match so
- * the swap is a pure import change.
- *
- * The zone-coloring / step-to-bar math lives in `services`; this component is
- * pure rendering and does NO FTP math — bars already carry absolute Watts.
+ * The shared data shapes (`WorkoutGraphPlanBar`, `WorkoutGraphPlan`,
+ * `WorkoutGraphActuals`, `WORKOUT_ZONE_COLORS`) come from `incyclist-services`
+ * and are re-exported here for existing consumers. The zone-coloring /
+ * step-to-bar math lives in `services`; this component is pure rendering and
+ * does NO FTP math — bars already carry absolute Watts.
  */
+
+export { WORKOUT_ZONE_COLORS } from 'incyclist-services';
+export type { WorkoutGraphPlanBar, WorkoutGraphPlan, WorkoutGraphActuals } from 'incyclist-services';
 
 export type WorkoutGraphMode = 'strip' | 'detail' | 'live';
 
@@ -21,61 +21,6 @@ export interface WorkoutGraphPoint {
     x: number; // elapsed activity time (s)
     y: number; // value — Watts for power, bpm for heartrate
 }
-
-/**
- * One zone-colored bar of the (current) workout. Mirrors web-ui getDataSeries()
- * output with absValues:true — absolute Watts, already resolved against FTP.
- * This is a rectangle series (react-vis VerticalRectSeries equivalent): each
- * bar spans [x0,x] horizontally and [y0,y] vertically.
- */
-export interface WorkoutGraphPlanBar {
-    x0: number;   // bar start   (elapsed time, s)
-    x: number;    // bar end     (elapsed time, s)
-    y: number;    // top power    (W) — max of the band, or the ramp value
-    y0: number;   // bottom power (W) — min of the band; 0 for single-value steps
-    zone: number; // 1..7 -> WORKOUT_ZONE_COLORS[zone]  (0 = uncolored)
-}
-
-export interface WorkoutGraphPlan {
-    bars: WorkoutGraphPlanBar[]; // whole workout, zone-colored, absolute Watts
-    ftp: number;                 // FTP the bars were resolved with
-    ftpLine: number;             // W value of the FTP reference line (= ftp)
-    domain: {
-        x: [number, number];     // [0, maxX]
-        y: [number, number];     // [0, max(bar power, recorded power) * headroom]
-    };
-}
-
-/**
- * Actuals + position marker for `live` mode: the already-ridden span, drawn as
- * a Power line + a Heartrate line (with a color legend) on top of the
- * (full-workout) plan bars, plus a position marker. Deliberately plain lines,
- * not filled areas — a filled area is ElevationGraph's visual language
- * elsewhere in this app, and workout-only rides have no elevation to show.
- * High-frequency (1 Hz) — delivered via `getGraphActuals()` on each
- * ride-observer tick, never via `page-update`.
- */
-export interface WorkoutGraphActuals {
-    power: WorkoutGraphPoint[];     // recorded power over the ridden span (grey filled area)
-    heartrate: WorkoutGraphPoint[]; // recorded HR over the ridden span (line); may be empty
-    position: number;               // current elapsed activity time (s) — marker x & plan/actual split
-}
-
-/**
- * Zone palette — indexed 0..7. Index 0 ('white') is uncolored; 1..7 are the
- * existing web-ui `zoneColor` values (identical to ActivityGraph's getZoneColor
- * thresholds). Lives in `services` once §7 #2 lands; local copy for the spike.
- */
-export const WORKOUT_ZONE_COLORS: readonly string[] = [
-    'white',   // 0 - uncolored
-    '#7f7f7f', // 1 - grey   (<= 55% FTP)
-    '#338cff', // 2 - blue   (<= 75%)
-    '#59bf59', // 3 - green  (<= 90%)
-    '#ffcc3f', // 4 - yellow (<= 105%)
-    '#ff6639', // 5 - orange (<= 120%)
-    '#ff330c', // 6 - red    (<= 150%)
-    '#ea39ff', // 7 - magenta(> 150%)
-];
 
 /** Props for the pure, presized WorkoutGraphView (SVG renderer). */
 export interface WorkoutGraphViewProps {


### PR DESCRIPTION
## Summary
Replaces the mobile-local placeholder copies of the WorkoutGraph data shapes with the real exports from `incyclist-services@1.7.78` (session 2.2 `workouts/base/graph` changes), completing the swap the session-1.3 spike planned for.

## What changed
- `src/components/WorkoutGraph/types.ts`: deleted the local `WORKOUT_ZONE_COLORS` constant and the `WorkoutGraphPlanBar` / `WorkoutGraphPlan` / `WorkoutGraphActuals` interfaces; they are now imported from `incyclist-services` and re-exported so existing consumers (`utils.ts`, `WorkoutGraphView`, mocks, tests, stories) are untouched. The mobile-local view props (`WorkoutGraphMode`, `WorkoutGraphPoint`, `WorkoutGraphViewProps`, `WorkoutGraphProps`) stay local.
- `jest.config.js`: extended `transformIgnorePatterns` so Babel transforms `uuid` and `@garmin/fitsdk` — both ESM-only packages that the `incyclist-services` barrel now pulls in at runtime (previously every test mocked the package, so they were never loaded).

No shape drift was found: the published palette is byte-identical to the local copy, and all interfaces match field-for-field.

## Test plan
- `npx tsc --noEmit` — clean
- Full jest suite: 64 suites / 336 tests / 6 snapshots, all green, no test file changed
- Storybook: `Components/WorkoutGraph` detail + live stories verified visually via screenshot — zone colors, FTP line, and live Power/HR overlay all render correctly with the palette imported from services