### PR TITLE
fix: subscribe to import observer to prevent stuck import dialog (5.12)

### DIFF
--- a/src/components/WorkoutImportDialog/WorkoutImportDialog.test.tsx
+++ b/src/components/WorkoutImportDialog/WorkoutImportDialog.test.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { WorkoutImportDisplayProps } from 'incyclist-services';
 import { WorkoutImportDialog } from './WorkoutImportDialog';
 
 const mockObserver = { on: jest.fn(), off: jest.fn() };
+const mockImportObserver = { on: jest.fn(), off: jest.fn() };
+
+const mockPickFile = jest.fn().mockResolvedValue(null);
 
 const mockService = {
     getImportDisplayProps: jest.fn<WorkoutImportDisplayProps, []>(() => ({
@@ -12,7 +15,7 @@ const mockService = {
     })),
     getPageObserver: jest.fn(() => mockObserver),
     onImportOpen: jest.fn(),
-    onImportFile: jest.fn(),
+    onImportFile: jest.fn(() => mockImportObserver),
     onImportSetGroup: jest.fn(),
     onImportClose: jest.fn(),
 };
@@ -22,7 +25,7 @@ jest.mock('incyclist-services', () => ({
 }));
 
 jest.mock('../../hooks/files/useFilePicker', () => ({
-    useFilePicker: () => ({ pickFile: jest.fn().mockResolvedValue(null) }),
+    useFilePicker: () => ({ pickFile: mockPickFile }),
 }));
 
 describe('WorkoutImportDialog', () => {
@@ -104,6 +107,36 @@ describe('WorkoutImportDialog', () => {
             registeredHandler();
 
             expect(mockService.getImportDisplayProps.mock.calls.length).toBeGreaterThan(callsBeforeUpdate);
+        });
+    });
+
+    // Regression coverage for 5.12's actual root cause: onImportFile() returns an Observer
+    // wrapping a real Node EventEmitter, which throws synchronously if 'error' is ever emitted
+    // with zero listeners registered (a special case unique to that literal event name). That
+    // throw was aborting WorkoutListPageService's own error-handling before it could update the
+    // dialog's phase - the dialog looked "stuck on Importing..." forever on a genuine parse
+    // failure. Fixed by subscribing to the returned observer, mirroring RouteImportDialog's
+    // existing pattern - this test would fail (via a thrown/unhandled error on `emit`) if that
+    // subscription were ever removed.
+    describe('onPickFile observer subscription', () => {
+        beforeEach(() => {
+            mockImportObserver.on.mockClear();
+            mockService.onImportFile.mockClear();
+            mockPickFile.mockResolvedValueOnce({
+                type: 'file', name: 'test.zwo', ext: 'zwo', filename: '/tmp/test.zwo',
+                delimiter: '/', dir: '/tmp', url: undefined,
+            });
+        });
+
+        it('subscribes to both success and error on the observer returned by onImportFile', async () => {
+            const { getByText } = render(<WorkoutImportDialog onClose={jest.fn()} />);
+
+            fireEvent.press(getByText('Choose Workout File'));
+
+            await waitFor(() => expect(mockService.onImportFile).toHaveBeenCalledTimes(1));
+
+            expect(mockImportObserver.on).toHaveBeenCalledWith('success', expect.any(Function));
+            expect(mockImportObserver.on).toHaveBeenCalledWith('error', expect.any(Function));
         });
     });
 });

--- a/src/components/WorkoutImportDialog/WorkoutImportDialog.tsx
+++ b/src/components/WorkoutImportDialog/WorkoutImportDialog.tsx
@@ -66,7 +66,18 @@ export const WorkoutImportDialog = ({ onClose }: WorkoutImportDialogProps) => {
             const fileInfo = await pickFile({ extensions: IMPORT_FILE_EXTENSIONS });
             if (!fileInfo) return;
 
-            service.onImportFile(fileInfo);
+            const observer = service.onImportFile(fileInfo);
+            // The dialog's own phase transitions are driven entirely by the 'import-update'
+            // subscription above (via getImportDisplayProps()) — these two listeners do nothing
+            // themselves. They exist because `observer` wraps a real Node EventEmitter, which has
+            // a special case for the literal 'error' event: emitting it with zero listeners
+            // registered throws synchronously instead of being a no-op like any other event name.
+            // That throw was aborting onImportFile()'s own error-handling mid-way through (before
+            // it could call emitImportUpdate()), which is why the dialog got stuck on 'importing'
+            // forever on a real parse failure — see session 5.12. RouteImportDialog already
+            // subscribes to its own equivalent observer for the same reason.
+            observer.on('success', () => {});
+            observer.on('error', () => {});
         } catch (err) {
             logError(err, 'onPickFile');
         }


### PR DESCRIPTION
## Summary
- Root cause (fully confirmed via real-device logging, see incyclist/services#463 for the full trace): `onPickFile` discarded the `Observer` returned by `service.onImportFile(fileInfo)` entirely. That observer wraps a real Node `EventEmitter`, which throws synchronously when `'error'` is emitted with zero listeners registered. The throw aborted `WorkoutListPageService`'s own `.catch()` handler mid-way, before it could call `emitImportUpdate()` — so the dialog never learned the import failed and stayed on `"Importing..."` forever on any genuine parse failure.
- Fix: `onPickFile` now subscribes to `'success'`/`'error'` on the returned observer (no-op handlers — the dialog's actual phase transitions are already driven by the separate `'import-update'`/`getImportDisplayProps()` channel). This mirrors `RouteImportDialog`'s existing, already-correct pattern at its two call sites.
- Companion services PR (#463, `incyclist/services`) documents the same landmine at the source with an explanatory comment.

## Test plan
- [x] `npm test` — full suite green (75 suites / 414 tests)
- [x] New regression test asserting `onPickFile` subscribes to both `'success'` and `'error'` on the observer `onImportFile()` returns
- [x] Confirmed on a real Android device: importing a genuinely malformed workout file now correctly shows the error screen instead of hanging on "Importing..."