### PR TITLE
fix: add Cancel button to the importing phase of WorkoutImportDialog

### DIFF
--- a/src/components/WorkoutImportDialog/WorkoutImportDialog.stories.tsx
+++ b/src/components/WorkoutImportDialog/WorkoutImportDialog.stories.tsx
@@ -42,7 +42,11 @@ export const Importing: Story = {
             importing: { fileName: 'sweet-spot-intervals.zwo' },
         },
         title: 'Importing...',
-        buttons: [],
+        // There's no real abort for the single-file import chain, so Cancel just stops the
+        // dialog from listening for the result and closes it - the import itself keeps running
+        // in the background (see importToken in WorkoutListPageService for the corresponding
+        // stale-result guard).
+        buttons: [{ label: 'Cancel', onClick: fn() }],
     },
 };
 

--- a/src/components/WorkoutImportDialog/WorkoutImportDialog.test.tsx
+++ b/src/components/WorkoutImportDialog/WorkoutImportDialog.test.tsx
@@ -139,4 +139,65 @@ describe('WorkoutImportDialog', () => {
             expect(mockImportObserver.on).toHaveBeenCalledWith('error', expect.any(Function));
         });
     });
+
+    // Session 5.12 follow-up: the 'importing' phase used to render zero buttons, leaving no way
+    // to back out of even a normal (non-buggy) slow import. There's no real abort for the
+    // single-file import chain in WorkoutListPageService (parse/build/save is one promise chain
+    // with no checkpoint to interrupt), so Cancel here means the dialog stops listening for the
+    // in-flight import's result and closes immediately - the underlying promise keeps running in
+    // the background. WorkoutListPageService.onImportClose() (already called by Cancel here, and
+    // by useUnmountEffect on every unmount) guards against that background result resurrecting
+    // stale state once it settles - see the importToken tests in services' service.unit.test.ts.
+    describe('Cancel during importing', () => {
+        beforeEach(() => {
+            mockObserver.on.mockClear();
+            mockObserver.off.mockClear();
+            mockService.onImportClose.mockClear();
+            mockService.getImportDisplayProps.mockClear();
+            mockService.getImportDisplayProps.mockReturnValue({
+                phase: 'importing',
+                knownGroups: ['My Workouts'],
+                importing: { fileName: 'sweet-spot.zwo' },
+            });
+        });
+
+        it('renders a Cancel button during the importing phase', () => {
+            const { getByText } = render(<WorkoutImportDialog onClose={jest.fn()} />);
+            expect(getByText('Cancel')).toBeTruthy();
+        });
+
+        it('tapping Cancel closes the dialog and resets the service-side import state', () => {
+            const onClose = jest.fn();
+            const { getByText } = render(<WorkoutImportDialog onClose={onClose} />);
+
+            fireEvent.press(getByText('Cancel'));
+
+            expect(mockService.onImportClose).toHaveBeenCalled();
+            expect(onClose).toHaveBeenCalled();
+        });
+
+        it('an import-update fired after Cancel (a late-arriving result) does not throw once the dialog has unmounted', () => {
+            const onClose = jest.fn();
+            const { getByText, unmount } = render(<WorkoutImportDialog onClose={onClose} />);
+
+            const [, registeredHandler] = mockObserver.on.mock.calls[mockObserver.on.mock.calls.length - 1];
+
+            fireEvent.press(getByText('Cancel'));
+            // mirrors what the real parent (WorkoutsPage) does once onClose() fires: it stops
+            // rendering the dialog, which runs useUnmountEffect's own onImportClose() call too.
+            unmount();
+
+            // simulate the now-discarded import's promise finally settling and the service
+            // emitting 'import-update' on the (still-shared) page observer
+            mockService.getImportDisplayProps.mockReturnValueOnce({
+                phase: 'result',
+                knownGroups: ['My Workouts'],
+                result: { id: 'w-1', workoutName: 'Late Result', group: 'My Workouts' },
+            });
+
+            expect(() => registeredHandler()).not.toThrow();
+            // the unmounted dialog must not still be subscribed by this point
+            expect(mockObserver.off).toHaveBeenCalledWith('import-update', registeredHandler);
+        });
+    });
 });

--- a/src/components/WorkoutImportDialog/WorkoutImportDialog.tsx
+++ b/src/components/WorkoutImportDialog/WorkoutImportDialog.tsx
@@ -89,8 +89,13 @@ export const WorkoutImportDialog = ({ onClose }: WorkoutImportDialogProps) => {
 
     const { phase } = displayProps;
 
-    const isDismissable = phase !== 'importing';
-    const onOutsideClick = isDismissable ? onDone : undefined;
+    // There's no real abort for the single-file import chain in WorkoutListPageService -
+    // parse/build/save is one promise chain with no checkpoint to interrupt mid-flight. "Cancel"
+    // here (and tapping outside, now that every phase is dismissable) means the dialog stops
+    // listening for that promise's result and closes immediately via onDone(), which also calls
+    // onImportClose() - the service guards against that background promise's eventual result
+    // resurrecting stale dialog state once it settles (see importToken in WorkoutListPageService).
+    const onOutsideClick = onDone;
 
     const title = useMemo(() => {
         switch (phase) {
@@ -108,7 +113,7 @@ export const WorkoutImportDialog = ({ onClose }: WorkoutImportDialogProps) => {
     const buttons: ButtonProps[] = useMemo(() => {
         switch (phase) {
             case 'importing':
-                return [];
+                return [{ label: 'Cancel', onClick: onDone }];
             case 'result':
                 return [{ label: 'Done', onClick: onDone, primary: true }];
             case 'error':

--- a/src/components/WorkoutImportDialog/WorkoutImportDialogView.test.tsx
+++ b/src/components/WorkoutImportDialog/WorkoutImportDialogView.test.tsx
@@ -20,8 +20,8 @@ describe('WorkoutImportDialogView', () => {
         render(<WorkoutImportDialogView {...defaultProps} />);
     });
 
-    it('renders importing phase without crashing', () => {
-        render(
+    it('renders importing phase with a Cancel button without crashing', () => {
+        const { getByText } = render(
             <WorkoutImportDialogView
                 {...defaultProps}
                 displayProps={{
@@ -29,9 +29,11 @@ describe('WorkoutImportDialogView', () => {
                     phase: 'importing',
                     importing: { fileName: 'sweet-spot.zwo' },
                 }}
-                buttons={[]}
+                buttons={[{ label: 'Cancel', onClick: jest.fn() }]}
             />
         );
+
+        expect(getByText('Cancel')).toBeTruthy();
     });
 
     it('renders result phase with the group picker without crashing', () => {


### PR DESCRIPTION
## Summary
- Adds a "Cancel" button to `WorkoutImportDialog`'s `importing` phase, which previously rendered zero buttons - there was no way to back out of even a normal (non-buggy) slow import, let alone a stuck one (session 5.12 follow-up: "Cancel-button addition to the importing phase still outstanding").
- Tapping outside the dialog during `importing` now also dismisses it, for consistency with every other phase (previously suppressed).
- Depends on incyclist/services#469, which hardens `WorkoutListPageService.onImportClose()`/`onImportFile()` so a cancelled-but-still-running import's eventual result can't corrupt dialog state if it arrives after the user has moved on.

## What "Cancel" means here
There's no real abort mechanism anywhere in the single-file import chain (`WorkoutListService.import()`/`_import()`/`doImport()` is one `await` chain with no loop or checkpoint to interrupt, no `AbortController`). Adding one is a larger structural change, out of scope for this fix. So Cancel is scoped honestly: the dialog stops listening for the in-flight import's result and closes immediately (reusing the existing `onDone` - `onImportClose()` + `onClose()`), while the underlying parse/save promise keeps running to completion in the background. The companion services PR ensures that background completion can't resurrect stale dialog state.

## Test plan
- [x] `npm test` - full suite passes (78 suites, 440 tests)
- [x] `npx eslint src/components/WorkoutImportDialog` - clean
- [x] `npx tsc --noEmit` - clean
- [x] New tests: Cancel button renders during `importing`; tapping it calls `onImportClose()` + `onClose()`; an `import-update` fired after Cancel + unmount (simulating a late-arriving result) doesn't throw, and the dialog is confirmed unsubscribed by then
- [x] Updated `Importing` Storybook story and `WorkoutImportDialogView` test to show the Cancel button