### PR TITLE
fix: OTA update crash (RNFS null-code reject) and unsafe bundle downgrade

### DIFF
--- a/patches/react-native-fs+2.20.0.patch
+++ b/patches/react-native-fs+2.20.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-native-fs/android/src/main/java/com/rnfs/RNFSManager.java b/node_modules/react-native-fs/android/src/main/java/com/rnfs/RNFSManager.java
+index 351ac06..305d9d0 100644
+--- a/node_modules/react-native-fs/android/src/main/java/com/rnfs/RNFSManager.java
++++ b/node_modules/react-native-fs/android/src/main/java/com/rnfs/RNFSManager.java
+@@ -975,7 +975,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
+       return;
+     }
+
+-    promise.reject(null, ex.getMessage());
++    promise.reject("EUNSPECIFIED", ex.getMessage());
+   }
+
+   private void rejectFileNotFound(Promise promise, String filepath) {

--- a/src/services/UpdateManager/UpdateService.ts
+++ b/src/services/UpdateManager/UpdateService.ts
@@ -28,10 +28,24 @@ const getBaseUrl = async (): Promise<string> => {
     return baseUrl
 }
 
-const createNewDir = async (path:string) =>{    
-    if (await exists(path)) 
+const createNewDir = async (path:string) =>{
+    if (await exists(path))
         await unlink(path);
     await mkdir(path);
+}
+
+const isNewerVersion = (remote: string, local: string): boolean => {
+    if (!local) return true
+    const remoteParts = remote.split('.').map(Number)
+    const localParts = local.split('.').map(Number)
+    const len = Math.max(remoteParts.length, localParts.length)
+    for (let i = 0; i < len; i++) {
+        const r = remoteParts[i] ?? 0
+        const l = localParts[i] ?? 0
+        if (r > l) return true
+        if (r < l) return false
+    }
+    return false
 }
 
 
@@ -120,7 +134,7 @@ export class UpdateService {
                 const bundleVersion = info.bundleVersion as string
                 const activeBundle = activeVersion??''
 
-                if ( activeBundle !== bundleVersion) {
+                if ( isNewerVersion(bundleVersion, activeBundle)) {
                     this.logger.logEvent({message:'Bundle update available',bundleVersion:bundleVersion});                    
                     return info
                 }    


### PR DESCRIPTION
## Summary
- Two Android Vitals crash reports traced to a native NullPointerException inside `react-native-fs`'s `RNFSManager.reject()`: on certain `downloadFile` errors (dropped connection, timeout — anything that isn't `FileNotFoundException`/`IORejectionException`), it calls `promise.reject(null, ...)`, and RN's Kotlin bridge requires a non-null `code`, crashing the whole app process. This hits the OTA bundle-update download path (`UpdateService.applyUpdate`), which runs on every app start.
- While investigating via device logs + `update-server` request logs, found a second, independent bug: the bundle-version check in `UpdateService.fetchBundleInfo` used a plain `!==` comparison instead of an ordering check, so any server-side revert or misconfiguration could cause already-updated devices to redownload and install an older bundle (a silent downgrade), while also re-exposing them to the RNFS crash on every mismatch, not just genuine upgrades.

## What changed
- `patches/react-native-fs+2.20.0.patch` (via `patch-package`): `RNFSManager.java`'s fallback reject path now passes a non-null `"EUNSPECIFIED"` code instead of `null`, eliminating the native NPE.
- `src/services/UpdateManager/UpdateService.ts`: added `isNewerVersion()` (numeric part-by-part comparison) and replaced the `activeBundle !== bundleVersion` check with `isNewerVersion(bundleVersion, activeBundle)`, so a download only triggers when the offered bundle is genuinely newer than what's installed.

## Test plan
- [x] `npm test` — full suite passes (76 suites / 421 tests)
- [x] Patch verified to apply cleanly against a pristine `react-native-fs@2.20.0` install and produce the same patched output as the local `node_modules` copy
- [ ] Manual device test of an OTA update cycle before merge (native code change requires a new app binary to take effect — cannot be verified via hot bundle update)