### PR TITLE
feat: swipe-to-delete for paired devices

### DIFF
--- a/src/components/DeviceEntry/DeviceEntry.test.tsx
+++ b/src/components/DeviceEntry/DeviceEntry.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import DeviceEntry from './DeviceEntry';
+
+const baseProps = {
+    deviceName: 'Tacx Neo',
+    value: 100,
+    interface: 'ble',
+    isSelected: false,
+    onClick: jest.fn(),
+    onDelete: jest.fn(),
+};
+
+describe('DeviceEntry', () => {
+    it('renders without crashing', () => {
+        const { toJSON } = render(<DeviceEntry {...baseProps} />);
+        expect(toJSON()).not.toBeNull();
+    });
+
+    it('calls onClick when the row is pressed', () => {
+        const onClick = jest.fn();
+        const { getByText } = render(<DeviceEntry {...baseProps} onClick={onClick} />);
+        fireEvent.press(getByText('Tacx Neo'));
+        expect(onClick).toHaveBeenCalled();
+    });
+
+    // Regression-style test for the swipe-to-delete wiring, following the same pattern
+    // used for WorkoutItemView: react-native-gesture-handler's native module isn't
+    // available in this test environment (Swipeable's own require() throws), so this
+    // exercises the fallback rendering path rather than the real native Swipeable. That
+    // fallback still renders renderRightActions() so the onPress -> onDelete wiring is
+    // actually under test here; it cannot confirm or rule out native gesture-timing
+    // behaviour on a physical device.
+    it('calls onDelete when the revealed delete action is pressed', () => {
+        const onDelete = jest.fn();
+        const { getByText } = render(<DeviceEntry {...baseProps} onDelete={onDelete} />);
+        fireEvent.press(getByText('Delete'));
+        expect(onDelete).toHaveBeenCalled();
+    });
+
+    it('does not render a delete action when onDelete is not provided', () => {
+        const { onDelete, ...rest } = baseProps;
+        const { queryByText } = render(<DeviceEntry {...rest} />);
+        expect(queryByText('Delete')).toBeNull();
+    });
+
+    it('does not render a delete action when the row is disabled', () => {
+        const { queryByText } = render(<DeviceEntry {...baseProps} disabled />);
+        expect(queryByText('Delete')).toBeNull();
+    });
+});

--- a/src/components/DeviceEntry/DeviceEntry.test.tsx
+++ b/src/components/DeviceEntry/DeviceEntry.test.tsx
@@ -39,6 +39,7 @@ describe('DeviceEntry', () => {
     });
 
     it('does not render a delete action when onDelete is not provided', () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { onDelete, ...rest } = baseProps;
         const { queryByText } = render(<DeviceEntry {...rest} />);
         expect(queryByText('Delete')).toBeNull();

--- a/src/components/DeviceEntry/DeviceEntry.tsx
+++ b/src/components/DeviceEntry/DeviceEntry.tsx
@@ -1,10 +1,36 @@
 import React, { FC } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Platform } from 'react-native';
 import { DeviceSelectionItemProps } from 'incyclist-services';
 
-import WifiIcon from '../../assets/icons/wifi.svg'; 
+import WifiIcon from '../../assets/icons/wifi.svg';
 import BleIcon from '../../assets/icons/ble.svg';
 import { colors,textSizes } from '../../theme'
+
+// Conditional import to prevent Storybook Vite from crashing - same pattern as
+// RouteItemView/WorkoutItemView. The revealed delete action uses RNGH's own
+// TouchableOpacity (not React Native's) since it lives inside Swipeable's
+// gesture tree, where a plain RN TouchableOpacity's tap can be swallowed by the
+// native pan/tap recognizers right after the swipe-open gesture.
+let Swipeable: any = View;
+let ActionTouchableOpacity: any = TouchableOpacity;
+try {
+    if (Platform.OS !== 'web') {
+        const gestureHandler = require('react-native-gesture-handler');
+        Swipeable = gestureHandler.Swipeable;
+        ActionTouchableOpacity = gestureHandler.TouchableOpacity;
+    }
+} catch {
+    // Storybook (Vite) / any environment without the native gesture-handler module:
+    // still render the revealed actions (just inline, unanimated) instead of silently
+    // dropping renderRightActions - otherwise the delete action never appears at all in
+    // Storybook or in Jest/RTL tests, and its wiring can never be exercised.
+    Swipeable = ({ children, renderRightActions }: any) => (
+        <View>
+            {children}
+            {renderRightActions?.()}
+        </View>
+    );
+}
 
 type ComponentProps = DeviceSelectionItemProps &  {
     disabled?: boolean
@@ -17,9 +43,10 @@ const DeviceEntry: FC<ComponentProps> = ({
     disabled,
     interface: deviceInterface,
     isSelected,
-    onClick,    
+    onClick,
+    onDelete,
 }) => {
-  
+
     const renderConnectState = () => {
     switch (connectState) {
         case 'connecting':
@@ -29,37 +56,44 @@ const DeviceEntry: FC<ComponentProps> = ({
         case 'failed':
             return <Text style={[styles.statusIcon, disabled  ? styles.disabled : styles.failed]}>✕</Text>; // Red X
         default:
-            return <Text style={[styles.statusIcon, disabled && styles.disabled]}> </Text>; 
+            return <Text style={[styles.statusIcon, disabled && styles.disabled]}> </Text>;
     }
     };
 
   const InterfaceIcon = deviceInterface === 'wifi' ? WifiIcon : BleIcon;
 
-    return (
+    const renderRightActions = () => (
+        <ActionTouchableOpacity style={styles.deleteAction} onPress={onDelete}>
+            <Text style={styles.deleteText}>Delete</Text>
+        </ActionTouchableOpacity>
+    );
+
+    const content = (
         <TouchableOpacity disabled={disabled} onPress={disabled ? null: onClick} style={[styles.container, (isSelected&&!disabled) && styles.selected]}>
 
-            <View style={styles.colState}>            
-                {/* Placeholder for optional delete button (e.g., hidden until hover in web) */}
-                {/* On native, delete might be a swipe gesture or a long press action */}
-                {/* <TouchableOpacity onPress={onDelete} style={styles.deleteButton}>
-                    <Text style={styles.deleteText}>Delete</Text>
-                </TouchableOpacity> */}
+            <View style={styles.colState}>
                 {renderConnectState()}
             </View>
 
-            <View style={styles.colDeviceName}>            
+            <View style={styles.colDeviceName}>
                 <Text style={[styles.deviceName,disabled && styles.disabled]} >{deviceName}</Text>
             </View>
 
-            <View style={styles.value}>            
+            <View style={styles.value}>
                 <Text style={[styles.deviceName,disabled && styles.disabled]}>{value??' '}</Text>
             </View>
-            
+
             <View style={styles.colInterface}>
                 <InterfaceIcon width={20} height={20} fill="#fff" style={styles.interfaceIcon} />
             </View>
         </TouchableOpacity>
     );
+
+    // No delete gesture when the row is disabled ("Disable All" checked) or when
+    // the page service hasn't wired an onDelete handler for this entry.
+    if (!onDelete || disabled) return content;
+
+    return <Swipeable renderRightActions={renderRightActions}>{content}</Swipeable>;
 };
 
 const styles = StyleSheet.create({
@@ -114,7 +148,18 @@ const styles = StyleSheet.create({
   },
   interfaceIcon: {
     marginLeft: 5,
-  }
+  },
+  deleteAction: {
+    backgroundColor: colors.error,
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: 80,
+    paddingVertical: 8,
+  },
+  deleteText: {
+    color: '#FFFFFF',
+    fontWeight: 'bold',
+  },
 });
 
 export default DeviceEntry;

--- a/src/components/DeviceEntry/DeviceEntry.tsx
+++ b/src/components/DeviceEntry/DeviceEntry.tsx
@@ -69,7 +69,7 @@ const DeviceEntry: FC<ComponentProps> = ({
     );
 
     const content = (
-        <TouchableOpacity disabled={disabled} onPress={disabled ? null: onClick} style={[styles.container, (isSelected&&!disabled) && styles.selected]}>
+        <TouchableOpacity disabled={disabled} onPress={disabled ? undefined : () => onClick?.()} style={[styles.container, (isSelected&&!disabled) && styles.selected]}>
 
             <View style={styles.colState}>
                 {renderConnectState()}


### PR DESCRIPTION
## Summary
- `DeviceEntry` now wires a swipe-to-delete gesture (Swipeable + revealed delete action) to the `onDelete` display prop, which `DevicesPageService.getDeviceListDisplayProps()` now populates on the `services` side (incyclist/services#475 — required for this to be functionally wired end-to-end; needs a version bump once published).
- Reused the existing `Swipeable` + RNGH `TouchableOpacity` list-item-delete pattern already established by `RouteItemView` and `WorkoutItemView`, rather than introducing a new inline button or long-press menu — this keeps device removal consistent with how routes/workouts are already deleted elsewhere in the app.
- Delete action is suppressed when the row is `disabled` (i.e. "Disable All" is checked) or when no `onDelete` handler is supplied.

## What changed
- `src/components/DeviceEntry/DeviceEntry.tsx`: conditional `Swipeable` import (Storybook/web-safe fallback), `renderRightActions`, guard for disabled/missing `onDelete`.
- `src/components/DeviceEntry/DeviceEntry.test.tsx`: new tests — renders, `onClick` wiring, delete action press → `onDelete`, delete action hidden when `onDelete` absent, delete action hidden when `disabled`.

## Test plan
- [x] `npm test` — full suite passes (83 suites / 474 tests)
- [x] New `DeviceEntry` tests pass in isolation
- [ ] Manual on-device verification of the swipe gesture (native `Swipeable` behaviour can't be fully exercised in Jest — same caveat as the existing `WorkoutItemView` swipe-delete tests)