### PR TITLE
test: verify WorkoutImportDialog's import-update subscription stays live

### DIFF
--- a/src/components/WorkoutImportDialog/WorkoutImportDialog.test.tsx
+++ b/src/components/WorkoutImportDialog/WorkoutImportDialog.test.tsx
@@ -54,4 +54,56 @@ describe('WorkoutImportDialog', () => {
         const { unmount } = render(<WorkoutImportDialog onClose={jest.fn()} />);
         expect(() => unmount()).not.toThrow();
     });
+
+    // Regression coverage for the "dialog stuck on Importing..." bug (5.12): the dialog
+    // never reads onImportFile()'s own return value - it relies entirely on
+    // getPageObserver()'s 'import-update' event (subscribed once on mount) to learn that
+    // the import settled. This checks that subscription actually stays live across the
+    // dialog's lifetime (a stale-closure bug here - e.g. the effect tearing down and
+    // resubscribing, or subscribing to an observer instance that later gets replaced -
+    // was flagged as a real, not-yet-ruled-out candidate for the bug).
+    describe('import-update subscription lifecycle', () => {
+        beforeEach(() => {
+            mockObserver.on.mockClear();
+            mockObserver.off.mockClear();
+            mockService.getImportDisplayProps.mockClear();
+            mockService.getImportDisplayProps.mockReturnValue({ phase: 'landing', knownGroups: ['My Workouts'] });
+        });
+
+        it('subscribes exactly once on mount and unsubscribes the same handler on unmount', () => {
+            const { unmount, rerender } = render(<WorkoutImportDialog onClose={jest.fn()} />);
+
+            expect(mockObserver.on).toHaveBeenCalledTimes(1);
+            expect(mockObserver.on).toHaveBeenCalledWith('import-update', expect.any(Function));
+            const [, registeredHandler] = mockObserver.on.mock.calls[0];
+
+            // a parent re-render (e.g. WorkoutsPage re-rendering for an unrelated reason)
+            // must not tear down and resubscribe - that would be exactly the stale-closure
+            // shape that could orphan the subscription
+            rerender(<WorkoutImportDialog onClose={jest.fn()} />);
+            expect(mockObserver.on).toHaveBeenCalledTimes(1);
+            expect(mockObserver.off).not.toHaveBeenCalled();
+
+            unmount();
+            expect(mockObserver.off).toHaveBeenCalledWith('import-update', registeredHandler);
+        });
+
+        it('re-fetches display props when the subscribed handler fires after onImportFile settles', () => {
+            render(<WorkoutImportDialog onClose={jest.fn()} />);
+
+            const callsBeforeUpdate = mockService.getImportDisplayProps.mock.calls.length;
+            const [, registeredHandler] = mockObserver.on.mock.calls[0];
+
+            // simulate WorkoutListPageService.onImportFile()'s .catch() emitting
+            // 'import-update' on the page observer once the import promise rejects
+            mockService.getImportDisplayProps.mockReturnValueOnce({
+                phase: 'error',
+                knownGroups: ['My Workouts'],
+                error: 'Invalid Step description, power: no values specified',
+            });
+            registeredHandler();
+
+            expect(mockService.getImportDisplayProps.mock.calls.length).toBeGreaterThan(callsBeforeUpdate);
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- Companion PR to incyclist/services#458, which fixes bug 5.12 (workout-mobile-session-plan.md): `WorkoutImportDialog` getting stuck showing "Importing..." forever instead of surfacing a failed import as an error.
- No mobile code changes needed. The mobile-side observer subscription (`WorkoutImportDialog.tsx`'s `useEffect` subscribing to `service.getPageObserver()`'s `'import-update'` event) was one of the candidates the write-up had not yet ruled out — specifically a possible stale-closure bug where the subscription might not stay live across the dialog's lifetime, or might tear down/resubscribe on re-render.
- This PR adds tests that rule that out with an automated test rather than static reading alone.

## What changed
- `src/components/WorkoutImportDialog/WorkoutImportDialog.test.tsx`: added an `'import-update subscription lifecycle'` describe block with two tests:
  - Confirms the dialog subscribes to `'import-update'` exactly once on mount, does not tear down/resubscribe on a parent re-render, and unsubscribes the exact same handler reference on unmount.
  - Confirms that when the subscribed handler fires (simulating `WorkoutListPageService.onImportFile()`'s `.catch()` emitting `'import-update'` after the import promise rejects), the dialog re-fetches display props (i.e. would re-render with the new phase).

## What I verified vs. what's still open
- **Verified**: the mobile-side subscription wiring is not the bug — both tests pass, confirming stable subscribe/unsubscribe behavior and correct reaction to the event.
- **Actual root cause**: found and fixed services-side, in incyclist/services#458 — `WorkoutListPageService.emitImportUpdate()` could have its synchronous `emit()` call aborted by a throwing listener, silently preventing the real import call from ever running. **incyclist/services#458 needs to merge and be published as a new `incyclist-services` version before this fix is live for mobile** (mobile just pins a version of the package; no mobile code needed the fix itself).
- **Not confirmed**: the exact real-device trigger — what specifically threw in the listener chain during the original on-device repro. See incyclist/services#458's description for the full caveat. I could not find an obvious throw path in the current `WorkoutImportDialog.tsx` code, so this PR's tests should be read as "ruling out the stale-closure candidate," not as reproducing the original crash.

## Test plan
- [x] `npm test` (full suite, includes `pretest` barrel-export check) — all passing, 389/389 tests, 73/73 suites, no failures
- [ ] Real-device retest of the original on-device repro, after incyclist-services is bumped to include incyclist/services#458 — not possible in this environment