### PR TITLE
fix: RideMenu 2-column settings layout for phone landscape fit

### DIFF
--- a/src/components/RideMenu/RideMenu.stories.tsx
+++ b/src/components/RideMenu/RideMenu.stories.tsx
@@ -109,24 +109,24 @@ export const WorkoutFirstStep: Story = {
 
 /**
  * Session 5.10 fit check - the item list has grown across 5.4 (Step Back/Forward, Load), 5.5
- * (RideMenu workout gating), and now 5.10 (Workout Settings), but nobody had verified the full
- * list actually fits a real phone frame in landscape. `iphone15Pro` (852x393) is the same
- * viewport already registered in `.storybook/preview.ts` and used by `WorkoutRidePage.stories.tsx`
- * for its compact/normal breakpoint checks (<420dp height = compact). Every workout-ride menu
- * item is present here: Pause, End Ride (footer, always), Step Back/Forward, Increase/Decrease
- * Load, Gear Settings, Ride Settings, Workout Settings (content, this story).
+ * (RideMenu workout gating), and now 5.10 (Workout Settings). `iphone15Pro` (852x393) is the
+ * same viewport already registered in `.storybook/preview.ts` and used by
+ * `WorkoutRidePage.stories.tsx` for its compact/normal breakpoint checks (<420dp height =
+ * compact). Every workout-ride menu item is present here: Pause, End Ride (footer, always),
+ * Step Back/Forward, Increase/Decrease Load, Gear Settings, Ride Settings, Workout Settings
+ * (content, this story).
  *
- * FINDING (headless Playwright screenshot against this exact story, 852x393): the content list
- * does NOT fully fit above the fixed footer (Pause/End Ride) on this viewport - "Ride Settings"
- * is the last item visible without scrolling; "Workout Settings" (this session's new item) sits
- * below the fold. `RideMenuView.tsx`'s content area (`styles.content`/`contentScroll`) is already
- * a `ScrollView`, so nothing is permanently clipped/inaccessible the way the GroupPicker/
- * SingleSelect `overflow:hidden` bug (session 5.11) was - scrolling the content area does reveal
- * Workout Settings correctly, icon and all. But a rider now has to know to scroll mid-ride to
- * reach it on a phone, which is a real UX regression from item-list growth, not something to
- * silently work around here - flagged in this session's PR for the architect/session-plan owner
- * to decide how to address (e.g. denser rows, collapsing Step/Load onto fewer rows, a smaller
- * footer in compact mode), not fixed as a bolt-on in this diff.
+ * FIXED (follow-up session): a headless Playwright screenshot against this exact story at
+ * 852x393 originally showed the content list did NOT fully fit above the fixed footer
+ * (Pause/End Ride) - "Ride Settings" was the last item visible without scrolling and "Workout
+ * Settings" sat below the fold. Row height (`minHeight: 52`) is a deliberate touch-target size
+ * and was not reduced. Instead, since ride screens run landscape (width is the generous
+ * resource, height is scarce - workout-mobile-hld.md §5), `Gear Settings`/`Ride Settings`/
+ * `Workout Settings` were rearranged into a 2-column tile layout (`renderMenuTile`/
+ * `renderTileRow`), the same way `Step Back/Forward` and `Load +/-` already share a row. This
+ * removes exactly one 52px row, which lined up with the observed one-item overflow. Re-verified
+ * via headless Playwright screenshot against this story: the full list, including Workout
+ * Settings, now fits above the footer without scrolling.
  */
 export const WorkoutFullListCompact: Story = {
     args: {

--- a/src/components/RideMenu/RideMenu.test.tsx
+++ b/src/components/RideMenu/RideMenu.test.tsx
@@ -206,4 +206,39 @@ describe('RideMenuView', () => {
     it('renders with Workout Settings dialog active', () => {
         render(<RideMenuView {...workoutProps} visible={true} activeDialog='workoutSettings' />);
     });
+
+    it('calls onGearSettings when the Gear Settings tile is pressed', () => {
+        const onGearSettings = jest.fn();
+        const { getByText } = render(
+            <RideMenuView {...mockProps} visible={true} activeDialog={null} onGearSettings={onGearSettings} />
+        );
+        fireEvent.press(getByText('Gear Settings'));
+        expect(onGearSettings).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onRideSettings when the Ride Settings tile is pressed', () => {
+        const onRideSettings = jest.fn();
+        const { getByText } = render(
+            <RideMenuView {...mockProps} visible={true} activeDialog={null} onRideSettings={onRideSettings} />
+        );
+        fireEvent.press(getByText('Ride Settings'));
+        expect(onRideSettings).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders Gear Settings and Ride Settings as a paired 2-column row even outside workout mode', () => {
+        const { getByText } = render(
+            <RideMenuView {...mockProps} visible={true} activeDialog={null} />
+        );
+        expect(getByText('Gear Settings')).toBeTruthy();
+        expect(getByText('Ride Settings')).toBeTruthy();
+    });
+
+    it('renders Gear Settings, Ride Settings and Workout Settings together on a workout ride', () => {
+        const { getByText } = render(
+            <RideMenuView {...workoutProps} visible={true} activeDialog={null} />
+        );
+        expect(getByText('Gear Settings')).toBeTruthy();
+        expect(getByText('Ride Settings')).toBeTruthy();
+        expect(getByText('Workout Settings')).toBeTruthy();
+    });
 });

--- a/src/components/RideMenu/RideMenuView.tsx
+++ b/src/components/RideMenu/RideMenuView.tsx
@@ -28,6 +28,13 @@ interface RowButtonSpec {
     disabled?: boolean;
 }
 
+interface TileSpec {
+    icon: any;
+    label: string;
+    onPress: () => void;
+    disabled?: boolean;
+}
+
 export const RideMenuView = ({
     visible,
     showResume,
@@ -87,41 +94,6 @@ export const RideMenuView = ({
         }).start();
     }, [visible, animTranslateY, panelHiddenByDialog, refPanelHeight]);
 
-    const renderMenuItem = (
-        iconName: any,
-        label: string,
-        onPress: () => void,
-        disabled = false
-    ) => {
-        const handlePress = () => {
-            logEvent({ message: 'button clicked', button: label });
-            onPress();
-        };
-
-        return (
-            <Pressable
-                key={label}
-                onPress={handlePress}
-                disabled={disabled}
-                style={({ pressed }) => [
-                    styles.menuItem,
-                    pressed && !disabled && styles.menuItemPressed,
-                ]}
-            >
-                <View style={styles.menuItemIcon}>
-                    <Icon
-                        name={iconName}
-                        size={24}
-                        color={disabled ? colors.disabled : colors.text}
-                    />
-                </View>
-                <Text style={[styles.menuItemLabel, disabled && styles.menuItemLabelDisabled]}>
-                    {label}
-                </Text>
-            </Pressable>
-        );
-    };
-
     // Icon-only half-width button used to pack two related actions (e.g. Step Back/Forward,
     // Decrease/Increase Load) onto a single row - keeps the compact panel short on phones.
     const renderRowButton = ({ icon, label, onPress, disabled = false }: RowButtonSpec) => {
@@ -157,6 +129,48 @@ export const RideMenuView = ({
                 {renderRowButton(left)}
                 {renderRowButton(right)}
             </View>
+        </View>
+    );
+
+    // Half-width icon+label tile, used to pack two unrelated settings entries (Gear Settings,
+    // Ride Settings, Workout Settings) onto shared rows the same way Step/Load already share
+    // rows. Unlike renderRowButton (icon-only, one shared row caption), each of these actions
+    // needs its own visible label, so this uses the same icon+label content as a full-width
+    // menu item, just at roughly half width.
+    const renderMenuTile = ({ icon, label, onPress, disabled = false }: TileSpec) => {
+        const handlePress = () => {
+            logEvent({ message: 'button clicked', button: label });
+            onPress();
+        };
+
+        return (
+            <Pressable
+                key={label}
+                onPress={handlePress}
+                disabled={disabled}
+                style={({ pressed }) => [
+                    styles.menuTile,
+                    pressed && !disabled && styles.menuItemPressed,
+                ]}
+            >
+                <View style={styles.menuItemIcon}>
+                    <Icon
+                        name={icon}
+                        size={24}
+                        color={disabled ? colors.disabled : colors.text}
+                    />
+                </View>
+                <Text style={[styles.menuItemLabel, disabled && styles.menuItemLabelDisabled]}>
+                    {label}
+                </Text>
+            </Pressable>
+        );
+    };
+
+    const renderTileRow = (rowKey: string, left: TileSpec, right?: TileSpec) => (
+        <View style={styles.menuTileRow} key={rowKey}>
+            {renderMenuTile(left)}
+            {right ? renderMenuTile(right) : <View style={styles.menuTileSpacer} />}
         </View>
     );
 
@@ -219,13 +233,20 @@ export const RideMenuView = ({
                             { icon: 'minus', label: 'Decrease Load', onPress: onDecreaseLoad },
                             { icon: 'plus', label: 'Increase Load', onPress: onIncreaseLoad }
                         )}
-                        {renderMenuItem('settings', 'Gear Settings', onGearSettings)}
-                        {renderMenuItem('controller', 'Ride Settings', onRideSettings)}
-                        {/* 'gear' is a real icon (unlike 'settings'/'controller' above, which are not
+                        {/* 'gear' is a real icon (unlike 'settings'/'controller' below, which are not
                             in Icon's IconName union and silently render blank - a pre-existing gap,
                             not introduced here; using a valid name for this new item rather than
-                            compounding it). */}
-                        {workout && renderMenuItem('gear', 'Workout Settings', onWorkoutSettings)}
+                            compounding it). Gear/Ride Settings pair onto one row and Workout
+                            Settings gets its own row - a 2-column layout, same reasoning as the
+                            Step/Load rows above, to remove one 52px row on the height-constrained
+                            landscape phone layout (see workout-mobile-hld.md §5). */}
+                        {renderTileRow('SettingsRow1',
+                            { icon: 'settings', label: 'Gear Settings', onPress: onGearSettings },
+                            { icon: 'controller', label: 'Ride Settings', onPress: onRideSettings }
+                        )}
+                        {workout && renderTileRow('SettingsRow2',
+                            { icon: 'gear', label: 'Workout Settings', onPress: onWorkoutSettings }
+                        )}
                     </ScrollView>
                 </View>
 
@@ -292,12 +313,6 @@ const styles = StyleSheet.create({
     contentScroll: {
         paddingVertical: 10,
     },
-    menuItem: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        paddingHorizontal: 20,
-        minHeight: 52,
-    },
     menuItemPressed: {
         backgroundColor: 'rgba(255,255,255,0.1)',
     },
@@ -330,6 +345,20 @@ const styles = StyleSheet.create({
         justifyContent: 'center',
         marginLeft: 8,
         borderRadius: 4,
+    },
+    menuTileRow: {
+        flexDirection: 'row',
+        minHeight: 52,
+        paddingHorizontal: 20,
+        gap: 12,
+    },
+    menuTile: {
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
+    },
+    menuTileSpacer: {
+        flex: 1,
     },
     footer: {
         paddingHorizontal: 12,


### PR DESCRIPTION
## Summary

Fixes a UX regression in `RideMenu` where, on a phone-sized landscape frame (e.g. iPhone 15 Pro, 852x393), the full workout-ride item list no longer fit above the fixed Pause/End Ride footer. The item list grew across sessions 5.4 (Step Back/Forward, Load), 5.5 (workout gating), and 5.10 (Workout Settings), and `Workout Settings` ended up below the fold - reachable via the existing `ScrollView` but only if a rider knew to scroll mid-ride.

## What changed

- `Gear Settings`, `Ride Settings`, and `Workout Settings` (previously three separate full-width rows) are now packed into a 2-column tile layout: `Gear Settings` + `Ride Settings` share one row, `Workout Settings` gets its own row. This mirrors the existing `Step Back/Forward` and `Load +/-` row pattern, removing exactly one 52px row - which lines up with the observed one-item overflow.
- Row height (`minHeight: 52`, a deliberate touch-target size) was **not** reduced, nor was font size - shrinking either would shrink the tap target on a menu used mid-workout, which was explicitly rejected.
- Added `renderMenuTile`/`renderTileRow` - unlike the existing icon-only `renderRowButton`/`renderMenuRow` pattern (single shared row caption), these three actions are unrelated and each need their own visible label, so the new tiles reuse the icon+label content at roughly half width.
- Removed the now-unused `renderMenuItem` helper and its `menuItem` style (both call sites were replaced by the new tile row).
- Updated the `RideMenu.stories.tsx` `WorkoutFullListCompact` story docblock to record the fix and how it was re-verified.
- Added unit tests covering the Gear/Ride Settings tile presses and that both settings rows render correctly in and out of workout mode.

## Verification

Took a real headless Playwright screenshot (not just a code read) against the `WorkoutFullListCompact` Storybook story at the exact 852x393 iPhone 15 Pro viewport, with every workout-ride menu item present. Confirmed the full list - Step, Load, Gear Settings, Ride Settings, and Workout Settings - now fits above the Pause/End Ride footer with no scrolling required.

## Test plan

- [x] `npm test` - all 82 suites / 468 tests pass
- [x] `tsc --noEmit` - clean
- [x] `npm run lint` - clean (no new errors/warnings introduced)
- [x] Headless Playwright screenshot against `WorkoutFullListCompact` story confirms the fix