### PR TITLE
fix: guard WorkoutGraph/ActivityGraph SVG paths against NaN/Infinity coordinates

### DIFF
--- a/src/components/ActivityGraph/ActivityGraphView.test.tsx
+++ b/src/components/ActivityGraph/ActivityGraphView.test.tsx
@@ -113,6 +113,49 @@ describe('ActivityGraphView', () => {
         expect(toJSON()).not.toBeNull();
     });
 
+    describe('degenerate domain (Android Vitals OOM regression)', () => {
+        // A NaN xMax (e.g. from a corrupt/partial activity log) must never reach a
+        // <Path> "d" string: react-native-svg's native PathParser can throw a fatal
+        // OutOfMemoryError when asked to parse a malformed path containing "NaN"/"Infinity".
+        const findPaths = (root: ReturnType<typeof render>['UNSAFE_root']) =>
+            root.findAll(node => typeof node.type === 'string' && node.type.includes('Path'));
+
+        it('never emits NaN/Infinity into a line series Path "d" string when xMax is NaN', () => {
+            const { UNSAFE_root } = render(
+                <ActivityGraphView
+                    width={300}
+                    height={200}
+                    series={[MOCK_HR_SERIES]}
+                    xMode="distance"
+                    xMin={0}
+                    xMax={NaN}
+                />
+            );
+            findPaths(UNSAFE_root).forEach(p => {
+                expect(p.props.d as string).not.toMatch(/NaN|Infinity/);
+            });
+        });
+
+        it('never emits NaN/Infinity into the elevation area Path "d" string when xMax is NaN', () => {
+            const { UNSAFE_root } = render(
+                <ActivityGraphView
+                    width={300}
+                    height={200}
+                    series={MOCK_SERIES}
+                    xMode="distance"
+                    xMin={0}
+                    xMax={NaN}
+                    elevationPoints={MOCK_ELEVATION}
+                    elevationYMin={80}
+                    elevationYMax={100}
+                />
+            );
+            findPaths(UNSAFE_root).forEach(p => {
+                expect(p.props.d as string).not.toMatch(/NaN|Infinity/);
+            });
+        });
+    });
+
     it('right Y-axis absent when only 1 series provided', () => {
         const { queryAllByText } = render(
             <ActivityGraphView

--- a/src/components/ActivityGraph/ActivityGraphView.tsx
+++ b/src/components/ActivityGraph/ActivityGraphView.tsx
@@ -45,10 +45,14 @@ export const ActivityGraphView = React.memo( ({
             return null;
         }
 
-        const points = elevationPoints.map((p: ActivityGraphPoint) => ({
-            x: domainToPixel(p.x, xMin, xMax, 0, plotWidth),
-            y: domainToPixel(p.y, elevationYMin, elevationYMax, plotHeight, 0),
-        }));
+        const points = elevationPoints
+            .map((p: ActivityGraphPoint) => ({
+                x: domainToPixel(p.x, xMin, xMax, 0, plotWidth),
+                y: domainToPixel(p.y, elevationYMin, elevationYMax, plotHeight, 0),
+            }))
+            .filter(p => Number.isFinite(p.x) && Number.isFinite(p.y));
+
+        if (points.length < 2) return null;
 
         const linePath = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ');
         const areaPath = `${linePath} L ${points[points.length - 1].x} ${plotHeight} L ${points[0].x} ${plotHeight} Z`;
@@ -84,10 +88,14 @@ export const ActivityGraphView = React.memo( ({
             });
         }
 
-        const points = s.points.map((p: ActivityGraphPoint) => ({
-            x: domainToPixel(p.x, xMin, xMax, 0, plotWidth),
-            y: domainToPixel(p.y, s.yMin, s.yMax, plotHeight, 0),
-        }));
+        const points = s.points
+            .map((p: ActivityGraphPoint) => ({
+                x: domainToPixel(p.x, xMin, xMax, 0, plotWidth),
+                y: domainToPixel(p.y, s.yMin, s.yMax, plotHeight, 0),
+            }))
+            .filter(p => Number.isFinite(p.x) && Number.isFinite(p.y));
+
+        if (points.length < 2) return null;
 
         const linePath = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ');
 

--- a/src/components/ActivityGraph/utils.test.ts
+++ b/src/components/ActivityGraph/utils.test.ts
@@ -1,0 +1,21 @@
+import { domainToPixel } from './utils';
+
+describe('domainToPixel', () => {
+    it('maps a value linearly onto the pixel range', () => {
+        expect(domainToPixel(50, 0, 100, 0, 300)).toBe(150);
+    });
+
+    it('returns pixelMin for a zero-width domain', () => {
+        expect(domainToPixel(5, 10, 10, 0, 300)).toBe(0);
+    });
+
+    // Regression: a NaN/Infinity domain bound (e.g. from a corrupt activity log)
+    // must not silently produce a NaN/Infinity pixel coordinate — that reaches a
+    // <Path> "d" string and can fatally OutOfMemoryError react-native-svg's
+    // native path parser on Android.
+    it('returns pixelMin rather than NaN when the domain is degenerate', () => {
+        expect(domainToPixel(50, 0, NaN, 0, 300)).toBe(0);
+        expect(domainToPixel(NaN, 0, 100, 0, 300)).toBe(0);
+        expect(domainToPixel(50, 0, Infinity, 0, 300)).toBe(0);
+    });
+});

--- a/src/components/ActivityGraph/utils.ts
+++ b/src/components/ActivityGraph/utils.ts
@@ -81,7 +81,7 @@ export const domainToPixel = (
         // Guard: any NaN/Infinity input returns pixelMin to avoid SVG path corruption
         // (react-native-svg's PathParser can OOM on a malformed "d" string). A NaN/Infinity
         // operand never throws in JS, so the surrounding try/catch alone can't catch this.
-        if (!isFinite(value) || !isFinite(domainMin) || !isFinite(domainMax)) return pixelMin;
+        if (!Number.isFinite(value) || !Number.isFinite(domainMin) || !Number.isFinite(domainMax)) return pixelMin;
         if (domainMax === domainMin) return pixelMin;
         return pixelMin + ((value - domainMin) / (domainMax - domainMin)) * (pixelMax - pixelMin);
     } catch (err: any) {

--- a/src/components/ActivityGraph/utils.ts
+++ b/src/components/ActivityGraph/utils.ts
@@ -78,6 +78,10 @@ export const domainToPixel = (
     pixelMax: number
 ): number => {
     try {
+        // Guard: any NaN/Infinity input returns pixelMin to avoid SVG path corruption
+        // (react-native-svg's PathParser can OOM on a malformed "d" string). A NaN/Infinity
+        // operand never throws in JS, so the surrounding try/catch alone can't catch this.
+        if (!isFinite(value) || !isFinite(domainMin) || !isFinite(domainMax)) return pixelMin;
         if (domainMax === domainMin) return pixelMin;
         return pixelMin + ((value - domainMin) / (domainMax - domainMin)) * (pixelMax - pixelMin);
     } catch (err: any) {

--- a/src/components/WorkoutGraph/WorkoutGraphView.test.tsx
+++ b/src/components/WorkoutGraph/WorkoutGraphView.test.tsx
@@ -254,6 +254,28 @@ describe('WorkoutGraphView', () => {
         });
     });
 
+    describe('degenerate domain (Android Vitals OOM regression)', () => {
+        // A NaN domain bound (e.g. from an imported workout with an unparseable
+        // duration — see WorkoutRidePageService.buildGraphPlan) must never reach a
+        // <Path> "d" string: react-native-svg's native PathParser can throw a fatal
+        // OutOfMemoryError when asked to parse a malformed path containing "NaN"/"Infinity".
+        const nanDomainPlan: WorkoutGraphPlan = {
+            ...MOCK_PLAN_LIVE_MID,
+            domain: { x: [0, NaN], y: MOCK_PLAN_LIVE_MID.domain.y },
+        };
+
+        it('never emits NaN/Infinity into a Path "d" string when the plan domain is NaN', () => {
+            const { UNSAFE_root } = render(
+                <WorkoutGraphView mode="live" plan={nanDomainPlan} actuals={MOCK_ACTUALS_MID} width={360} height={200} />
+            );
+            const paths = UNSAFE_root.findAll(node => typeof node.type === 'string' && node.type.includes('Path'));
+            paths.forEach(p => {
+                const d = p.props.d as string;
+                expect(d).not.toMatch(/NaN|Infinity/);
+            });
+        });
+    });
+
     describe('actuals downsampling (long-ride performance)', () => {
         // ~1 Hz activity.logs over a full hour — workout-graph-component-design.md
         // §5 point 2 / §6 requires the Power/HR <Path>s stay bounded to ≤ plotWidth

--- a/src/components/WorkoutGraph/WorkoutGraphView.tsx
+++ b/src/components/WorkoutGraph/WorkoutGraphView.tsx
@@ -149,12 +149,16 @@ const ActualsOverlay = React.memo(({
     );
     let powerLine = null;
     if (powerRaw.length >= 2) {
-        const points = powerRaw.map(p => ({
-            x: offsetX + domainToPixel(p.x, xMin, xMax, 0, plotWidth),
-            y: offsetY + domainToPixel(p.y, yMin, yMax, plotHeight, 0),
-        }));
-        const path = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ');
-        powerLine = <Path d={path} fill="none" stroke={ACTUAL_POWER_COLOR} strokeWidth={1.75} />;
+        const points = powerRaw
+            .map(p => ({
+                x: offsetX + domainToPixel(p.x, xMin, xMax, 0, plotWidth),
+                y: offsetY + domainToPixel(p.y, yMin, yMax, plotHeight, 0),
+            }))
+            .filter(p => Number.isFinite(p.x) && Number.isFinite(p.y));
+        if (points.length >= 2) {
+            const path = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ');
+            powerLine = <Path d={path} fill="none" stroke={ACTUAL_POWER_COLOR} strokeWidth={1.75} />;
+        }
     }
 
     const hrRaw = downsampleToWidth(
@@ -164,12 +168,16 @@ const ActualsOverlay = React.memo(({
     let hrLine = null;
     if (hrRaw.length >= 2 && hrDomain) {
         const [dMin, dMax] = hrDomain;
-        const points = hrRaw.map(p => ({
-            x: offsetX + domainToPixel(p.x, xMin, xMax, 0, plotWidth),
-            y: offsetY + domainToPixel(p.y, dMin, dMax, plotHeight, 0),
-        }));
-        const path = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ');
-        hrLine = <Path d={path} fill="none" stroke={ACTUAL_HEARTRATE_COLOR} strokeWidth={1.5} />;
+        const points = hrRaw
+            .map(p => ({
+                x: offsetX + domainToPixel(p.x, xMin, xMax, 0, plotWidth),
+                y: offsetY + domainToPixel(p.y, dMin, dMax, plotHeight, 0),
+            }))
+            .filter(p => Number.isFinite(p.x) && Number.isFinite(p.y));
+        if (points.length >= 2) {
+            const path = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ');
+            hrLine = <Path d={path} fill="none" stroke={ACTUAL_HEARTRATE_COLOR} strokeWidth={1.5} />;
+        }
     }
 
     let marker = null;

--- a/src/components/WorkoutGraph/utils.test.ts
+++ b/src/components/WorkoutGraph/utils.test.ts
@@ -1,5 +1,25 @@
-import { computeHrDomain, downsampleToWidth } from './utils';
+import { computeHrDomain, domainToPixel, downsampleToWidth } from './utils';
 import type { WorkoutGraphPoint } from './types';
+
+describe('domainToPixel', () => {
+    it('maps a value linearly onto the pixel range', () => {
+        expect(domainToPixel(50, 0, 100, 0, 360)).toBe(180);
+    });
+
+    it('returns pixelMin for a zero-width domain', () => {
+        expect(domainToPixel(5, 10, 10, 0, 360)).toBe(0);
+    });
+
+    // Regression: a NaN/Infinity domain bound (e.g. from a workout with an
+    // unparseable duration) must not silently produce a NaN/Infinity pixel
+    // coordinate — that reaches a <Path> "d" string and can fatally
+    // OutOfMemoryError react-native-svg's native path parser on Android.
+    it('returns pixelMin rather than NaN when the domain is degenerate', () => {
+        expect(domainToPixel(50, 0, NaN, 0, 360)).toBe(0);
+        expect(domainToPixel(NaN, 0, 100, 0, 360)).toBe(0);
+        expect(domainToPixel(50, 0, Infinity, 0, 360)).toBe(0);
+    });
+});
 
 describe('computeHrDomain', () => {
     it('returns null for fewer than 2 usable points', () => {

--- a/src/components/WorkoutGraph/utils.ts
+++ b/src/components/WorkoutGraph/utils.ts
@@ -14,7 +14,7 @@ export const domainToPixel = (
 ): number => {
     // Guard: any NaN/Infinity input returns pixelMin to avoid SVG path corruption
     // (react-native-svg's PathParser can OOM on a malformed "d" string — see ElevationGraph/utils.ts).
-    if (!isFinite(value) || !isFinite(domainMin) || !isFinite(domainMax)) return pixelMin;
+    if (!Number.isFinite(value) || !Number.isFinite(domainMin) || !Number.isFinite(domainMax)) return pixelMin;
     if (domainMax === domainMin) return pixelMin;
     return pixelMin + ((value - domainMin) / (domainMax - domainMin)) * (pixelMax - pixelMin);
 };

--- a/src/components/WorkoutGraph/utils.ts
+++ b/src/components/WorkoutGraph/utils.ts
@@ -12,6 +12,9 @@ export const domainToPixel = (
     pixelMin: number,
     pixelMax: number
 ): number => {
+    // Guard: any NaN/Infinity input returns pixelMin to avoid SVG path corruption
+    // (react-native-svg's PathParser can OOM on a malformed "d" string — see ElevationGraph/utils.ts).
+    if (!isFinite(value) || !isFinite(domainMin) || !isFinite(domainMax)) return pixelMin;
     if (domainMax === domainMin) return pixelMin;
     return pixelMin + ((value - domainMin) / (domainMax - domainMin)) * (pixelMax - pixelMin);
 };


### PR DESCRIPTION
## Summary
- Android Vitals reported a fatal `java.lang.OutOfMemoryError` inside react-native-svg's native `PathParser` (`Float.parseFloat`), triggered by `PathView.setD` via Fabric's `SurfaceMountingManager`.
- Root cause: a degenerate/non-finite domain value (e.g. a `NaN` `plan.domain.x`, see the companion fix `incyclist/services#464`) reached `domainToPixel()` in both `WorkoutGraph` and `ActivityGraph` unguarded, producing a literal `"NaN"` token inside an SVG `<Path d="...">` string. Since `NaN` arithmetic never throws in JS, this fails silently on the JS side and only surfaces as a native OOM crash — one that a JS-level `ErrorBoundary` cannot catch, since the failure occurs in native Fabric mounting code, off the JS call stack.
- `ElevationGraph` already had this guard (`domainToPixel` returns `pixelMin` for non-finite input); this PR backports the same defense to `WorkoutGraph` and `ActivityGraph`, plus adds a post-conversion finiteness filter on pixel points right before building each `d` string, as defense in depth.

## What changed
- `src/components/WorkoutGraph/utils.ts`, `src/components/ActivityGraph/utils.ts` — `domainToPixel()` now guards `NaN`/`Infinity` inputs.
- `src/components/WorkoutGraph/WorkoutGraphView.tsx`, `src/components/ActivityGraph/ActivityGraphView.tsx` — pixel points filtered for `Number.isFinite` immediately before joining a `<Path>` `d` string.
- Regression tests in `WorkoutGraphView.test.tsx`, `utils.test.ts` (WorkoutGraph), `ActivityGraphView.test.tsx`, and a new `ActivityGraph/utils.test.ts` — assert no `<Path>` ever emits `NaN`/`Infinity` when fed a degenerate domain.

## Test plan
- [x] `npx jest src/components/WorkoutGraph src/components/ActivityGraph` — 52 tests pass
- [x] Confirmed all new assertions fail without the fix (reproduced the literal `"M NaN ..."` path string) and pass with it
- [x] `tsc --noEmit` clean on the touched files