### PR TITLE
fix: device selector list no longer scrolls under the footer bar

### DIFF
--- a/src/components/DeviceSelector/DeviceSelector.stories.tsx
+++ b/src/components/DeviceSelector/DeviceSelector.stories.tsx
@@ -60,3 +60,20 @@ export const Disabled: Story = {
         disabled: true,
     },
 };
+
+// Regression case for the scroll/overlap bug: with enough entries to overflow the list's
+// maxHeight, the last entries must remain reachable by scrolling and must not render hidden
+// underneath the "For all capabilities" / "Disable All" footer bar.
+export const LongList: Story = {
+    args: {
+        ...Default.args,
+        devices: Array.from({ length: 25 }, (_, i) => ({
+            deviceName: `Device ${i + 1}`,
+            value: i,
+            interface: i % 2 === 0 ? 'ble' : 'wifi',
+            isSelected: false,
+            onClick: fn(),
+            onDelete: () => {},
+        })),
+    },
+};

--- a/src/components/DeviceSelector/DeviceSelector.test.tsx
+++ b/src/components/DeviceSelector/DeviceSelector.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { ScrollView } from 'react-native';
+import { DeviceSelector } from './DeviceSelector';
+import { DeviceSelectionItemProps, DeviceSelectionProps, TIncyclistCapability } from 'incyclist-services';
+
+const buildDevice = (i: number): DeviceSelectionItemProps => ({
+    deviceName: `Device ${i}`,
+    value: i,
+    interface: i % 2 === 0 ? 'ble' : 'wifi',
+    isSelected: false,
+    onClick: jest.fn(),
+    onDelete: jest.fn(),
+});
+
+const buildProps = (deviceCount: number): DeviceSelectionProps => ({
+    capability: 'control' as TIncyclistCapability,
+    devices: Array.from({ length: deviceCount }, (_, i) => buildDevice(i)),
+    isScanning: false,
+    disabled: false,
+    changeForAll: true,
+    canSelectAll: true,
+    onClose: jest.fn(),
+});
+
+describe('DeviceSelector', () => {
+    it('renders without crashing for a short device list', () => {
+        const { getByText } = render(<DeviceSelector {...buildProps(3)} />);
+        expect(getByText('Device 0')).toBeTruthy();
+        expect(getByText('Device 2')).toBeTruthy();
+    });
+
+    it('renders without crashing for a long, overflowing device list', () => {
+        // Regression scenario for the scroll/overlap bug: a long list used to leave the last
+        // entries hidden underneath the footer and made scrolling unreliable.
+        const { getByText } = render(<DeviceSelector {...buildProps(30)} />);
+        expect(getByText('Device 0')).toBeTruthy();
+        expect(getByText('Device 29')).toBeTruthy();
+    });
+
+    it('gives the device list ScrollView bottom padding matching the footer height, so the last entries clear it', () => {
+        const { UNSAFE_root } = render(<DeviceSelector {...buildProps(10)} />);
+
+        const scrollViews = UNSAFE_root.findAllByType(ScrollView);
+        expect(scrollViews.length).toBe(1); // only DeviceSelector's own list ScrollView - Dialog's is disabled
+
+        const contentContainerStyle = scrollViews[0].props.contentContainerStyle;
+        const flatStyle = Array.isArray(contentContainerStyle)
+            ? Object.assign({}, ...contentContainerStyle)
+            : contentContainerStyle;
+
+        expect(flatStyle.paddingBottom).toBeGreaterThanOrEqual(60);
+    });
+
+    it('renders both "For all capabilities" and "Disable All" controls', () => {
+        const { getByText } = render(<DeviceSelector {...buildProps(5)} />);
+        expect(getByText('For all capabilities')).toBeTruthy();
+        expect(getByText('Disable All')).toBeTruthy();
+    });
+});

--- a/src/components/DeviceSelector/DeviceSelector.tsx
+++ b/src/components/DeviceSelector/DeviceSelector.tsx
@@ -38,13 +38,14 @@ export const DeviceSelector: FC<DeviceSelectionProps> = ({
     const deviceListStyle = [styles.deviceList, { minHeight: deviceListMinHeight }];
 
     return (
-        <Dialog 
-            style={dialogStyle} 
-            title={isScanning ? 'Searching ...' : 'Select Device'} 
+        <Dialog
+            style={dialogStyle}
+            title={isScanning ? 'Searching ...' : 'Select Device'}
             onOutsideClick={onDialogClosed}
+            scrollable={false}
         >
             <View style={styles.modalView}>
-                <ScrollView style={deviceListStyle}>
+                <ScrollView style={deviceListStyle} contentContainerStyle={styles.deviceListContent}>
                     {devices.map((device) => (
                         <DeviceEntry 
                             key={`${device.deviceName}-${device.interface}`} 
@@ -81,6 +82,8 @@ export const DeviceSelector: FC<DeviceSelectionProps> = ({
     );
 };
 
+const FOOTER_HEIGHT = 60;
+
 const styles = StyleSheet.create({
     dialog: {
         // Dynamic width applied via inline style
@@ -88,16 +91,24 @@ const styles = StyleSheet.create({
     modalView: {
         width: 'auto',
         flex: 1,
-        height: '100%',
+        // No explicit height here: with Dialog's `scrollable={false}`, this View's parent has a
+        // definite (flex-resolved) height, so `flex: 1` alone reliably fills it. A `height: '100%'`
+        // is unnecessary and, if this were ever nested back inside a ScrollView, would resolve
+        // against an undefined parent size (see Dialog's `scrollable` prop doc).
     },
     deviceList: {
         flex: 1,
         maxHeight: 380,
         // Dynamic minHeight applied via inline style
     },
+    // Reserves space at the bottom of the scrollable content so the last device entries clear
+    // the footer bar, which is absolutely positioned over the bottom of `modalView`.
+    deviceListContent: {
+        paddingBottom: FOOTER_HEIGHT,
+    },
     footer: {
         flexDirection: 'row',
-        height: 60,
+        height: FOOTER_HEIGHT,
         width: '100%',
         position: 'absolute',
         left: 0,

--- a/src/components/Dialog/Dialog.test.tsx
+++ b/src/components/Dialog/Dialog.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { ScrollView, Text, View } from 'react-native';
+import { Dialog } from './Dialog';
+
+describe('Dialog', () => {
+    it('wraps children in a ScrollView by default (scrollable=true)', () => {
+        const { UNSAFE_root } = render(
+            <Dialog title="Test Dialog">
+                <Text>content</Text>
+            </Dialog>
+        );
+
+        expect(UNSAFE_root.findAllByType(ScrollView).length).toBeGreaterThan(0);
+    });
+
+    it('renders children in a plain View (no ScrollView) when scrollable=false', () => {
+        // Regression test: nesting a component that manages its own scrolling (e.g.
+        // DeviceSelector's device list + fixed footer) inside Dialog's own ScrollView left the
+        // inner scroll area's height undefined and caused nested-ScrollView gesture conflicts.
+        // scrollable=false must render children directly, with no ScrollView ancestor from Dialog.
+        const { UNSAFE_root } = render(
+            <Dialog title="Test Dialog" scrollable={false}>
+                <Text>content</Text>
+            </Dialog>
+        );
+
+        expect(UNSAFE_root.findAllByType(ScrollView).length).toBe(0);
+    });
+
+    it('still renders the children content when scrollable=false', () => {
+        const { getByText } = render(
+            <Dialog title="Test Dialog" scrollable={false}>
+                <View>
+                    <Text>my content</Text>
+                </View>
+            </Dialog>
+        );
+
+        expect(getByText('my content')).toBeTruthy();
+    });
+});

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -31,6 +31,7 @@ export const Dialog = ({
     nested = false,
     onOutsideClick,
     slideFrom,
+    scrollable = true,
 }: PropsWithChildren<DialogProps>) => {
 
     const { logEvent } = useLogging('Incyclist');
@@ -160,13 +161,21 @@ export const Dialog = ({
                                 <Text style={[styles.title, titleStyle]}>{title}</Text>
                             </View>
 
-                            <ScrollView
-                                style={styles.scrollArea}
-                                contentContainerStyle={styles.content}
-                                bounces={false}
-                            >
-                                {children}
-                            </ScrollView>
+                            {scrollable ? (
+                                <ScrollView
+                                    style={styles.scrollArea}
+                                    contentContainerStyle={styles.content}
+                                    bounces={false}
+                                >
+                                    {children}
+                                </ScrollView>
+                            ) : (
+                                <View style={styles.scrollArea}>
+                                    <View style={styles.content}>
+                                        {children}
+                                    </View>
+                                </View>
+                            )}
 
                             {buttons?.length ? (
                                 <View style={styles.footer}>
@@ -200,13 +209,21 @@ export const Dialog = ({
                                 <Text style={[styles.title, titleStyle]}>{title}</Text>
                             </View>
 
-                            <ScrollView
-                                style={styles.scrollArea}
-                                contentContainerStyle={styles.content}
-                                bounces={false}
-                            >
-                                {children}
-                            </ScrollView>
+                            {scrollable ? (
+                                <ScrollView
+                                    style={styles.scrollArea}
+                                    contentContainerStyle={styles.content}
+                                    bounces={false}
+                                >
+                                    {children}
+                                </ScrollView>
+                            ) : (
+                                <View style={styles.scrollArea}>
+                                    <View style={styles.content}>
+                                        {children}
+                                    </View>
+                                </View>
+                            )}
 
                             {buttons?.length ? (
                                 <View style={styles.footer}>

--- a/src/components/Dialog/types.ts
+++ b/src/components/Dialog/types.ts
@@ -17,4 +17,15 @@ export interface DialogProps {
     nested?: boolean;
     titleStyle?: StyleProp<TextStyle>;
     slideFrom?: 'left'; // only applies to variant='full'
+    /**
+     * When false, Dialog renders `children` in a plain View instead of wrapping them in its
+     * own ScrollView. Use this when `children` already manage their own internal scrolling
+     * (e.g. a scrollable list with a fixed footer below it) - nesting that inside Dialog's
+     * ScrollView leaves the inner scroll area's height undefined (a ScrollView lets its content
+     * overflow rather than constraining it, so a `height: '100%'` child has no definite parent
+     * size to resolve against) and causes RN's gesture responder to fight over the scroll
+     * gesture between the two nested ScrollViews. Defaults to true to preserve existing
+     * behaviour for all other Dialog consumers.
+     */
+    scrollable?: boolean;
 }


### PR DESCRIPTION
## Summary
- Fixes the Device screen's device selector: when the device list is long enough to overflow, it did not scroll reliably and the last entries ended up hidden underneath the "For all capabilities" / "Disable All" footer bar, making both the hidden entries and the footer's own controls unreachable.

## Root cause
`DeviceSelector` nested its own device-list `ScrollView` (with an absolutely positioned footer) *inside* `Dialog`'s own `ScrollView`. Two problems stemmed from that:
1. The footer (`position:'absolute', bottom:0, height:60`) had no matching bottom padding on the sibling `ScrollView`, so the last ~60dp of scrollable content sat behind it.
2. `modalView`'s `height:'100%'` was resolving against a `ScrollView` content container, which lets content overflow rather than constrain it — i.e. no definite parent height. Combined with a nested ScrollView-in-ScrollView, RN's gesture responder had two scrollable ancestors fighting over the same pan gesture, which is why scrolling itself was unreliable, not just the visual overlap.

## What changed
- `src/components/Dialog/Dialog.tsx` / `types.ts`: added a `scrollable` prop (default `true`, so **all existing Dialog consumers are unaffected**). When `false`, Dialog renders `children` in a plain `View` pair (mirroring the same style/padding structure as its ScrollView + contentContainerStyle) instead of wrapping them in its own `ScrollView`.
- `src/components/DeviceSelector/DeviceSelector.tsx`:
  - Passes `scrollable={false}` to `Dialog`, so the device list is the *only* scrollable ancestor (no more nested ScrollViews).
  - Adds `contentContainerStyle={{ paddingBottom: FOOTER_HEIGHT }}` to the device-list `ScrollView` so the last entries clear the footer.
  - Removes the now-redundant/unreliable `height: '100%'` on `modalView` in favor of `flex: 1`, which now resolves correctly since its parent has a definite flex-computed height (no longer inside a ScrollView).
- Added `Dialog.test.tsx` and `DeviceSelector.test.tsx` (neither had tests before) and a `LongList` Storybook story for `DeviceSelector` with 25 devices.

## Test plan
- [x] `npm test` — full suite passes: 84 suites / 476 tests / 6 snapshots, all green.
- [x] New unit tests added:
  - `Dialog.test.tsx`: confirms `scrollable=true` (default) still wraps children in a `ScrollView`, and `scrollable=false` renders children in a plain `View` with no `ScrollView` ancestor, while still rendering content correctly.
  - `DeviceSelector.test.tsx`: confirms it renders correctly with both short and long (30-entry) device lists, that there is exactly one `ScrollView` in the tree (Dialog's own is now disabled), and that its `contentContainerStyle` carries `paddingBottom >= 60` (the footer height) so the last entries clear the footer.
- [x] Added `LongList` Storybook story (25 devices) for visual reference.
- [ ] **Manual on-device/simulator verification still needed**: this environment has no simulator/device available, so this PR was validated via static analysis of the RN layout logic and unit tests only — not by actually observing scroll behavior on a real screen. Before merging, please manually verify on a device or simulator with a long device list (e.g. via the new `LongList` story, or by pairing many devices) that: (1) the list scrolls smoothly with a single, non-conflicting gesture, and (2) all entries plus both footer controls ("For all capabilities" / "Disable All") are reachable.