### PR TITLE
fix: workout-only ride start flow (dialog reopen, frozen overlay, vibrate crash)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,7 +18,10 @@
 
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />    
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+
+    <!-- Swipe-gesture feedback on the workout ride screen (useWorkoutRideGestures) -->
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <!-- BLE Android 12+ -->
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "axios": "^1.17.0",
         "events": "^3.3.0",
         "gd-eventlog": "^0.1.27",
-        "incyclist-services": "^1.7.81",
+        "incyclist-services": "^1.7.82",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
         "react": "^19.2.4",
@@ -11739,9 +11739,9 @@
       }
     },
     "node_modules/incyclist-services": {
-      "version": "1.7.81",
-      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.81.tgz",
-      "integrity": "sha512-RcGrt2Z4h4ODQRzx7D0zOpNebbKQ0b7mMTBcvOGuo2lf+FqfTj9tNMQAC9QTj3mDGV4L6s/Wgd2EVfbop0pUWw==",
+      "version": "1.7.82",
+      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.82.tgz",
+      "integrity": "sha512-ysv8rSIBM31dXNDKF8B/rt9AgLNiCDXlk85KJVOI0JvkqBEXEAQTJ2P6/w3nuQ+aXnw6k4akwFEi7TEovdF3+g==",
       "dependencies": {
         "@garmin/fitsdk": "^21.200.0",
         "axios": "^1.15.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "axios": "^1.17.0",
     "events": "^3.3.0",
     "gd-eventlog": "^0.1.27",
-    "incyclist-services": "^1.7.81",
+    "incyclist-services": "^1.7.82",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "react": "^19.2.4",

--- a/src/components/WorkoutDetailsDialog/WorkoutDetailsDialog.tsx
+++ b/src/components/WorkoutDetailsDialog/WorkoutDetailsDialog.tsx
@@ -10,7 +10,6 @@ import {
 import { WorkoutDetailsView } from './WorkoutDetailsView';
 import { WorkoutDetailsDialogProps } from './types';
 import { useLogging, useScreenLayout, useUnmountEffect } from '../../hooks';
-import { navigate } from '../../services';
 
 /** Absolute-Watt bars + an FTP line at the effective (session-override) FTP — mirrors
  * `WorkoutsTable`'s strip-mode `buildPlan()`, but with `absValues:true` since `detail`
@@ -59,16 +58,9 @@ export const WorkoutDetailsDialog = ({ workoutId }: WorkoutDetailsDialogProps) =
     useEffect(() => {
         const observer = service.getPageObserver();
 
-        const onStartRide = (payload: { id: string; noRoute: boolean }) => {
-            if (payload?.id !== workoutId) return;
-            navigate('rideWorkout', payload);
-        };
-
         observer?.on('page-update', refresh);
-        observer?.on('start-ride', onStartRide);
         return () => {
             observer?.off('page-update', refresh);
-            observer?.off('start-ride', onStartRide);
         };
     }, [service, workoutId, refresh]);
 

--- a/src/hooks/ride/useWorkoutRideGestures.test.ts
+++ b/src/hooks/ride/useWorkoutRideGestures.test.ts
@@ -106,6 +106,25 @@ describe('useWorkoutRideGestures', () => {
         expect(result.current.feedback).toEqual({ visible: true, message: '◀ Step Back' });
     });
 
+    // regression: real devices can throw SecurityException/other native errors out of
+    // Vibration.vibrate() (e.g. a missing VIBRATE permission) - that must never take the
+    // in-progress ride's gesture handling down with it.
+    it('still performs the action and shows feedback when Vibration.vibrate() throws', () => {
+        jest.spyOn(Vibration, 'vibrate').mockImplementation(() => {
+            throw new Error('vibrate: Neither user 10465 nor current process has android.permission.VIBRATE.');
+        });
+        const { result } = renderHook(() => useWorkoutRideGestures());
+
+        expect(() => {
+            act(() => {
+                capturedOnEnd!({ translationX: -100, translationY: 0, velocityX: 0, velocityY: 0 });
+            });
+        }).not.toThrow();
+
+        expect(mockOnStepBack).toHaveBeenCalledTimes(1);
+        expect(result.current.feedback).toEqual({ visible: true, message: '◀ Step Back' });
+    });
+
     it('steps forward on a right swipe', () => {
         const { result } = renderHook(() => useWorkoutRideGestures());
         act(() => {

--- a/src/hooks/ride/useWorkoutRideGestures.ts
+++ b/src/hooks/ride/useWorkoutRideGestures.ts
@@ -66,7 +66,7 @@ export interface UseWorkoutRideGesturesResult {
 }
 
 export const useWorkoutRideGestures = (): UseWorkoutRideGesturesResult => {
-    const { logEvent } = useLogging('WorkoutRideGestures');
+    const { logEvent, logError } = useLogging('WorkoutRideGestures');
     const userSettings = useUserSettings();
     const service = getWorkoutRidePageService();
 
@@ -89,7 +89,14 @@ export const useWorkoutRideGestures = (): UseWorkoutRideGesturesResult => {
     }, [userSettings]);
 
     const handleSwipe = useCallback((direction: SwipeDirection) => {
-        Vibration.vibrate(VIBRATION_DURATION_MS);
+        // Vibration.vibrate() can throw natively (missing permission, no vibrator motor on this
+        // device) - that must never take down an in-progress ride over haptic feedback.
+        try {
+            Vibration.vibrate(VIBRATION_DURATION_MS);
+        }
+        catch (err) {
+            logError(err as Error, 'handleSwipe - vibrate');
+        }
 
         switch (direction) {
             case 'left':
@@ -117,7 +124,7 @@ export const useWorkoutRideGestures = (): UseWorkoutRideGesturesResult => {
                 break;
             }
         }
-    }, [logEvent, service, getLoadIncrement, showFeedback]);
+    }, [logEvent, logError, service, getLoadIncrement, showFeedback]);
 
     const gesture = useMemo(() => {
         if (!Gesture) {


### PR DESCRIPTION
## Summary
Mobile side of the workout-only ride start-flow fix (services counterpart: incyclist/services#466, released as `incyclist-services@1.7.82`).

- Bumped `incyclist-services` to `1.7.82`, which fixes the actual start-flow bugs (dialog reopening after cancel, frozen start overlay, ride never actually starting due to a redundant/racy `RideDisplayService.init()` call).
- `WorkoutDetailsDialog`: removed the dead `start-ride` navigation listener — `WorkoutListPageService.onStart()` now drives navigation itself via `moveTo()`, so the dialog no longer needs to.
- Fixed a real-device crash: swipe-up/down on the workout ride screen called `Vibration.vibrate()` without the app ever declaring `android.permission.VIBRATE`, throwing an uncaught `SecurityException` on a background native thread — uncatchable from JS, crashes the whole app. Added the permission (the actual fix) plus a defensive try/catch around the call (covers other failure modes, e.g. no vibration motor on some hardware; doesn't catch this specific async native-thread crash on its own).

## Test plan
- [x] `npm test` — full suite green (431/431 tests, 77 suites)
- [x] `tsc --noEmit` clean
- [x] Regression test added for the vibrate-throws case in `useWorkoutRideGestures.test.ts`
- [x] Verified end-to-end on a real Android device (paired FTMS trainer): workout starts correctly, cancel returns to the plain Workouts list, swipe gestures (including load up/down) no longer crash