### PR TITLE
WorkoutRidePage assembly (workout-only ride screen)

### DIFF
--- a/src/components/StartRideDisplay/StartRideDisplay.stories.tsx
+++ b/src/components/StartRideDisplay/StartRideDisplay.stories.tsx
@@ -115,6 +115,20 @@ export const MapError: Story = {
     } as any,
 };
 
+export const StartingWorkoutGestureLegend: Story = {
+    args: {
+        mode: 'Free-Ride',
+        rideState: 'Starting',
+        devices: [
+            { udid: '1', name: 'Daum 8080', isControl: true, status: 'Started', capabilities: ['control'] },
+            { udid: '2', name: 'Polar Hrm', isControl: false, status: 'Starting', capabilities: ['heartrate'] },
+        ],
+        readyToStart: true,
+        workout: true,
+        loadIncrementPct: 2,
+    } as any,
+};
+
 export const StartingFiveSensors: Story = {
     args: {
         mode: 'Free-Ride',

--- a/src/components/StartRideDisplay/StartRideDisplay.tsx
+++ b/src/components/StartRideDisplay/StartRideDisplay.tsx
@@ -11,7 +11,7 @@ import {
 } from './types';
 
 export const StartRideDisplay = (props: StartRideDisplayProps) => {
-    const { devices, rideState, readyToStart, onStart, onRetry, onCancel, onIgnore } = props;
+    const { devices, rideState, readyToStart, onStart, onRetry, onCancel, onIgnore, workout, loadIncrementPct } = props;
 
     const layout = useScreenLayout();
 
@@ -198,7 +198,7 @@ export const StartRideDisplay = (props: StartRideDisplayProps) => {
           ];
 
     return (
-        <Dialog 
+        <Dialog
             title="Starting activity ..."
             variant="info"
             minWidth={minWidth}
@@ -206,10 +206,26 @@ export const StartRideDisplay = (props: StartRideDisplayProps) => {
         >
             <View style={styles.bodyContainer}>
                 {renderDeviceList()}
+                {workout && <GestureLegend loadIncrementPct={loadIncrementPct ?? DEFAULT_LEGEND_INCREMENT} />}
             </View>
         </Dialog>
     );
 };
+
+// Workout-ride-only (workout-mobile-hld.md §3.2), shown while waiting for pedaling — teaches the
+// swipe gestures (session 5.4) before the ride starts, when the rider is attentive and not under
+// load. `loadIncrementPct` must always come from the live `preferences.workouts.loadIncrement`
+// setting (never hardcoded) — the fallback below only covers the case where a caller omits the
+// prop entirely, it does not stand in for reading the real setting.
+const DEFAULT_LEGEND_INCREMENT = 1;
+
+const GestureLegend = ({ loadIncrementPct }: { loadIncrementPct: number }) => (
+    <View style={styles.legendContainer}>
+        <Text style={styles.legendText}>
+            {`◀ ▶ step  ·  ▲ ▼ load ±${loadIncrementPct}%`}
+        </Text>
+    </View>
+);
 
 const styles = StyleSheet.create({
     bodyContainer: {
@@ -249,5 +265,17 @@ const styles = StyleSheet.create({
     },
     spacer: {
         height: 8,
+    },
+    legendContainer: {
+        marginTop: 12,
+        paddingTop: 8,
+        borderTopWidth: 1,
+        borderTopColor: 'rgba(255,255,255,0.15)',
+        alignItems: 'center',
+    },
+    legendText: {
+        color: colors.disabled,
+        fontSize: textSizes.subtitle,
+        textAlign: 'center',
     },
 });

--- a/src/components/StartRideDisplay/types.ts
+++ b/src/components/StartRideDisplay/types.ts
@@ -12,8 +12,17 @@ export type StartCancelReason = {
     map?:boolean
 }
 export type StartRideDisplayProps = (StartOverlayProps | GPXStartOverlayProps | VideoStartOverlayProps) & {
-    onStart: ()=>void, 
-    onRetry: ()=>void, 
-    onCancel: (reason?:StartCancelReason)=>void, 
-    onIgnore: ()=>void    
+    onStart: ()=>void,
+    onRetry: ()=>void,
+    onCancel: (reason?:StartCancelReason)=>void,
+    onIgnore: ()=>void
+    /**
+     * Workout-ride-only (workout-mobile-hld.md §3.2 "StartRideDisplay gesture legend", session
+     * 5.6). When true, the default 'starting' state (waiting for pedaling, no error) shows a
+     * compact "◀ ▶ step · ▲ ▼ load ±N%" legend teaching the swipe gestures before the ride
+     * starts. `loadIncrementPct` supplies N — always the live `preferences.workouts.loadIncrement`
+     * setting (session 5.4), never hardcoded.
+     */
+    workout?: boolean
+    loadIncrementPct?: number
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './logging'
 export * from './unmount'
 export * from './render'
 export * from './navigation/useBackHandler' // Export the new hook
+export * from './ride'

--- a/src/hooks/ride/useWorkoutRideGestures.test.ts
+++ b/src/hooks/ride/useWorkoutRideGestures.test.ts
@@ -81,6 +81,18 @@ describe('useWorkoutRideGestures', () => {
         expect(capturedOnEnd).toBeInstanceOf(Function);
     });
 
+    it('exposes the live loadIncrement setting, never a hardcoded value', () => {
+        mockGetValue.mockImplementation(() => 7);
+        const { result } = renderHook(() => useWorkoutRideGestures());
+        expect(result.current.loadIncrement).toBe(7);
+        expect(mockGetValue).toHaveBeenCalledWith(WORKOUT_LOAD_INCREMENT_SETTING_KEY, DEFAULT_WORKOUT_LOAD_INCREMENT);
+    });
+
+    it('falls back to the default loadIncrement when no setting is stored', () => {
+        const { result } = renderHook(() => useWorkoutRideGestures());
+        expect(result.current.loadIncrement).toBe(DEFAULT_WORKOUT_LOAD_INCREMENT);
+    });
+
     it('steps back on a left swipe, vibrates, and shows feedback', () => {
         const vibrateSpy = jest.spyOn(Vibration, 'vibrate');
         const { result } = renderHook(() => useWorkoutRideGestures());

--- a/src/hooks/ride/useWorkoutRideGestures.ts
+++ b/src/hooks/ride/useWorkoutRideGestures.ts
@@ -59,6 +59,10 @@ export interface UseWorkoutRideGesturesResult {
     /** Pass to <GestureDetector gesture={gesture}>; undefined on web/Storybook, where GestureDetector must not be rendered. */
     gesture: any;
     feedback: WorkoutRideGestureFeedback;
+    /** Current `preferences.workouts.loadIncrement` setting (%) — read live, never hardcoded.
+     * Exposed so callers (e.g. the StartRideDisplay gesture legend) can show the real value
+     * without duplicating the useUserSettings() lookup this hook already does for swipe-up/down. */
+    loadIncrement: number;
 }
 
 export const useWorkoutRideGestures = (): UseWorkoutRideGesturesResult => {
@@ -130,5 +134,5 @@ export const useWorkoutRideGestures = (): UseWorkoutRideGesturesResult => {
             });
     }, [handleSwipe]);
 
-    return { gesture, feedback };
+    return { gesture, feedback, loadIncrement: getLoadIncrement() };
 };

--- a/src/pages/RidePage/RidePage.tsx
+++ b/src/pages/RidePage/RidePage.tsx
@@ -4,6 +4,7 @@ import { getRidePageService, RideType, StartGateProps } from 'incyclist-services
 import { MainBackground, Button, Dialog,PageTransition } from '../../components';
 import { VideoRidePage } from './Video';
 import { GPXTourPage } from './GPX'; // New import for GPXTourPage
+import { WorkoutRidePage } from './Workout';
 import { colors } from '../../theme';
 import { textSizes } from '../../theme';
 import { initSecrets } from '../../bindings/secret';
@@ -134,6 +135,10 @@ export const RidePage = ({ simulate = false }: RidePageProps) => {
 
     if (rideType === 'GPX') { // Handle GPX ride type
         return <GPXTourPage simulate={simulate} onRideTypeChange={onRideTypeChange} onCancelStart={onCancelStart} onClose={onClose} />;
+    }
+
+    if (rideType === 'Workout') {
+        return <WorkoutRidePage simulate={simulate} onRideTypeChange={onRideTypeChange} onCancelStart={onCancelStart} onClose={onClose} />;
     }
 
     // Default case for any other rideType not explicitly handled

--- a/src/pages/RidePage/Workout/View.tsx
+++ b/src/pages/RidePage/Workout/View.tsx
@@ -1,0 +1,233 @@
+import React, { useCallback, useState } from 'react';
+import { Platform, StyleSheet, View } from 'react-native';
+import { IObserver, WorkoutGraphActuals, WorkoutRidePageDisplayProps } from 'incyclist-services';
+import {
+    Button,
+    Dynamic,
+    MainBackground,
+    RideDashboard,
+    RideMenu,
+    StartRideDisplay,
+    WorkoutGraph,
+    WorkoutStepsList,
+    WorkoutSwipeFeedback,
+} from '../../../components';
+import { colors } from '../../../theme';
+import { useScreenLayout, WorkoutRideGestureFeedback } from '../../../hooks';
+
+// Conditional import — same pattern as WorkoutItemView / useWorkoutRideGestures (session 5.4):
+// keeps Storybook (Vite/web) and any environment without the native module from crashing.
+// `gesture` (from useWorkoutRideGestures) is already undefined on web/Storybook, so
+// GestureDetector is simply never rendered there even when this fallback resolves to `View`.
+let GestureDetector: any = View;
+try {
+    if (Platform.OS !== 'web') {
+        ({ GestureDetector } = require('react-native-gesture-handler'));
+    }
+} catch {
+    GestureDetector = View;
+}
+
+export interface WorkoutRidePageViewProps {
+    displayProps: WorkoutRidePageDisplayProps;
+    rideObserver: IObserver | null;
+    /** From useWorkoutRideGestures() — undefined on web/Storybook, where GestureDetector must not be used. */
+    gesture: any;
+    feedback: WorkoutRideGestureFeedback;
+    /** Live `preferences.workouts.loadIncrement` setting (%) — shown in the start-overlay legend. */
+    loadIncrementPct: number;
+    /** Pulls a fresh WorkoutGraphActuals snapshot — wired to the ride observer's `data-update`
+     * tick via <Dynamic>, so only the graph subtree re-renders at 1 Hz, never the whole page. */
+    getGraphActuals: () => WorkoutGraphActuals;
+    onMenuOpen: () => void;
+    onMenuClose: () => void;
+    onCloseRidePage: () => void;
+    onRetryStart: () => void;
+    onIgnoreStart: () => void;
+    onCancelStart: () => void;
+}
+
+const noop = () => {};
+
+const MenuButton = React.memo(({ onPress }: { onPress: () => void }) => (
+    <Button id="menu" label="Menu" primary={true} onClick={onPress} />
+));
+
+/**
+ * Pure view for the Workout ride screen (workout-mobile-hld.md §3.2/§5, session 5.6). Composes
+ * `RideDashboard` (workout shoutout line), `WorkoutStepsList`, `WorkoutGraph` `live` mode, the
+ * session-5.4 swipe gesture surface + feedback toast, and the workout-flavored `RideMenu` — the
+ * same pieces the session-4.2 `WorkoutRidePrototype` story checked visually, now laid out with
+ * this app's absolute-overlay ride-screen convention (`VideoRidePageView`/`GPXTourPageView`)
+ * instead of that story's in-flow flex column.
+ *
+ * No map/video/elevation strip — the graph is the dominant element (HLD §5) and fills the whole
+ * area below the dashboard + steps/menu band; the background is solid black, not the usual
+ * MainBackground photo (session 4.2 review — see `colors.workoutRideBackground`).
+ */
+export const WorkoutRidePageView = (props: WorkoutRidePageViewProps) => {
+    const {
+        displayProps,
+        rideObserver,
+        gesture,
+        feedback,
+        loadIncrementPct,
+        getGraphActuals,
+        onMenuOpen,
+        onMenuClose,
+        onCloseRidePage,
+        onRetryStart,
+        onIgnoreStart,
+        onCancelStart,
+    } = props;
+
+    const { startOverlayProps, menuProps, graph, steps, dashboard } = displayProps;
+
+    const layout = useScreenLayout();
+    const isCompact = layout === 'compact';
+
+    // Measured, not analytically budgeted — unlike the 4.2 Storybook prototype (whose fixed-dp
+    // frames couldn't rely on onLayout resolving under the Vite renderer), this is the real app,
+    // where onLayout is already how VideoRidePageView/GPXTourPageView size their own dashboard band.
+    const [dashboardHeight, setDashboardHeight] = useState(0);
+    const onDashboardLayout = useCallback((e: any) => {
+        setDashboardHeight(e.nativeEvent.layout.height);
+    }, []);
+
+    const [midBandHeight, setMidBandHeight] = useState(0);
+    const onMidBandLayout = useCallback((e: any) => {
+        setMidBandHeight(e.nativeEvent.layout.height);
+    }, []);
+
+    const midBandTopStyle = { top: dashboardHeight };
+    const graphTopStyle = { top: dashboardHeight + midBandHeight };
+
+    const content = (
+        <View style={StyleSheet.absoluteFill}>
+            <View style={styles.dashboardContainer} onLayout={onDashboardLayout}>
+                <RideDashboard layout="icon-left" workoutShoutout={dashboard} />
+            </View>
+
+            {/* Menu button (top-left — the RideMenu panel is left-anchored, review round 4 of the
+                4.2 prototype) + upcoming-steps panel (right), banded directly below the dashboard,
+                on top of the graph rather than stealing a fixed share of it. */}
+            <View style={[styles.middleBand, midBandTopStyle]} onLayout={onMidBandLayout}>
+                <View style={isCompact ? styles.menuButtonCompact : styles.menuButtonTablet}>
+                    <MenuButton onPress={onMenuOpen} />
+                </View>
+                <View style={styles.middleSpacer} />
+                <WorkoutStepsList
+                    steps={steps}
+                    compact={isCompact}
+                    style={isCompact ? styles.stepsCompact : styles.stepsTablet}
+                />
+            </View>
+
+            <View style={[styles.graphContainer, graphTopStyle]}>
+                <Dynamic
+                    observer={rideObserver ?? undefined}
+                    event="data-update"
+                    prop="actuals"
+                    transform={getGraphActuals}
+                >
+                    <WorkoutGraph mode="live" plan={graph} showAxes={true} showFtpLine={true} style={styles.graph} />
+                </Dynamic>
+            </View>
+
+            <WorkoutSwipeFeedback visible={feedback.visible} message={feedback.message} />
+
+            {menuProps && (
+                <RideMenu
+                    visible={true}
+                    workout={true}
+                    onClose={onMenuClose}
+                    onCloseRidePage={onCloseRidePage}
+                />
+            )}
+        </View>
+    );
+
+    return (
+        <View style={styles.container}>
+            {!startOverlayProps && (
+                gesture ? (
+                    <GestureDetector gesture={gesture}>
+                        {content}
+                    </GestureDetector>
+                ) : content
+            )}
+
+            {startOverlayProps && <MainBackground />}
+
+            {startOverlayProps && (
+                <StartRideDisplay
+                    {...startOverlayProps}
+                    workout={true}
+                    loadIncrementPct={loadIncrementPct}
+                    onStart={noop}
+                    onRetry={onRetryStart}
+                    onIgnore={onIgnoreStart}
+                    onCancel={onCancelStart}
+                />
+            )}
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: colors.workoutRideBackground,
+        overflow: 'hidden',
+    },
+    dashboardContainer: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        zIndex: 10,
+    },
+    middleBand: {
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        flexDirection: 'row',
+        alignItems: 'flex-start',
+        zIndex: 10,
+    },
+    middleSpacer: {
+        flex: 1,
+    },
+    menuButtonTablet: {
+        marginLeft: 12,
+        marginTop: 8,
+    },
+    menuButtonCompact: {
+        marginLeft: 8,
+        marginTop: 4,
+    },
+    stepsTablet: {
+        width: 340,
+        marginRight: 12,
+        marginTop: 8,
+    },
+    stepsCompact: {
+        width: 260,
+        marginRight: 8,
+        marginTop: 4,
+    },
+    graphContainer: {
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        bottom: 0,
+    },
+    graph: {
+        marginHorizontal: 8,
+        marginBottom: 4,
+    },
+});

--- a/src/pages/RidePage/Workout/WorkoutRidePage.stories.tsx
+++ b/src/pages/RidePage/Workout/WorkoutRidePage.stories.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { StyleSheet, useWindowDimensions, View } from 'react-native';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { fn } from 'storybook/test';
+import type { WorkoutGraphActuals, WorkoutRidePageDisplayProps } from 'incyclist-services';
+import { WorkoutRidePageView } from './View';
+import {
+    MOCK_ACTUALS_MID,
+    MOCK_ACTUALS_SKIPBACK,
+    MOCK_PLAN_LIVE_MID,
+    MOCK_PLAN_LIVE_SKIPBACK,
+} from '../../../components/WorkoutGraph/WorkoutGraph.mock';
+
+/**
+ * Real page-assembly story (session 5.6) — supersedes the session-4.2 `WorkoutRidePrototype`
+ * checkpoint story (kept as historical record, not deleted). Targets `WorkoutRidePageView`
+ * (the pure view, per this repo's Storybook rules), driven by hand-authored
+ * `WorkoutRidePageDisplayProps` mocks reused from the signed-off 4.2 prototype so the two stay
+ * visually comparable.
+ */
+
+const callbacks = {
+    onMenuOpen: fn(),
+    onMenuClose: fn(),
+    onCloseRidePage: fn(),
+    onRetryStart: fn(),
+    onIgnoreStart: fn(),
+    onCancelStart: fn(),
+};
+
+const styles = StyleSheet.create({
+    container: { flex: 1, position: 'relative', width: '100%' },
+});
+
+const meta: Meta<typeof WorkoutRidePageView> = {
+    title: 'Pages/WorkoutRidePage',
+    component: WorkoutRidePageView,
+    args: {
+        ...callbacks,
+        rideObserver: null,
+        gesture: undefined,
+        feedback: { visible: false, message: '' },
+        loadIncrementPct: 1,
+        getGraphActuals: (): WorkoutGraphActuals => ({ power: [], heartrate: [], position: 0 }),
+    },
+    decorators: [
+        (Story) => {
+            const { width, height } = useWindowDimensions();
+            const fullScreen = { minHeight: height || 500, minWidth: width || 800 };
+            return (
+                <View style={[styles.container, fullScreen]}>
+                    <Story />
+                </View>
+            );
+        },
+    ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof WorkoutRidePageView>;
+
+const MID_WORKOUT: WorkoutRidePageDisplayProps = {
+    rideState: 'Active',
+    rideType: 'Workout',
+    startOverlayProps: null,
+    startGateProps: null,
+    menuProps: { showResume: false, canStepBack: true, canStepForward: true },
+    graph: MOCK_PLAN_LIVE_MID,
+    steps: {
+        previous: { label: '200W', targetPower: 200, duration: 300, remaining: null, isCurrent: false },
+        current: { label: '280W', targetPower: 280, duration: 180, remaining: 30, isCurrent: true },
+        upcoming: [
+            { label: '130W', targetPower: 130, duration: 120, remaining: null, isCurrent: false },
+            { label: '280W', targetPower: 280, duration: 180, remaining: null, isCurrent: false },
+            { label: '130W', targetPower: 130, duration: 120, remaining: null, isCurrent: false },
+        ],
+        hasMore: true,
+    },
+    dashboard: { text: '280W for 3min - VO2 max (1/3)', mode: 'ERG' },
+    title: 'VO2 max (1/3)',
+};
+
+const AFTER_SKIP_BACK: WorkoutRidePageDisplayProps = {
+    rideState: 'Active',
+    rideType: 'Workout',
+    startOverlayProps: null,
+    startGateProps: null,
+    menuProps: { showResume: false, canStepBack: true, canStepForward: false },
+    graph: MOCK_PLAN_LIVE_SKIPBACK,
+    steps: {
+        previous: { label: '130W', targetPower: 130, duration: 120, remaining: null, isCurrent: false },
+        current: { label: 'Ramp 150-100W', targetPower: 125, duration: 300, remaining: 150, isCurrent: true },
+        upcoming: [],
+        hasMore: false,
+    },
+    dashboard: { text: 'Ramp 150-100W for 5min - Cooldown', mode: 'ERG' },
+    title: 'Cooldown',
+};
+
+const STARTING: WorkoutRidePageDisplayProps = {
+    rideState: 'Starting',
+    rideType: 'Workout',
+    startOverlayProps: {
+        mode: 'Free-Ride',
+        rideState: 'Starting',
+        devices: [
+            { udid: '1', name: 'Smart Trainer', isControl: true, status: 'Started', capabilities: ['control'] },
+            { udid: '2', name: 'Polar Hrm', isControl: false, status: 'Starting', capabilities: ['heartrate'] },
+        ],
+        readyToStart: true,
+    } as any,
+    startGateProps: null,
+    menuProps: null,
+    graph: { bars: [], ftp: 0, ftpLine: 0, domain: { x: [0, 0], y: [0, 0] } },
+    steps: { previous: null, current: null, upcoming: [], hasMore: false },
+    dashboard: { text: '', mode: null },
+    title: '',
+};
+
+export const MidWorkout: Story = {
+    args: {
+        displayProps: MID_WORKOUT,
+        getGraphActuals: (): WorkoutGraphActuals => MOCK_ACTUALS_MID,
+    },
+};
+
+/** Same session, after the skip-back — compare the graph's trailing x-tick and steps' "end of workout" hint. */
+export const AfterSkipBack: Story = {
+    args: {
+        displayProps: AFTER_SKIP_BACK,
+        getGraphActuals: (): WorkoutGraphActuals => MOCK_ACTUALS_SKIPBACK,
+    },
+};
+
+export const MenuOpen: Story = {
+    args: {
+        displayProps: { ...MID_WORKOUT, menuProps: { showResume: false, canStepBack: true, canStepForward: true } },
+        getGraphActuals: (): WorkoutGraphActuals => MOCK_ACTUALS_MID,
+    },
+};
+
+/** Waiting for pedaling — the new session-5.6 gesture legend under the device list. */
+export const Starting: Story = {
+    args: {
+        displayProps: STARTING,
+        loadIncrementPct: 2,
+    },
+};
+
+/** Frozen frame right after a swipe-up fires — judges the toast against the real page layout. */
+export const SwipeFeedback: Story = {
+    args: {
+        displayProps: MID_WORKOUT,
+        getGraphActuals: (): WorkoutGraphActuals => MOCK_ACTUALS_MID,
+        feedback: { visible: true, message: '+1%' },
+    },
+};

--- a/src/pages/RidePage/Workout/WorkoutRidePage.stories.tsx
+++ b/src/pages/RidePage/Workout/WorkoutRidePage.stories.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { StyleSheet, useWindowDimensions, View } from 'react-native';
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { fn } from 'storybook/test';
-import type { WorkoutGraphActuals, WorkoutRidePageDisplayProps } from 'incyclist-services';
+import { ActivityRideService, Observer } from 'incyclist-services';
+import type { ActivityDashboardItem, WorkoutGraphActuals, WorkoutRidePageDisplayProps } from 'incyclist-services';
 import { WorkoutRidePageView } from './View';
 import {
     MOCK_ACTUALS_MID,
@@ -32,9 +33,54 @@ const styles = StyleSheet.create({
     container: { flex: 1, position: 'relative', width: '100%' },
 });
 
+const MOCK_ACTIVITY_DASHBOARD_ITEMS: ActivityDashboardItem[] = [
+    { title: 'Time', data: [{ value: '0:12:30' }] },
+    { title: 'Power', data: [{ value: '278', unit: 'W' }, { value: '245', label: 'avg' }] },
+    { title: 'Heartrate', data: [{ value: '151', unit: 'bpm' }, { value: '142', label: 'avg' }] },
+    { title: 'Cadence', data: [{ value: '92', unit: 'rpm' }, { value: '88', label: 'avg' }] },
+];
+
+/**
+ * `RideDashboard` (rendered inside `WorkoutRidePageView`, same as `VideoRidePageView`/
+ * `GPXTourPageView`) is a smart component — it calls `useActivityRide()` directly, which is a
+ * live `@Singleton` service with no data outside a real ride, so it renders nothing here.
+ * `incyclist-services` doesn't surface its `Inject()` DI-override helper (the one `services`'
+ * own Jest tests use, e.g. `services/src/workouts/ride/page/service.unit.test.ts`) through its
+ * public package API, so this seeds the `@Singleton`-backed `ActivityRideService` instance
+ * directly instead: `useActivityRide()` is just `new ActivityRideService()` under the hood, and
+ * `@Singleton` guarantees every subsequent call — including `RideDashboard`'s — returns this
+ * same, already-patched instance. Module-level, so it runs once before any story renders.
+ */
+const activityRideInstance = new ActivityRideService();
+activityRideInstance.getObserver = () => new Observer();
+activityRideInstance.getDashboardDisplayProperties = () => MOCK_ACTIVITY_DASHBOARD_ITEMS;
+
+/**
+ * `<Dynamic>` (see Dynamic.tsx) only subscribes to `rideObserver` and pulls a fresh
+ * `getGraphActuals()` snapshot when it's given a non-null observer — with `rideObserver: null`
+ * the whole subscription effect short-circuits and `WorkoutGraph` never receives `actuals`,
+ * regardless of how good a story's `getGraphActuals` mock is. This renderer gives every story a
+ * real `Observer` (per-story instance, so stories don't share subscription state) and emits a
+ * single `data-update` tick right after mount — mirroring the real ride observer's tick — so
+ * `<Dynamic>` calls `getGraphActuals()` and the graph actually shows each story's mock data.
+ */
+const WorkoutRidePageStoryRenderer = (args: React.ComponentProps<typeof WorkoutRidePageView>) => {
+    const observerRef = useRef<Observer | null>(null);
+    if (!observerRef.current) {
+        observerRef.current = new Observer();
+    }
+
+    useEffect(() => {
+        observerRef.current?.emit('data-update');
+    }, []);
+
+    return <WorkoutRidePageView {...args} rideObserver={observerRef.current} />;
+};
+
 const meta: Meta<typeof WorkoutRidePageView> = {
     title: 'Pages/WorkoutRidePage',
     component: WorkoutRidePageView,
+    render: (args) => <WorkoutRidePageStoryRenderer {...args} />,
     args: {
         ...callbacks,
         rideObserver: null,
@@ -65,7 +111,7 @@ const MID_WORKOUT: WorkoutRidePageDisplayProps = {
     rideType: 'Workout',
     startOverlayProps: null,
     startGateProps: null,
-    menuProps: { showResume: false, canStepBack: true, canStepForward: true },
+    menuProps: null,
     graph: MOCK_PLAN_LIVE_MID,
     steps: {
         previous: { label: '200W', targetPower: 200, duration: 300, remaining: null, isCurrent: false },
@@ -86,7 +132,7 @@ const AFTER_SKIP_BACK: WorkoutRidePageDisplayProps = {
     rideType: 'Workout',
     startOverlayProps: null,
     startGateProps: null,
-    menuProps: { showResume: false, canStepBack: true, canStepForward: false },
+    menuProps: null,
     graph: MOCK_PLAN_LIVE_SKIPBACK,
     steps: {
         previous: { label: '130W', targetPower: 130, duration: 120, remaining: null, isCurrent: false },

--- a/src/pages/RidePage/Workout/WorkoutRidePage.test.tsx
+++ b/src/pages/RidePage/Workout/WorkoutRidePage.test.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { WorkoutRidePage } from './WorkoutRidePage';
+
+const mockOnMenuOpen = jest.fn();
+const mockOnMenuClose = jest.fn();
+const mockOnRetryStart = jest.fn();
+const mockOnIgnoreStart = jest.fn();
+const mockGetGraphActuals = jest.fn(() => ({ power: [], heartrate: [], position: 0 }));
+const mockPausePage = jest.fn();
+const mockResumePage = jest.fn();
+const mockClosePage = jest.fn();
+const mockGetRideObserver = jest.fn(() => ({ on: jest.fn(), off: jest.fn() }));
+const mockGetPageDisplayProps = jest.fn(() => ({
+    rideState: 'Active',
+    rideType: 'Workout',
+    startOverlayProps: null,
+    startGateProps: null,
+    menuProps: null,
+    graph: { bars: [], ftp: 200, ftpLine: 200, domain: { x: [0, 0], y: [0, 0] } },
+    steps: { previous: null, current: null, upcoming: [], hasMore: false },
+    dashboard: { text: '', mode: null },
+    title: '',
+}));
+
+let capturedHandlers: Record<string, (...args: any[]) => void> = {};
+const mockOpenPage = jest.fn(() => {
+    capturedHandlers = {};
+    return {
+        on: jest.fn((event: string, handler: (...args: any[]) => void) => { capturedHandlers[event] = handler; }),
+        off: jest.fn(),
+        stop: jest.fn(),
+    };
+});
+
+const mockGoBack = jest.fn();
+
+jest.mock('incyclist-services', () => ({
+    getWorkoutRidePageService: () => ({
+        openPage: mockOpenPage,
+        closePage: mockClosePage,
+        pausePage: mockPausePage,
+        resumePage: mockResumePage,
+        getRideObserver: mockGetRideObserver,
+        getPageDisplayProps: mockGetPageDisplayProps,
+        getGraphActuals: mockGetGraphActuals,
+        onMenuOpen: mockOnMenuOpen,
+        onMenuClose: mockOnMenuClose,
+        onRetryStart: mockOnRetryStart,
+        onIgnoreStart: mockOnIgnoreStart,
+    }),
+}));
+
+jest.mock('../../../hooks', () => ({
+    useUnmountEffect: (effect: () => void) => {
+        const ReactActual = require('react');
+        ReactActual.useEffect(() => () => effect(), []);
+    },
+    useWorkoutRideGestures: () => ({
+        gesture: undefined,
+        feedback: { visible: false, message: '' },
+        loadIncrement: 1,
+    }),
+}));
+
+jest.mock('../../../services', () => ({
+    // Indirected through a wrapper (not `goBack: mockGoBack` directly) — this factory runs at
+    // require-time, before the later `const mockGoBack = jest.fn()` assignment further down this
+    // file has executed, so capturing it eagerly here would freeze `goBack` at `undefined`.
+    goBack: (...args: unknown[]) => mockGoBack(...args),
+}));
+
+jest.mock('../../../components', () => {
+    const { Text } = require('react-native');
+    return {
+        MainBackground: () => <Text>main-background</Text>,
+        ErrorBoundary: ({ children }: any) => children,
+    };
+});
+
+jest.mock('./View', () => {
+    const { Text } = require('react-native');
+    return {
+        WorkoutRidePageView: (props: any) => <Text>view:{props.displayProps?.rideState}</Text>,
+    };
+});
+
+describe('WorkoutRidePage', () => {
+    const noop = () => {};
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockGetPageDisplayProps.mockReturnValue({
+            rideState: 'Active',
+            rideType: 'Workout',
+            startOverlayProps: null,
+            startGateProps: null,
+            menuProps: null,
+            graph: { bars: [], ftp: 200, ftpLine: 200, domain: { x: [0, 0], y: [0, 0] } },
+            steps: { previous: null, current: null, upcoming: [], hasMore: false },
+            dashboard: { text: '', mode: null },
+            title: '',
+        } as any);
+    });
+
+    it('renders without crashing, opens the page on mount and closes it on unmount', () => {
+        const { unmount, toJSON } = render(
+            <WorkoutRidePage onRideTypeChange={noop} onCancelStart={noop} onClose={noop} />
+        );
+        expect(toJSON()).toBeDefined();
+        expect(mockOpenPage).toHaveBeenCalledTimes(1);
+
+        unmount();
+        expect(mockClosePage).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows the empty/loading background before the service reports display props', () => {
+        mockOpenPage.mockImplementationOnce(() => ({ on: jest.fn(), off: jest.fn(), stop: jest.fn() }));
+        mockGetPageDisplayProps.mockReturnValueOnce(undefined as any);
+        const { getByText } = render(
+            <WorkoutRidePage onRideTypeChange={noop} onCancelStart={noop} onClose={noop} />
+        );
+        expect(getByText('main-background')).toBeTruthy();
+    });
+
+    it('renders the view once the page service reports display props', () => {
+        const { getByText } = render(
+            <WorkoutRidePage onRideTypeChange={noop} onCancelStart={noop} onClose={noop} />
+        );
+        expect(getByText('view:Active')).toBeTruthy();
+    });
+
+    it('calls navigation.goBack() when the service emits navigate-back', () => {
+        render(<WorkoutRidePage onRideTypeChange={noop} onCancelStart={noop} onClose={noop} />);
+        expect(capturedHandlers['navigate-back']).toBeInstanceOf(Function);
+
+        capturedHandlers['navigate-back']();
+        expect(mockGoBack).toHaveBeenCalledTimes(1);
+    });
+
+    it('pauses the page when the app goes to background and resumes on foreground', () => {
+        render(<WorkoutRidePage onRideTypeChange={noop} onCancelStart={noop} onClose={noop} />);
+
+        const { AppState } = require('react-native');
+        const listener = (AppState.addEventListener as jest.Mock).mock.calls.at(-1)[1];
+
+        listener('background');
+        expect(mockPausePage).toHaveBeenCalledTimes(1);
+
+        listener('active');
+        expect(mockResumePage).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/pages/RidePage/Workout/WorkoutRidePage.tsx
+++ b/src/pages/RidePage/Workout/WorkoutRidePage.tsx
@@ -1,0 +1,141 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { View, AppState } from 'react-native';
+import {
+    getWorkoutRidePageService,
+    IObserver,
+    RideType,
+    WorkoutGraphActuals,
+    WorkoutRidePageDisplayProps,
+    WorkoutRidePageService,
+} from 'incyclist-services';
+import { useUnmountEffect, useWorkoutRideGestures } from '../../../hooks';
+import { colors } from '../../../theme';
+import { WorkoutRidePageView } from './View';
+import { MainBackground, ErrorBoundary } from '../../../components';
+import { goBack } from '../../../services';
+
+interface WorkoutRidePageProps {
+    simulate?: boolean;
+    onRideTypeChange: (updated: RideType) => void;
+    onCancelStart: () => void;
+    onClose: () => void;
+}
+
+const EMPTY_ACTUALS: WorkoutGraphActuals = { power: [], heartrate: [], position: 0 };
+
+/**
+ * Smart page for a workout-only ride (workout-mobile-hld.md §3.2/§5, session 5.6). Owns
+ * `WorkoutRidePageService`'s lifecycle and app background/foreground handling — mirrors
+ * `VideoRidePage`/`GPXTourPage` exactly, except this page's service is a dedicated sibling
+ * service (`WorkoutRidePageService`, session 2.2), not the shared `RidePageService` those two
+ * ride types use (workout-ride-page-service-design.md §7 #5 — explicit non-goal).
+ *
+ * One extra subscription vs. Video/GPX: `navigate-back`, emitted when the workout finishes,
+ * is stopped, or the underlying ride reaches `Finished` on its own (design doc §5) — the UI
+ * calls `navigation.goBack()` directly for that path. The RideMenu's own "End Ride" flow is
+ * unchanged (pause + ActivitySummaryDialog review, then `onCloseRidePage` -> this page's
+ * `onClose` prop -> the base `RidePageService.onEndRide()`, same as every other ride type).
+ */
+export const WorkoutRidePage = ({ simulate = false, onRideTypeChange, onCancelStart, onClose }: WorkoutRidePageProps) => {
+    const [displayProps, setDisplayProps] = useState<WorkoutRidePageDisplayProps | null>(null);
+
+    const refService = useRef<WorkoutRidePageService | null>(null);
+    const refObserver = useRef<IObserver | null>(null);
+    const refRideObserver = useRef<IObserver | null>(null);
+    const refInitialized = useRef(false);
+
+    const { gesture, feedback, loadIncrement } = useWorkoutRideGestures();
+
+    const onUpdate = useCallback(() => {
+        const service = refService.current;
+        if (service) {
+            const update = service.getPageDisplayProps();
+            setDisplayProps(update);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (refInitialized.current) return;
+        refInitialized.current = true;
+
+        const service = getWorkoutRidePageService();
+        refService.current = service;
+
+        // openPage returns the page observer
+        refObserver.current = service.openPage(simulate);
+        // ride observer is available after page is open
+        refRideObserver.current = service.getRideObserver();
+
+        if (refObserver.current) {
+            refObserver.current.on('page-update', onUpdate);
+            refObserver.current.on('ride-type-update', onRideTypeChange);
+            refObserver.current.on('navigate-back', goBack);
+        }
+
+        onUpdate();
+    }, [simulate, onUpdate, onRideTypeChange]);
+
+    useEffect(() => {
+        const subscription = AppState.addEventListener('change', (nextAppState) => {
+            const service = refService.current;
+            if (!service) return;
+
+            if (nextAppState === 'background' || nextAppState === 'inactive') {
+                service.pausePage();
+            } else if (nextAppState === 'active') {
+                service.resumePage();
+            }
+        });
+
+        return () => {
+            subscription.remove();
+        };
+    }, []);
+
+    useUnmountEffect(() => {
+        if (refObserver.current) {
+            refObserver.current.off('page-update', onUpdate);
+            refObserver.current.off('ride-type-update', onRideTypeChange);
+            refObserver.current.off('navigate-back', goBack);
+        }
+        refService.current?.closePage();
+        refInitialized.current = false;
+    });
+
+    const onMenuOpen = useCallback(() => refService.current?.onMenuOpen(), []);
+    const onMenuClose = useCallback(() => refService.current?.onMenuClose(), []);
+    const onRetryStart = useCallback(() => refService.current?.onRetryStart(), []);
+    const onIgnoreStart = useCallback(() => refService.current?.onIgnoreStart(), []);
+    const getGraphActuals = useCallback(
+        () => refService.current?.getGraphActuals() ?? EMPTY_ACTUALS,
+        []
+    );
+
+    const styleEmpty = { flex: 1, backgroundColor: colors.background };
+    if (!displayProps) {
+        return (
+            <View style={styleEmpty}>
+                <MainBackground />
+            </View>
+        );
+    }
+
+    return (
+        <ErrorBoundary>
+            <WorkoutRidePageView
+                displayProps={displayProps}
+                rideObserver={refRideObserver.current}
+                gesture={gesture}
+                feedback={feedback}
+                loadIncrementPct={loadIncrement}
+                getGraphActuals={getGraphActuals}
+                onMenuOpen={onMenuOpen}
+                onMenuClose={onMenuClose}
+                onCloseRidePage={onClose}
+                onRetryStart={onRetryStart}
+                onIgnoreStart={onIgnoreStart}
+                onCancelStart={onCancelStart}
+            />
+        </ErrorBoundary>
+    );
+};

--- a/src/pages/RidePage/Workout/index.ts
+++ b/src/pages/RidePage/Workout/index.ts
@@ -1,0 +1,2 @@
+export { WorkoutRidePage } from './WorkoutRidePage';
+export { WorkoutRidePageView } from './View';

--- a/src/pages/RidePage/index.ts
+++ b/src/pages/RidePage/index.ts
@@ -1,3 +1,4 @@
 export * from './Video';
 export * from './GPX'; // Export new GPX folder
+export * from './Workout';
 export * from './RidePage';

--- a/src/pages/RootNavigator/RootNavigator.tsx
+++ b/src/pages/RootNavigator/RootNavigator.tsx
@@ -49,6 +49,9 @@ export const RootNavigator = () => {
                 <Stack.Screen name='rideGpxTour'>
                     {() => <RidePage />}
                 </Stack.Screen>
+                <Stack.Screen name='rideWorkout'>
+                    {() => <RidePage />}
+                </Stack.Screen>
             </Stack.Navigator>
         </NavigationContainer>
     );

--- a/src/services/Navigation/index.ts
+++ b/src/services/Navigation/index.ts
@@ -11,3 +11,13 @@ export const navigate = (name: string, params?: object) => {
         navigationRef.dispatch(StackActions.replace(name, params));
     }
 };
+
+// Used by WorkoutRidePageService's `navigate-back` page-observer event
+// (workout-ride-page-service-design.md §5): "UI calls navigation.goBack()".
+// Distinct from the RideMenu End-Ride flow, which still goes through
+// RidePageService.onEndRide() -> moveToPreviousPage (unchanged for every ride type).
+export const goBack = () => {
+    if (navigationRef.isReady() && navigationRef.canGoBack()) {
+        navigationRef.goBack();
+    }
+};

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -32,5 +32,10 @@ export const colors = {
     error: '#D32F2F',
     warning: '#FFBF00',
     success: '#4CAF50',
-    disabled: '#9fa4a8'
+    disabled: '#9fa4a8',
+    // Workout ride screen only (workout-mobile-hld.md §5 "Ride screen — layout", session 4.2
+    // prototype sign-off): solid black rather than the usual `background` — a workout-only ride
+    // has no route/video visuals to show, and black maximises contrast for WorkoutGraph's small
+    // axis/tick labels.
+    workoutRideBackground: '#000000'
 }


### PR DESCRIPTION
## Summary
- Assembles `WorkoutRidePage` — the real ride screen for a workout-only ride — composing pieces already built in earlier sessions: `RideDashboard` (workout shoutout line), `WorkoutStepsList`, `WorkoutGraph` in `live` mode, the swipe gesture handler (`useWorkoutRideGestures`), and the workout-flavored `RideMenu`. Wired to `WorkoutRidePageService`.
- Registers the `'rideWorkout'` route in `RootNavigator`, resolving the forward-reference left by session 5.3's `WorkoutDetailsDialog` (`navigate('rideWorkout', payload)`).
- Adds a compact gesture legend ("◀ ▶ step · ▲ ▼ load ±N%") to `StartRideDisplay`, workout-ride-only, while waiting for pedaling — `N` reads the live `preferences.workouts.loadIncrement` setting, never hardcoded.
- Session 5.9 (`WorkoutGestureHintOverlay`) is still "Pending" per the session plan's overview table, so its conditional wire-in was skipped per the starting prompt's own instruction.

## What changed
- **New:** `src/pages/RidePage/Workout/{WorkoutRidePage.tsx,View.tsx,index.ts}` — smart page + pure view, mirroring `VideoRidePage`'s structure: owns `WorkoutRidePageService`'s `openPage`/`closePage` lifecycle and `AppState` background/foreground handling (`pausePage`/`resumePage`). No map/video/elevation strip — the `WorkoutGraph` is the dominant element on a solid-black background (new `colors.workoutRideBackground` token), matching the session-4.2 prototype's sign-off. The dashboard + menu/steps band heights are measured via `onLayout` (not the Storybook-only analytic budget the 4.2 prototype needed).
- **New:** one extra page-observer subscription vs. `VideoRidePage`/`GPXTourPage` — `navigate-back` (emitted by `WorkoutRidePageService` when the workout finishes/is stopped, or the ride reaches `Finished` on its own) calls a new `goBack()` helper in `src/services/Navigation/index.ts` directly. This is distinct from the `RideMenu`'s "End Ride" flow, which is unchanged (pause + `ActivitySummaryDialog` review, then `onCloseRidePage` → the base `RidePageService.onEndRide()`, same as every other ride type) — see design decisions below.
- **Changed:** `src/pages/RidePage/RidePage.tsx` — added the `rideType === 'Workout'` branch rendering `WorkoutRidePage` (mirrors the existing `Video`/`GPX` branches).
- **Changed:** `src/pages/RootNavigator/RootNavigator.tsx` — registered `'rideWorkout'` following the `rideGpxTour`/`rideDeviceOK` pattern.
- **Changed:** `src/hooks/ride/useWorkoutRideGestures.ts` — now also returns `loadIncrement` (the live setting value), reusing the lookup the hook already does internally for swipe up/down, so the new `StartRideDisplay` legend and the gesture handler share one source of truth.
- **Changed:** `src/components/StartRideDisplay/{types.ts,StartRideDisplay.tsx,StartRideDisplay.stories.tsx}` — new optional `workout`/`loadIncrementPct` props; the legend renders only in the default "starting" state (waiting for pedaling, no error), workout rides only.
- **Changed:** `src/hooks/index.ts` — added `export * from './ride'` (previously never re-exported from the top-level barrel since nothing consumed `useWorkoutRideGestures` yet).
- **Changed:** `src/theme/colors.ts` — added `workoutRideBackground` token.

## Design decisions not fully spelled out in the spec
1. **`navigate-back` handling.** The service design doc (`workout-ride-page-service-design.md` §5) says "UI calls `navigation.goBack()`" for this event, distinct from `VideoRidePage`/`GPXTourPage` (which have no such event — ending those rides always routes through the base `RidePageService`). I added a small `goBack()` helper to the `Navigation` service (mirroring the existing `navigate()`) rather than reusing `RidePageService.onEndRide()`, since the design doc treats this as a direct navigation concern, not a ride-lifecycle one.
2. **Graph actuals wiring.** `WorkoutGraph`/`WorkoutGraphView` take an `actuals` prop but have no built-in observer subscription. To match the design doc's "kept off `page-update` so 1 Hz telemetry never re-renders the whole page," I wrapped the smart `WorkoutGraph` wrapper in the existing `<Dynamic>` component, subscribed to the ride observer's `data-update` event, calling `service.getGraphActuals()` fresh each tick — the same pattern `VideoRidePageView` already uses for `ElevationGraph`'s `position-update`.
3. **Layout mechanism.** The session-4.2 `WorkoutRidePrototype` story used an in-flow flex column with analytically-budgeted heights (necessary only because Storybook's renderer doesn't resolve `onLayout` reliably). The real page uses this app's absolute-overlay ride-screen convention instead, measuring the dashboard and menu/steps band via `onLayout` (as `VideoRidePageView` already does for its own dashboard) rather than hardcoding a reserved-height budget.
4. **`ride-type-update` subscription.** Kept it wired even though `WorkoutRidePageService` never actually emits this event (it's a "sibling" service per the HLD's explicit non-goal, unlike `RidePageService` which `Video`/`GPX` share) — purely to keep the three ride-type pages structurally identical, per the task's "mirror `VideoRidePage`'s conventions, don't invent a new pattern" instruction. It's an inert no-op today.

## Test plan
- [x] `npm test` — all 76 suites / 421 tests pass, including new tests for `WorkoutRidePage` (lifecycle, `navigate-back` → `goBack()`, background/foreground pause/resume) and `useWorkoutRideGestures`'s new `loadIncrement` field.
- [x] `tsc --noEmit` — clean.
- [x] New Storybook stories: `Pages/WorkoutRidePage` (mid-workout, after-skip-back, menu-open, starting w/ gesture legend, swipe-feedback toast) and a `StartingWorkoutGestureLegend` story on `Components/StartRideDisplay`.
- [ ] Real-device verification (swipe gestures, gesture legend readability, graph live-update) — not done in this session, recommended before merge.