### PR TITLE
fix: Dialog swipe gestures inert (missing GestureHandlerRootView)

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -20,6 +20,21 @@ import { colors, textSizes } from '../../theme';
 import { useLogging, useUnmountEffect, useScreenLayout } from '../../hooks';
 import { EventLogger } from 'gd-eventlog';
 
+// Conditional import - same pattern as DeviceEntry/RouteItemView/WorkoutItemView: a static
+// import of react-native-gesture-handler crashes in Jest (no native RNGestureHandlerModule)
+// and in Storybook/Vite. RN's Modal renders its subtree on a separate native surface, outside
+// the app root's GestureHandlerRootView (see App.tsx), so any Swipeable/gesture-handler content
+// rendered inside a Dialog needs its own nested root - falling back to a plain View keeps
+// Dialog's own tests/Storybook usage working when the native module isn't available.
+let GestureHandlerRootView: any = View;
+try {
+    if (Platform.OS !== 'web') {
+        GestureHandlerRootView = require('react-native-gesture-handler').GestureHandlerRootView;
+    }
+} catch {
+    GestureHandlerRootView = View;
+}
+
 export const Dialog = ({
     title,
     titleStyle,
@@ -143,48 +158,50 @@ export const Dialog = ({
                 presentationStyle="overFullScreen"                              
                 onRequestClose={onOutsideClick}
             >
-                <Animated.View style={[
-                    styles.fullScreenWrapper,
-                    { transform: [dynamicTransform] },
-                ]}>
-                    <View style={styles.fullLayout}>
-                        <TouchableOpacity
-                            style={styles.strip}
-                            onPress={onOutsideClick}
-                            activeOpacity={1}
-                        />
-                        <BackgroundContainer
-                            colors={gradientColors}
-                            style={[backgroundStyle, styles.fullContentArea, style]}
-                        >
-                            <View style={styles.header}>
-                                <Text style={[styles.title, titleStyle]}>{title}</Text>
-                            </View>
+                <GestureHandlerRootView style={styles.fullScreenWrapper}>
+                    <Animated.View style={[
+                        styles.fullScreenWrapper,
+                        { transform: [dynamicTransform] },
+                    ]}>
+                        <View style={styles.fullLayout}>
+                            <TouchableOpacity
+                                style={styles.strip}
+                                onPress={onOutsideClick}
+                                activeOpacity={1}
+                            />
+                            <BackgroundContainer
+                                colors={gradientColors}
+                                style={[backgroundStyle, styles.fullContentArea, style]}
+                            >
+                                <View style={styles.header}>
+                                    <Text style={[styles.title, titleStyle]}>{title}</Text>
+                                </View>
 
-                            {scrollable ? (
-                                <ScrollView
-                                    style={styles.scrollArea}
-                                    contentContainerStyle={styles.content}
-                                    bounces={false}
-                                >
-                                    {children}
-                                </ScrollView>
-                            ) : (
-                                <View style={styles.scrollArea}>
-                                    <View style={styles.content}>
+                                {scrollable ? (
+                                    <ScrollView
+                                        style={styles.scrollArea}
+                                        contentContainerStyle={styles.content}
+                                        bounces={false}
+                                    >
                                         {children}
+                                    </ScrollView>
+                                ) : (
+                                    <View style={styles.scrollArea}>
+                                        <View style={styles.content}>
+                                            {children}
+                                        </View>
                                     </View>
-                                </View>
-                            )}
+                                )}
 
-                            {buttons?.length ? (
-                                <View style={styles.footer}>
-                                    <ButtonBar buttons={buttons} />
-                                </View>
-                            ) : <></>}
-                        </BackgroundContainer>
-                    </View>
-                </Animated.View>
+                                {buttons?.length ? (
+                                    <View style={styles.footer}>
+                                        <ButtonBar buttons={buttons} />
+                                    </View>
+                                ) : <></>}
+                            </BackgroundContainer>
+                        </View>
+                    </Animated.View>
+                </GestureHandlerRootView>
             </Modal>
         );
     }
@@ -198,43 +215,45 @@ export const Dialog = ({
             presentationStyle="overFullScreen"              
             supportedOrientations={['landscape']}
         >
-            <TouchableWithoutFeedback onPress={onOutsideClick}>
-                <View style={styles.overlay}>
-                    <TouchableWithoutFeedback>
-                        <BackgroundContainer
-                            colors={gradientColors}
-                            style={[backgroundStyle, style]}
-                        >
-                            <View style={styles.header}>
-                                <Text style={[styles.title, titleStyle]}>{title}</Text>
-                            </View>
+            <GestureHandlerRootView style={styles.fullScreenWrapper}>
+                <TouchableWithoutFeedback onPress={onOutsideClick}>
+                    <View style={styles.overlay}>
+                        <TouchableWithoutFeedback>
+                            <BackgroundContainer
+                                colors={gradientColors}
+                                style={[backgroundStyle, style]}
+                            >
+                                <View style={styles.header}>
+                                    <Text style={[styles.title, titleStyle]}>{title}</Text>
+                                </View>
 
-                            {scrollable ? (
-                                <ScrollView
-                                    style={styles.scrollArea}
-                                    contentContainerStyle={styles.content}
-                                    bounces={false}
-                                >
-                                    {children}
-                                </ScrollView>
-                            ) : (
-                                <View style={styles.scrollArea}>
-                                    <View style={styles.content}>
+                                {scrollable ? (
+                                    <ScrollView
+                                        style={styles.scrollArea}
+                                        contentContainerStyle={styles.content}
+                                        bounces={false}
+                                    >
                                         {children}
+                                    </ScrollView>
+                                ) : (
+                                    <View style={styles.scrollArea}>
+                                        <View style={styles.content}>
+                                            {children}
+                                        </View>
                                     </View>
-                                </View>
-                            )}
+                                )}
 
-                            {buttons?.length ? (
-                                <View style={styles.footer}>
-                                    <ButtonBar buttons={buttons} />
-                                </View>
-                            ) : <></>}
+                                {buttons?.length ? (
+                                    <View style={styles.footer}>
+                                        <ButtonBar buttons={buttons} />
+                                    </View>
+                                ) : <></>}
 
-                        </BackgroundContainer>
-                    </TouchableWithoutFeedback>
-                </View>
-            </TouchableWithoutFeedback>
+                            </BackgroundContainer>
+                        </TouchableWithoutFeedback>
+                    </View>
+                </TouchableWithoutFeedback>
+            </GestureHandlerRootView>
         </Modal>
     );
 };


### PR DESCRIPTION
## Summary
- Swipe-to-delete on a paired device row (`DeviceEntry`'s `Swipeable`) had no effect at all inside the DevicePairing screen — no visual feedback, no delete triggered.
- Root cause: `Dialog` renders its children inside React Native's native `<Modal>` (both branches), which mounts its subtree on a separate native surface outside the app's single `GestureHandlerRootView` (set up once, at the root, in `App.tsx`). `Swipeable`'s pan gesture recognizer never activated as a result — a silent no-op, no crash.
- Fix: wrap `Dialog`'s `Modal` content in its own `GestureHandlerRootView` in both render branches, so any current or future gesture-handler content works correctly inside a `Dialog`.

## What changed
- `src/components/Dialog/Dialog.tsx`: added a conditionally-required `GestureHandlerRootView` (falls back to plain `View` when the native module isn't available, e.g. Storybook/Jest — same pattern already used elsewhere in this repo), wrapping the Modal content in both the `variant === 'full'` branch and the default branch.

## Test plan
- [x] `npm test` — full suite passes (85 suites / 481 tests), including `Dialog.test.tsx`, `DeviceEntry.test.tsx`, `DeviceSelector.test.tsx`
- [x] Verified on a real device: swipe-to-delete on a paired device row in the DevicePairing screen now reveals Delete and removes the device (closes `TESTING_BACKLOG.md` #4's outstanding verification for the swipe gesture itself)

Filed as `FIXES_BACKLOG.md` item #11.