### PR TITLE
fix: allow creating a new group on the workout-import result screen

### DIFF
--- a/src/components/WorkoutImportDialog/views/ResultView.test.tsx
+++ b/src/components/WorkoutImportDialog/views/ResultView.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, fireEvent } from '@testing-library/react-native';
 import { ResultView } from './ResultView';
 
 const defaultProps = {
@@ -30,5 +30,22 @@ describe('ResultView', () => {
 
     it('renders correctly in compact mode', () => {
         render(<ResultView {...defaultProps} compact={true} />);
+    });
+
+    it('offers "+ New" so the group field can create a new group', () => {
+        const { getByText } = render(<ResultView {...defaultProps} />);
+        expect(getByText('+ New')).toBeTruthy();
+    });
+
+    it('typing a new group name and submitting calls onSetGroup with the typed value', () => {
+        const onSetGroup = jest.fn();
+        const { getByText, getByPlaceholderText } = render(
+            <ResultView {...defaultProps} onSetGroup={onSetGroup} />
+        );
+        fireEvent.press(getByText('+ New'));
+        const input = getByPlaceholderText('New group name');
+        fireEvent.changeText(input, 'Climbing Prep');
+        fireEvent(input, 'submitEditing');
+        expect(onSetGroup).toHaveBeenCalledWith('Climbing Prep');
     });
 });

--- a/src/components/WorkoutImportDialog/views/ResultView.tsx
+++ b/src/components/WorkoutImportDialog/views/ResultView.tsx
@@ -25,7 +25,7 @@ export const ResultView = ({ compact, workoutName, group, knownGroups, onSetGrou
         </Text>
         {group !== undefined && (
             <View style={styles.groupFieldContainer}>
-                <GroupPicker label="Group" groups={knownGroups} value={group} allowNew={false} onValueChange={onSetGroup} />
+                <GroupPicker label="Group" groups={knownGroups} value={group} onValueChange={onSetGroup} />
             </View>
         )}
     </View>


### PR DESCRIPTION
## Summary
- On the workout-import result screen, the Group field only offered existing groups — no way to type a new one.
- Root cause: `ResultView.tsx` passed `allowNew={false}` to `GroupPicker`, copied from `WorkoutsTable`'s filter-row usage (where "+ New" correctly doesn't apply) during an earlier retrofit. The import result screen is exactly the place a newly-imported workout often needs a group that doesn't exist yet.
- Fix: removed the `allowNew={false}` override so `GroupPicker`'s default (`allowNew: true`) applies, re-enabling the "+ New" option.

Corresponds to section 5.17 ("Import result: Group field can't create a new group") of `internal/designs/workout-mobile-session-plan.md`.

## What changed
- `src/components/WorkoutImportDialog/views/ResultView.tsx` — removed `allowNew={false}` from the `GroupPicker` usage.
- `src/components/WorkoutImportDialog/views/ResultView.test.tsx` — added tests confirming "+ New" is offered and that typing a new group name and submitting calls `onSetGroup` with the typed value.

## Test plan
- [x] `npm test` — full suite passes (75 suites, 411 tests)
- [x] New/updated tests specifically cover the "+ New" option appearing and creating a new group via `onSetGroup`