### PR TITLE
fix: map ExoPlayer error codes to human-readable video error messages

### DIFF
--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -12,6 +12,7 @@ import { VideoView } from './VideoView';
 import { sleep } from '../../utils/timers';
 import { Platform } from 'react-native';
 import { getFileSystemBinding } from '../../bindings/fs';
+import { mapAndroidErrorCode } from './mapAndroidErrorCode';
 
 export const Video = (props: VideoProps) => {
     const {
@@ -165,8 +166,11 @@ export const Video = (props: VideoProps) => {
 
     const handleError = useCallback((error: OnVideoErrorData) => {
         const hasErrorCode = error?.error?.errorCode !== undefined
-        const code = hasErrorCode
-            ? Number(error.error.errorCode) 
+        const rawCode = hasErrorCode
+            ? Number(error.error.errorCode)
+            : undefined;
+        const code = Platform.OS === 'android' && rawCode !== undefined
+            ? mapAndroidErrorCode(rawCode)
             : undefined;
 
         const message = error?.error?.errorString ?? error?.error?.localizedDescription;

--- a/src/components/Video/mapAndroidErrorCode.test.ts
+++ b/src/components/Video/mapAndroidErrorCode.test.ts
@@ -1,0 +1,47 @@
+import { mapAndroidErrorCode } from './mapAndroidErrorCode';
+
+// W3C MediaError codes, matching what the shared RLVDisplayService.buildVideoError
+// (incyclist-services) expects.
+const MEDIA_ERR_NETWORK = 2;
+const MEDIA_ERR_DECODE = 3;
+const MEDIA_ERR_SRC_NOT_SUPPORTED = 4;
+
+describe('mapAndroidErrorCode', () => {
+    test('maps ERROR_CODE_IO_BAD_HTTP_STATUS (22004) to MEDIA_ERR_NETWORK', () => {
+        expect(mapAndroidErrorCode(22004)).toBe(MEDIA_ERR_NETWORK);
+    });
+
+    test('maps other IO/source errors (2xxx -> 22xxx) to MEDIA_ERR_NETWORK', () => {
+        expect(mapAndroidErrorCode(22000)).toBe(MEDIA_ERR_NETWORK); // IO_UNSPECIFIED
+        expect(mapAndroidErrorCode(22001)).toBe(MEDIA_ERR_NETWORK); // IO_NETWORK_CONNECTION_FAILED
+        expect(mapAndroidErrorCode(22002)).toBe(MEDIA_ERR_NETWORK); // IO_NETWORK_CONNECTION_TIMEOUT
+        expect(mapAndroidErrorCode(22999)).toBe(MEDIA_ERR_NETWORK);
+    });
+
+    test('maps parsing/container errors (3xxx -> 23xxx) to MEDIA_ERR_SRC_NOT_SUPPORTED', () => {
+        expect(mapAndroidErrorCode(23001)).toBe(MEDIA_ERR_SRC_NOT_SUPPORTED); // PARSING_CONTAINER_MALFORMED
+        expect(mapAndroidErrorCode(23004)).toBe(MEDIA_ERR_SRC_NOT_SUPPORTED); // PARSING_MANIFEST_UNSUPPORTED
+    });
+
+    test('maps decoder/renderer errors (4xxx-5xxx -> 24xxx-25xxx) to MEDIA_ERR_DECODE', () => {
+        expect(mapAndroidErrorCode(24001)).toBe(MEDIA_ERR_DECODE); // DECODER_INIT_FAILED
+        expect(mapAndroidErrorCode(24003)).toBe(MEDIA_ERR_DECODE); // DECODING_FAILED
+        expect(mapAndroidErrorCode(25001)).toBe(MEDIA_ERR_DECODE); // renderer/track error range
+    });
+
+    test('leaves general errors (1xxx -> 21xxx) unmapped', () => {
+        expect(mapAndroidErrorCode(21000)).toBeUndefined(); // ERROR_CODE_UNSPECIFIED
+        expect(mapAndroidErrorCode(21001)).toBeUndefined(); // ERROR_CODE_TIMEOUT
+    });
+
+    test('leaves DRM errors (6xxx -> 26xxx) unmapped', () => {
+        expect(mapAndroidErrorCode(26001)).toBeUndefined();
+    });
+
+    test('leaves out-of-range/unrecognized codes unmapped', () => {
+        expect(mapAndroidErrorCode(0)).toBeUndefined();
+        expect(mapAndroidErrorCode(1234)).toBeUndefined();
+        expect(mapAndroidErrorCode(30000)).toBeUndefined();
+        expect(mapAndroidErrorCode(99999)).toBeUndefined();
+    });
+});

--- a/src/components/Video/mapAndroidErrorCode.ts
+++ b/src/components/Video/mapAndroidErrorCode.ts
@@ -1,0 +1,26 @@
+// W3C MediaError codes - what the shared RLVDisplayService.buildVideoError (incyclist-services)
+// switches on to produce a human-readable message. Android/ExoPlayer (react-native-video) reports
+// its own errorCode as the string "2" + PlaybackException's numeric code (e.g. "22004" for
+// ERROR_CODE_IO_BAD_HTTP_STATUS = 2004 - see react-native-video's
+// ReactExoplayerView.java#onPlayerError: `errorCode = "2" + e.errorCode`), which never matches the
+// W3C 1-4 range on its own. Map ExoPlayer's documented code ranges to the closest W3C category.
+const MEDIA_ERR_NETWORK = 2;
+const MEDIA_ERR_DECODE = 3;
+const MEDIA_ERR_SRC_NOT_SUPPORTED = 4;
+
+export const mapAndroidErrorCode = (rawCode: number): number | undefined => {
+    if (rawCode < 20000 || rawCode >= 30000)
+        return undefined;
+
+    const exoCode = rawCode - 20000;
+    if (exoCode >= 2000 && exoCode < 3000)
+        return MEDIA_ERR_NETWORK;              // IO/source errors (e.g. bad HTTP status, timeouts)
+    if (exoCode >= 3000 && exoCode < 4000)
+        return MEDIA_ERR_SRC_NOT_SUPPORTED;    // container/manifest parsing errors
+    if (exoCode >= 4000 && exoCode < 6000)
+        return MEDIA_ERR_DECODE;               // decoder/renderer errors
+
+    // general (1xxx) and DRM (6xxx) codes have no confident W3C equivalent - leave unmapped,
+    // falls through to the raw native message (no worse than before this fix)
+    return undefined;
+};


### PR DESCRIPTION
## Summary
- When a video fails to load during a video ride, the displayed error message was the raw native player string (e.g. "ExoPlaybackException: ERROR_CODE_IO_BAD_HTTP_STATUS") instead of a human-readable message like "Could not load video" - confirmed in a production log.
- Root cause: the shared `RLVDisplayService.buildVideoError` (`incyclist-services`) switches on W3C `MediaError` codes (1-4) to produce friendly text - this works correctly for web-ui/desktop (browser's native `MediaError`), but mobile passed react-native-video's platform-native ExoPlayer/AVPlayer error code straight through, which never matches that range.

## What changed
- Traced react-native-video's Android source (`ReactExoplayerView.java#onPlayerError`) to confirm the exact scheme: `errorCode = "2" + e.errorCode` (ExoPlayer's own `PlaybackException` numeric code, e.g. `"22004"` for `ERROR_CODE_IO_BAD_HTTP_STATUS = 2004`).
- Added `src/components/Video/mapAndroidErrorCode.ts`: maps ExoPlayer's documented code ranges to the closest W3C `MediaError` category (IO/source -> NETWORK, parsing/container -> SRC_NOT_SUPPORTED, decoder/renderer -> DECODE). General and DRM codes, and all iOS codes (a completely different NSError-based scheme, not confidently mappable here), are left unmapped - falls through to the raw native message, same as before this fix (no regression).
- `Video.tsx`'s `handleError` now applies this mapping on Android before constructing `VideoMediaError`.

## Test plan
- [x] New `mapAndroidErrorCode.test.ts` covering the IO/network, parsing, decoder, general, DRM, and out-of-range cases, including the exact `22004` -> `NETWORK` case from the production log
- [x] `npm test` on `src/components/Video`, `src/pages/RidePage` - all pass
- [x] `tsc --noEmit` / `eslint` clean on changed files