### PR TITLE
fix: gate post-pairing scheduled-workout prompt on MOBILE_WORKOUTS toggle

### DIFF
--- a/src/hooks/workouts/useScheduledWorkoutPrompt.test.ts
+++ b/src/hooks/workouts/useScheduledWorkoutPrompt.test.ts
@@ -10,6 +10,7 @@ const mockSetState = jest.fn((key: string, value: any) => {
     if (value === null) delete appStateStore[key];
     else appStateStore[key] = value;
 });
+let mockHasFeature = jest.fn(() => true);
 
 class FakeWorkoutCalendar extends EventEmitter {
     getScheduledToday = jest.fn();
@@ -17,7 +18,7 @@ class FakeWorkoutCalendar extends EventEmitter {
 let mockCalendar: FakeWorkoutCalendar;
 
 jest.mock('incyclist-services', () => ({
-    useAppState: () => ({ getState: mockGetState, setState: mockSetState }),
+    useAppState: () => ({ getState: mockGetState, setState: mockSetState, hasFeature: mockHasFeature }),
     useWorkoutCalendar: () => mockCalendar,
 }));
 
@@ -42,6 +43,7 @@ describe('useScheduledWorkoutPrompt', () => {
         jest.clearAllMocks();
         appStateStore = {};
         mockCalendar = new FakeWorkoutCalendar();
+        mockHasFeature = jest.fn(() => true);
     });
 
     it('shows nothing when no workout is scheduled today', () => {
@@ -85,6 +87,19 @@ describe('useScheduledWorkoutPrompt', () => {
     it('does nothing while disabled (enabled=false), even with a workout scheduled and no guard', () => {
         mockCalendar.getScheduledToday.mockReturnValue(SCHEDULED);
         const { result } = renderHook(() => useScheduledWorkoutPrompt(false));
+        expect(result.current.prompt).toBeNull();
+        expect(mockSetState).not.toHaveBeenCalled();
+    });
+
+    it('does nothing while the MOBILE_WORKOUTS feature toggle is off, even with a workout scheduled and no guard', () => {
+        // WorkoutCalendarService is synced unconditionally at launch (preloadData()), regardless
+        // of the MOBILE_WORKOUTS toggle - so without this gate the prompt would fire and its
+        // Yes/Check-workouts actions would navigate to a Workouts page stuck on its "under
+        // development" placeholder (WorkoutListPageService.getPageDisplayProps() short-circuits
+        // to pageType:'placeholder' when the toggle is off, never rendering WorkoutDetailsDialog).
+        mockHasFeature = jest.fn(() => false);
+        mockCalendar.getScheduledToday.mockReturnValue(SCHEDULED);
+        const { result } = renderHook(() => useScheduledWorkoutPrompt());
         expect(result.current.prompt).toBeNull();
         expect(mockSetState).not.toHaveBeenCalled();
     });

--- a/src/hooks/workouts/useScheduledWorkoutPrompt.ts
+++ b/src/hooks/workouts/useScheduledWorkoutPrompt.ts
@@ -57,6 +57,13 @@ export const useScheduledWorkoutPrompt = (enabled: boolean = true): UseScheduled
 
     const checkAndShow = useCallback(() => {
         if (!enabled) return;
+        // Mirrors WorkoutListPageService.getPageDisplayProps()'s own MOBILE_WORKOUTS gate (returns
+        // pageType:'placeholder' when off) - the calendar/sync engine itself isn't feature-gated
+        // (preloadData() always calls workouts.preload()), so without this check the prompt could
+        // fire even while the Workouts page is showing its "under development" placeholder, and
+        // Yes/Check-workouts would navigate there with nothing real to land on (autoOpenDetailsId
+        // silently ignored, since the placeholder never renders WorkoutDetailsDialog).
+        if (!appState.hasFeature('MOBILE_WORKOUTS')) return;
         if (appState.getState(SCHEDULED_PROMPT_GUARD_KEY)) return;
 
         const scheduled: ScheduledWorkout | undefined = calendar.getScheduledToday();

--- a/src/pages/ActivitiesPage/ActivitiesPage.test.tsx
+++ b/src/pages/ActivitiesPage/ActivitiesPage.test.tsx
@@ -23,8 +23,9 @@ jest.mock('incyclist-services', () => ({
         onCloseActivity: () => {},
     }),
     // Needed by useScheduledWorkoutPrompt (session 5.7), which every content page - including
-    // ActivitiesPage - now calls.
-    useAppState: () => ({ getState: jest.fn(), setState: jest.fn() }),
+    // ActivitiesPage - now calls. hasFeature (6.1 integration pass) gates the prompt on
+    // MOBILE_WORKOUTS, mirroring WorkoutListPageService.getPageDisplayProps()'s own gate.
+    useAppState: () => ({ getState: jest.fn(), setState: jest.fn(), hasFeature: jest.fn(() => true) }),
     useWorkoutCalendar: () => ({
         getScheduledToday: jest.fn(),
         on: jest.fn(),

--- a/src/pages/WorkoutsPage/WorkoutsPage.test.tsx
+++ b/src/pages/WorkoutsPage/WorkoutsPage.test.tsx
@@ -28,8 +28,9 @@ jest.mock('incyclist-services', () => ({
         onSelectGroup: mockOnSelectGroup,
     }),
     // Needed by useScheduledWorkoutPrompt (session 5.7), which every content page - including
-    // WorkoutsPage - now calls.
-    useAppState: () => ({ getState: jest.fn(), setState: jest.fn() }),
+    // WorkoutsPage - now calls. hasFeature (6.1 integration pass) gates the prompt on
+    // MOBILE_WORKOUTS, mirroring WorkoutListPageService.getPageDisplayProps()'s own gate.
+    useAppState: () => ({ getState: jest.fn(), setState: jest.fn(), hasFeature: jest.fn(() => true) }),
     useWorkoutCalendar: () => ({
         getScheduledToday: jest.fn(),
         on: jest.fn(),


### PR DESCRIPTION
## Summary
- Session 6.1 (Workout mobile feature, Phase 1 integration pass): walked the full Phase 1 flow end-to-end via code-path tracing and the unit/Storybook test suite (no real device available in this environment — see test plan for what could/couldn't be exercised).
- Found: `useScheduledWorkoutPrompt` checks `WorkoutCalendarService.getScheduledToday()` directly but never checked the `MOBILE_WORKOUTS` feature toggle, unlike `WorkoutListPageService.getPageDisplayProps()` which gates the whole Workouts page behind it. Since the calendar/sync engine runs unconditionally at launch (`preloadData()`), the prompt could fire with the toggle off, and its Yes/Check-workouts actions would navigate to a Workouts page stuck on the "under development" placeholder — `autoOpenDetailsId` silently ignored.
- Companion fix in `incyclist-services` (unrelated bug from the same pass, RideMenu's Increase/Decrease Load buttons ignoring the configured load increment): https://github.com/incyclist/services/pull/472 — no version bump needed here since it's an internal-behavior-only fix, no public API/type change.

## What changed
- `src/hooks/workouts/useScheduledWorkoutPrompt.ts`: added an `appState.hasFeature('MOBILE_WORKOUTS')` check alongside the existing once-per-session guard.
- `src/hooks/workouts/useScheduledWorkoutPrompt.test.ts`: new regression test — toggle off, workout scheduled, no guard set → prompt stays null.
- `src/pages/ActivitiesPage/ActivitiesPage.test.tsx`, `src/pages/WorkoutsPage/WorkoutsPage.test.tsx`: updated their `useAppState` mocks to include `hasFeature` (both pages mount the hook), otherwise they'd throw on the new call.

## Integration-pass punch list (verified via code tracing + existing unit/Storybook coverage — no real device in this environment)

**Confirmed working as designed:**
- Import → list → group filter → Upcoming Training section (`WorkoutsTable`/`WorkoutListView`)
- `WorkoutDetailsDialog` open/close via service state (`detailWorkoutId`), FTP/ERG launch-scoped overrides, Start → `onStart` → navigate (session 5.22's fix)
- RC-5 case-4 leak: `WorkoutListService.getScheduledWorkouts()` never auto-selects on mobile (`isMobile()` gate); covered by an existing services regression test
- RC-7: launch-time auto-navigate-to-Workouts gated to non-mobile
- Post-pairing prompt: once-per-session guard, Yes/No/Check-workouts wiring, reacts to the calendar's async `'scheduled'` event
- Direct navigation to Workouts still highlights today's scheduled item (`isToday`, independent of the prompt)
- Delete/change-group (`GroupPicker` post-5.11 inline-list fix), import error/empty states, swipe-delete (session 5.14's RNGH TouchableOpacity fix)
- `ActivityDetailsDialog`/`ActivitySummaryDialog` routeless handling (session 0.1's `routeType==='None'` fix)

**Fixed in this PR:** the `MOBILE_WORKOUTS` gate above.

**Fixed in the companion services PR:** RideMenu's Increase/Decrease Load buttons silently using a hardcoded 1% instead of the user's configured `preferences.workouts.loadIncrement`.

**Known/deferred, not touched (per session instructions):**
- Session 5.19 (card-lookup collision between a regular and same-content scheduled workout) — in progress on a separate branch.
- `RideMenu` phone-frame overflow (Workout Settings below the fold) — in progress on a separate branch.
- Session 5.21 (`MaxListenersExceededWarning`) — deliberately deferred to real-device/RC testing.

**Could not exercise (no real device/hardware in this environment):**
- Actual swipe gesture recognition, haptics, and the RNGH `Swipeable` delete-button tap behavior on a physical touchscreen.
- Real FTMS trainer pairing/start/stop flow.
- Any Storybook visual/screenshot verification (no Playwright/browser available here) — relied on the existing test suite and code tracing instead.

## Test plan
- [x] `npm test` — 82/82 suites, 465/465 tests passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (same 24 pre-existing warnings as baseline, 0 errors)
- [x] New regression test for the `MOBILE_WORKOUTS` gate fails without the fix, passes with it