### PR TITLE
fix: show resulting Watts in workout swipe load-adjustment feedback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "axios": "^1.17.0",
         "events": "^3.3.0",
         "gd-eventlog": "^0.1.27",
-        "incyclist-services": "^1.7.86",
+        "incyclist-services": "^1.7.87",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
         "react": "^19.2.4",
@@ -11721,9 +11721,9 @@
       }
     },
     "node_modules/incyclist-devices": {
-      "version": "3.0.24",
-      "resolved": "https://registry.npmjs.org/incyclist-devices/-/incyclist-devices-3.0.24.tgz",
-      "integrity": "sha512-3dXHSguq7B8YFnn2fiMUOd41TCXFcEdAENUwzELd8gVJNO5ZLBnz8S3EoKl+FJJFZN/gZIAaa2Hqs3OMH9jXjg==",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/incyclist-devices/-/incyclist-devices-3.0.25.tgz",
+      "integrity": "sha512-D9qWefa2kgqeGLBc9wFawDbwLxgnk7/12/ituYK25B5H/R9Pqi9ulMsorij7NJuffPLpe7f4q8WyHuUPpB5Qzg==",
       "dependencies": {
         "@protobuf-ts/runtime": "^2.11.1",
         "@serialport/bindings-interface": "^1.2.2",
@@ -11739,13 +11739,13 @@
       }
     },
     "node_modules/incyclist-services": {
-      "version": "1.7.86",
-      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.86.tgz",
-      "integrity": "sha512-5qXDAtYzGDSPwvR/Xj/4IFdcJMGY3yiDj9S2UHJzmpc2eS0jWh76IMosZxrGvDnytL0Ic0qIuZj8borC/4tUbQ==",
+      "version": "1.7.87",
+      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.87.tgz",
+      "integrity": "sha512-lXSr4Xhfvdnt6OSjavXX5aIDF+b61ZpOmCVVRDKpcYhVrL9VGiHskjE9+J54V7ZYtEe0uopqRKnSdZU9PIUkQg==",
       "dependencies": {
         "@garmin/fitsdk": "^21.200.0",
         "axios": "^1.15.2",
-        "incyclist-devices": "^3.0.24",
+        "incyclist-devices": "^3.0.25",
         "promise.any": "^2.0.6",
         "semver": "^7.7.4",
         "tcx-builder": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "axios": "^1.17.0",
     "events": "^3.3.0",
     "gd-eventlog": "^0.1.27",
-    "incyclist-services": "^1.7.86",
+    "incyclist-services": "^1.7.87",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "react": "^19.2.4",

--- a/src/hooks/ride/useWorkoutRideGestures.test.ts
+++ b/src/hooks/ride/useWorkoutRideGestures.test.ts
@@ -3,7 +3,7 @@ import { Vibration } from 'react-native';
 import {
     useWorkoutRideGestures,
     classifySwipe,
-    formatTargetPower,
+    formatAdjustedFtp,
     DEFAULT_WORKOUT_LOAD_INCREMENT,
     WORKOUT_LOAD_INCREMENT_SETTING_KEY,
 } from './useWorkoutRideGestures';
@@ -38,21 +38,21 @@ jest.mock('react-native-gesture-handler', () => ({
     Gesture: { Pan: jest.fn(() => mockPanBuilder) },
 }));
 
-describe('formatTargetPower', () => {
+describe('formatAdjustedFtp', () => {
     it('formats a whole-number watt value', () => {
-        expect(formatTargetPower(275)).toBe(' (275W)');
+        expect(formatAdjustedFtp(220)).toBe(' (220W)');
     });
 
     it('rounds a fractional watt value to the nearest whole number', () => {
-        expect(formatTargetPower(254.6)).toBe(' (255W)');
+        expect(formatAdjustedFtp(254.6)).toBe(' (255W)');
     });
 
     it('returns an empty string when the value is undefined', () => {
-        expect(formatTargetPower(undefined)).toBe('');
+        expect(formatAdjustedFtp(undefined)).toBe('');
     });
 
     it('returns an empty string when the value is NaN', () => {
-        expect(formatTargetPower(NaN)).toBe('');
+        expect(formatAdjustedFtp(NaN)).toBe('');
     });
 });
 
@@ -154,33 +154,31 @@ describe('useWorkoutRideGestures', () => {
         expect(result.current.feedback.message).toBe('Step Forward ▶');
     });
 
-    it('increases load by the configured increment on an upward swipe and shows the resulting Watts', () => {
+    it('increases load by the configured increment on an upward swipe and shows the adjusted Workout FTP', () => {
         mockGetValue.mockImplementation(() => 5);
-        mockAdjustLoad.mockReturnValue(275);
+        mockAdjustLoad.mockReturnValue(220);
         const { result } = renderHook(() => useWorkoutRideGestures());
         act(() => {
             capturedOnEnd!({ translationX: 0, translationY: -100, velocityX: 0, velocityY: 0 });
         });
         expect(mockGetValue).toHaveBeenCalledWith(WORKOUT_LOAD_INCREMENT_SETTING_KEY, DEFAULT_WORKOUT_LOAD_INCREMENT);
         expect(mockAdjustLoad).toHaveBeenCalledWith(5);
-        expect(result.current.feedback.message).toBe('+5% (275W)');
+        expect(result.current.feedback.message).toBe('+5% (220W)');
     });
 
-    it('decreases load by the configured increment on a downward swipe and shows the resulting Watts', () => {
+    it('decreases load by the configured increment on a downward swipe and shows the adjusted Workout FTP', () => {
         mockGetValue.mockImplementation(() => 1);
-        mockAdjustLoad.mockReturnValue(255);
+        mockAdjustLoad.mockReturnValue(91);
         const { result } = renderHook(() => useWorkoutRideGestures());
         act(() => {
             capturedOnEnd!({ translationX: 0, translationY: 100, velocityX: 0, velocityY: 0 });
         });
         expect(mockAdjustLoad).toHaveBeenCalledWith(-1);
-        expect(result.current.feedback.message).toBe('-1% (255W)');
+        expect(result.current.feedback.message).toBe('-1% (91W)');
     });
 
-    // Graduated-step case (services WorkoutRideService.powerUp/powerDown, minPower!==maxPower):
-    // targetPower is nudged directly by a fixed Watt amount rather than derived from FTP. The
-    // hook must show whatever adjustLoad() returns verbatim - it must not re-derive Watts itself.
-    it('shows a fractional graduated-step targetPower rounded to a whole number', () => {
+    // The hook must show whatever adjustLoad() returns verbatim - it must not re-derive Watts itself.
+    it('shows a fractional adjusted-FTP value rounded to a whole number', () => {
         mockGetValue.mockImplementation(() => 1);
         mockAdjustLoad.mockReturnValue(154.6);
         const { result } = renderHook(() => useWorkoutRideGestures());
@@ -190,7 +188,7 @@ describe('useWorkoutRideGestures', () => {
         expect(result.current.feedback.message).toBe('+1% (155W)');
     });
 
-    it('falls back to a bare percentage when adjustLoad cannot report a resulting Watts value', () => {
+    it('falls back to a bare percentage when adjustLoad cannot report an adjusted FTP (e.g. no FTP configured)', () => {
         mockGetValue.mockImplementation(() => 5);
         mockAdjustLoad.mockReturnValue(undefined);
         const { result } = renderHook(() => useWorkoutRideGestures());

--- a/src/hooks/ride/useWorkoutRideGestures.test.ts
+++ b/src/hooks/ride/useWorkoutRideGestures.test.ts
@@ -3,7 +3,7 @@ import { Vibration } from 'react-native';
 import {
     useWorkoutRideGestures,
     classifySwipe,
-    formatAdjustedFtp,
+    formatPowerAdjustment,
     DEFAULT_WORKOUT_LOAD_INCREMENT,
     WORKOUT_LOAD_INCREMENT_SETTING_KEY,
 } from './useWorkoutRideGestures';
@@ -38,21 +38,25 @@ jest.mock('react-native-gesture-handler', () => ({
     Gesture: { Pan: jest.fn(() => mockPanBuilder) },
 }));
 
-describe('formatAdjustedFtp', () => {
-    it('formats a whole-number watt value', () => {
-        expect(formatAdjustedFtp(220)).toBe(' (220W)');
+describe('formatPowerAdjustment', () => {
+    it('labels an FTP adjustment with "FTP:"', () => {
+        expect(formatPowerAdjustment({ type: 'ftp', value: 220 })).toBe(' (FTP: 220W)');
+    });
+
+    it('shows a target-power adjustment as a bare watt value, no label', () => {
+        expect(formatPowerAdjustment({ type: 'targetPower', value: 155 })).toBe(' (155W)');
     });
 
     it('rounds a fractional watt value to the nearest whole number', () => {
-        expect(formatAdjustedFtp(254.6)).toBe(' (255W)');
+        expect(formatPowerAdjustment({ type: 'ftp', value: 254.6 })).toBe(' (FTP: 255W)');
     });
 
-    it('returns an empty string when the value is undefined', () => {
-        expect(formatAdjustedFtp(undefined)).toBe('');
+    it('returns an empty string when the result is undefined', () => {
+        expect(formatPowerAdjustment(undefined)).toBe('');
     });
 
     it('returns an empty string when the value is NaN', () => {
-        expect(formatAdjustedFtp(NaN)).toBe('');
+        expect(formatPowerAdjustment({ type: 'ftp', value: NaN })).toBe('');
     });
 });
 
@@ -154,33 +158,35 @@ describe('useWorkoutRideGestures', () => {
         expect(result.current.feedback.message).toBe('Step Forward ▶');
     });
 
-    it('increases load by the configured increment on an upward swipe and shows the adjusted Workout FTP', () => {
+    it('increases load by the configured increment on an upward swipe and shows the adjusted Workout FTP, labelled', () => {
         mockGetValue.mockImplementation(() => 5);
-        mockAdjustLoad.mockReturnValue(220);
+        mockAdjustLoad.mockReturnValue({ type: 'ftp', value: 220 });
         const { result } = renderHook(() => useWorkoutRideGestures());
         act(() => {
             capturedOnEnd!({ translationX: 0, translationY: -100, velocityX: 0, velocityY: 0 });
         });
         expect(mockGetValue).toHaveBeenCalledWith(WORKOUT_LOAD_INCREMENT_SETTING_KEY, DEFAULT_WORKOUT_LOAD_INCREMENT);
         expect(mockAdjustLoad).toHaveBeenCalledWith(5);
-        expect(result.current.feedback.message).toBe('+5% (220W)');
+        expect(result.current.feedback.message).toBe('+5% (FTP: 220W)');
     });
 
-    it('decreases load by the configured increment on a downward swipe and shows the adjusted Workout FTP', () => {
+    it('decreases load by the configured increment on a downward swipe and shows the adjusted Workout FTP, labelled', () => {
         mockGetValue.mockImplementation(() => 1);
-        mockAdjustLoad.mockReturnValue(91);
+        mockAdjustLoad.mockReturnValue({ type: 'ftp', value: 91 });
         const { result } = renderHook(() => useWorkoutRideGestures());
         act(() => {
             capturedOnEnd!({ translationX: 0, translationY: 100, velocityX: 0, velocityY: 0 });
         });
         expect(mockAdjustLoad).toHaveBeenCalledWith(-1);
-        expect(result.current.feedback.message).toBe('-1% (91W)');
+        expect(result.current.feedback.message).toBe('-1% (FTP: 91W)');
     });
 
-    // The hook must show whatever adjustLoad() returns verbatim - it must not re-derive Watts itself.
-    it('shows a fractional adjusted-FTP value rounded to a whole number', () => {
+    // Regression: a step that allows a power range (e.g. 120-170W) nudges targetPower directly,
+    // without touching FTP - feedback must show the plain Watts value, with no "FTP:" label, since
+    // it isn't the workout's FTP that moved.
+    it('shows a range-step target power adjustment as a bare watt value, no FTP label', () => {
         mockGetValue.mockImplementation(() => 1);
-        mockAdjustLoad.mockReturnValue(154.6);
+        mockAdjustLoad.mockReturnValue({ type: 'targetPower', value: 155 });
         const { result } = renderHook(() => useWorkoutRideGestures());
         act(() => {
             capturedOnEnd!({ translationX: 0, translationY: -100, velocityX: 0, velocityY: 0 });
@@ -188,7 +194,18 @@ describe('useWorkoutRideGestures', () => {
         expect(result.current.feedback.message).toBe('+1% (155W)');
     });
 
-    it('falls back to a bare percentage when adjustLoad cannot report an adjusted FTP (e.g. no FTP configured)', () => {
+    // The hook must show whatever adjustLoad() returns verbatim - it must not re-derive Watts itself.
+    it('shows a fractional adjusted value rounded to a whole number', () => {
+        mockGetValue.mockImplementation(() => 1);
+        mockAdjustLoad.mockReturnValue({ type: 'ftp', value: 154.6 });
+        const { result } = renderHook(() => useWorkoutRideGestures());
+        act(() => {
+            capturedOnEnd!({ translationX: 0, translationY: -100, velocityX: 0, velocityY: 0 });
+        });
+        expect(result.current.feedback.message).toBe('+1% (FTP: 155W)');
+    });
+
+    it('falls back to a bare percentage when adjustLoad cannot report an adjustment (e.g. no FTP configured)', () => {
         mockGetValue.mockImplementation(() => 5);
         mockAdjustLoad.mockReturnValue(undefined);
         const { result } = renderHook(() => useWorkoutRideGestures());

--- a/src/hooks/ride/useWorkoutRideGestures.test.ts
+++ b/src/hooks/ride/useWorkoutRideGestures.test.ts
@@ -3,6 +3,7 @@ import { Vibration } from 'react-native';
 import {
     useWorkoutRideGestures,
     classifySwipe,
+    formatTargetPower,
     DEFAULT_WORKOUT_LOAD_INCREMENT,
     WORKOUT_LOAD_INCREMENT_SETTING_KEY,
 } from './useWorkoutRideGestures';
@@ -37,6 +38,24 @@ jest.mock('react-native-gesture-handler', () => ({
     Gesture: { Pan: jest.fn(() => mockPanBuilder) },
 }));
 
+describe('formatTargetPower', () => {
+    it('formats a whole-number watt value', () => {
+        expect(formatTargetPower(275)).toBe(' (275W)');
+    });
+
+    it('rounds a fractional watt value to the nearest whole number', () => {
+        expect(formatTargetPower(254.6)).toBe(' (255W)');
+    });
+
+    it('returns an empty string when the value is undefined', () => {
+        expect(formatTargetPower(undefined)).toBe('');
+    });
+
+    it('returns an empty string when the value is NaN', () => {
+        expect(formatTargetPower(NaN)).toBe('');
+    });
+});
+
 describe('classifySwipe', () => {
     it('returns null for movement below both thresholds', () => {
         expect(classifySwipe(10, 5, 50, 50)).toBeNull();
@@ -67,6 +86,7 @@ describe('useWorkoutRideGestures', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockGetValue.mockImplementation((_key: string, def: any) => def);
+        mockAdjustLoad.mockReturnValue(undefined);
         jest.useFakeTimers();
         capturedOnEnd = undefined;
     });
@@ -134,25 +154,50 @@ describe('useWorkoutRideGestures', () => {
         expect(result.current.feedback.message).toBe('Step Forward ▶');
     });
 
-    it('increases load by the configured increment on an upward swipe', () => {
+    it('increases load by the configured increment on an upward swipe and shows the resulting Watts', () => {
         mockGetValue.mockImplementation(() => 5);
+        mockAdjustLoad.mockReturnValue(275);
         const { result } = renderHook(() => useWorkoutRideGestures());
         act(() => {
             capturedOnEnd!({ translationX: 0, translationY: -100, velocityX: 0, velocityY: 0 });
         });
         expect(mockGetValue).toHaveBeenCalledWith(WORKOUT_LOAD_INCREMENT_SETTING_KEY, DEFAULT_WORKOUT_LOAD_INCREMENT);
         expect(mockAdjustLoad).toHaveBeenCalledWith(5);
-        expect(result.current.feedback.message).toBe('+5%');
+        expect(result.current.feedback.message).toBe('+5% (275W)');
     });
 
-    it('decreases load by the configured increment on a downward swipe', () => {
+    it('decreases load by the configured increment on a downward swipe and shows the resulting Watts', () => {
         mockGetValue.mockImplementation(() => 1);
+        mockAdjustLoad.mockReturnValue(255);
         const { result } = renderHook(() => useWorkoutRideGestures());
         act(() => {
             capturedOnEnd!({ translationX: 0, translationY: 100, velocityX: 0, velocityY: 0 });
         });
         expect(mockAdjustLoad).toHaveBeenCalledWith(-1);
-        expect(result.current.feedback.message).toBe('-1%');
+        expect(result.current.feedback.message).toBe('-1% (255W)');
+    });
+
+    // Graduated-step case (services WorkoutRideService.powerUp/powerDown, minPower!==maxPower):
+    // targetPower is nudged directly by a fixed Watt amount rather than derived from FTP. The
+    // hook must show whatever adjustLoad() returns verbatim - it must not re-derive Watts itself.
+    it('shows a fractional graduated-step targetPower rounded to a whole number', () => {
+        mockGetValue.mockImplementation(() => 1);
+        mockAdjustLoad.mockReturnValue(154.6);
+        const { result } = renderHook(() => useWorkoutRideGestures());
+        act(() => {
+            capturedOnEnd!({ translationX: 0, translationY: -100, velocityX: 0, velocityY: 0 });
+        });
+        expect(result.current.feedback.message).toBe('+1% (155W)');
+    });
+
+    it('falls back to a bare percentage when adjustLoad cannot report a resulting Watts value', () => {
+        mockGetValue.mockImplementation(() => 5);
+        mockAdjustLoad.mockReturnValue(undefined);
+        const { result } = renderHook(() => useWorkoutRideGestures());
+        act(() => {
+            capturedOnEnd!({ translationX: 0, translationY: -100, velocityX: 0, velocityY: 0 });
+        });
+        expect(result.current.feedback.message).toBe('+5%');
     });
 
     it('does not call any service method or show feedback below both thresholds', () => {

--- a/src/hooks/ride/useWorkoutRideGestures.ts
+++ b/src/hooks/ride/useWorkoutRideGestures.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { Platform, Vibration } from 'react-native';
-import { getWorkoutRidePageService, useUserSettings } from 'incyclist-services';
+import { getWorkoutRidePageService, useUserSettings, type PowerAdjustmentResult } from 'incyclist-services';
 import { useLogging } from '../logging';
 
 // Conditional import to prevent Storybook/web from crashing (same pattern as RouteItemView/WorkoutItemView)
@@ -50,15 +50,17 @@ export const classifySwipe = (
     return translationY > 0 ? 'down' : 'up';
 };
 
-// Appends the adjusted Workout FTP to the swipe feedback, e.g. "+5% (220W)". The value comes
-// straight from adjustLoad()'s return (the actual post-adjustment settings.ftp reported by
-// WorkoutRideService.powerUp()/powerDown()). Omitted entirely if the value is unavailable (e.g. no
-// FTP configured for this workout).
-export const formatAdjustedFtp = (adjustedFtp: number | undefined): string => {
-    if (adjustedFtp === undefined || adjustedFtp === null || Number.isNaN(adjustedFtp)) {
+// Appends the adjusted quantity to the swipe feedback. adjustLoad() reports two distinct cases
+// (WorkoutRideService.powerUp()/powerDown()): a step that allows a power range (e.g. 120-170W)
+// has its targetPower nudged directly - "+5% (155W)"; otherwise the Workout FTP itself was scaled -
+// "+5% (FTP: 220W)", labelled so it isn't mistaken for the current step's target. Omitted entirely
+// when unavailable (e.g. no FTP configured and the current step isn't a power range).
+export const formatPowerAdjustment = (result: PowerAdjustmentResult | undefined): string => {
+    if (!result || Number.isNaN(result.value)) {
         return '';
     }
-    return ` (${Math.round(adjustedFtp)}W)`;
+    const watts = Math.round(result.value);
+    return result.type === 'ftp' ? ` (FTP: ${watts}W)` : ` (${watts}W)`;
 };
 
 export interface WorkoutRideGestureFeedback {
@@ -123,15 +125,15 @@ export const useWorkoutRideGestures = (): UseWorkoutRideGesturesResult => {
             case 'up': {
                 const increment = getLoadIncrement();
                 logEvent({ message: 'gesture triggered', gesture: 'swipe-up', action: 'increase-load', increment, eventSource: 'user' });
-                const adjustedFtp = service.adjustLoad(increment);
-                showFeedback(`+${increment}%${formatAdjustedFtp(adjustedFtp)}`);
+                const result = service.adjustLoad(increment);
+                showFeedback(`+${increment}%${formatPowerAdjustment(result)}`);
                 break;
             }
             case 'down': {
                 const increment = getLoadIncrement();
                 logEvent({ message: 'gesture triggered', gesture: 'swipe-down', action: 'decrease-load', increment, eventSource: 'user' });
-                const adjustedFtp = service.adjustLoad(-increment);
-                showFeedback(`-${increment}%${formatAdjustedFtp(adjustedFtp)}`);
+                const result = service.adjustLoad(-increment);
+                showFeedback(`-${increment}%${formatPowerAdjustment(result)}`);
                 break;
             }
         }

--- a/src/hooks/ride/useWorkoutRideGestures.ts
+++ b/src/hooks/ride/useWorkoutRideGestures.ts
@@ -50,6 +50,18 @@ export const classifySwipe = (
     return translationY > 0 ? 'down' : 'up';
 };
 
+// Appends the resulting absolute power target to the swipe feedback, e.g. "+5% (275W)". The value
+// comes straight from adjustLoad()'s return (the actual post-adjustment targetPower reported by
+// WorkoutRideService.powerUp()/powerDown()) rather than being re-derived from FTP on this side -
+// the "graduated" step case adjusts targetPower directly without changing FTP, so an FTP-based
+// recompute here would be wrong for that case. Omitted entirely if the value is unavailable.
+export const formatTargetPower = (targetPower: number | undefined): string => {
+    if (targetPower === undefined || targetPower === null || Number.isNaN(targetPower)) {
+        return '';
+    }
+    return ` (${Math.round(targetPower)}W)`;
+};
+
 export interface WorkoutRideGestureFeedback {
     visible: boolean;
     message: string;
@@ -112,15 +124,15 @@ export const useWorkoutRideGestures = (): UseWorkoutRideGesturesResult => {
             case 'up': {
                 const increment = getLoadIncrement();
                 logEvent({ message: 'gesture triggered', gesture: 'swipe-up', action: 'increase-load', increment, eventSource: 'user' });
-                service.adjustLoad(increment);
-                showFeedback(`+${increment}%`);
+                const targetPower = service.adjustLoad(increment);
+                showFeedback(`+${increment}%${formatTargetPower(targetPower)}`);
                 break;
             }
             case 'down': {
                 const increment = getLoadIncrement();
                 logEvent({ message: 'gesture triggered', gesture: 'swipe-down', action: 'decrease-load', increment, eventSource: 'user' });
-                service.adjustLoad(-increment);
-                showFeedback(`-${increment}%`);
+                const targetPower = service.adjustLoad(-increment);
+                showFeedback(`-${increment}%${formatTargetPower(targetPower)}`);
                 break;
             }
         }

--- a/src/hooks/ride/useWorkoutRideGestures.ts
+++ b/src/hooks/ride/useWorkoutRideGestures.ts
@@ -50,16 +50,15 @@ export const classifySwipe = (
     return translationY > 0 ? 'down' : 'up';
 };
 
-// Appends the resulting absolute power target to the swipe feedback, e.g. "+5% (275W)". The value
-// comes straight from adjustLoad()'s return (the actual post-adjustment targetPower reported by
-// WorkoutRideService.powerUp()/powerDown()) rather than being re-derived from FTP on this side -
-// the "graduated" step case adjusts targetPower directly without changing FTP, so an FTP-based
-// recompute here would be wrong for that case. Omitted entirely if the value is unavailable.
-export const formatTargetPower = (targetPower: number | undefined): string => {
-    if (targetPower === undefined || targetPower === null || Number.isNaN(targetPower)) {
+// Appends the adjusted Workout FTP to the swipe feedback, e.g. "+5% (220W)". The value comes
+// straight from adjustLoad()'s return (the actual post-adjustment settings.ftp reported by
+// WorkoutRideService.powerUp()/powerDown()). Omitted entirely if the value is unavailable (e.g. no
+// FTP configured for this workout).
+export const formatAdjustedFtp = (adjustedFtp: number | undefined): string => {
+    if (adjustedFtp === undefined || adjustedFtp === null || Number.isNaN(adjustedFtp)) {
         return '';
     }
-    return ` (${Math.round(targetPower)}W)`;
+    return ` (${Math.round(adjustedFtp)}W)`;
 };
 
 export interface WorkoutRideGestureFeedback {
@@ -124,15 +123,15 @@ export const useWorkoutRideGestures = (): UseWorkoutRideGesturesResult => {
             case 'up': {
                 const increment = getLoadIncrement();
                 logEvent({ message: 'gesture triggered', gesture: 'swipe-up', action: 'increase-load', increment, eventSource: 'user' });
-                const targetPower = service.adjustLoad(increment);
-                showFeedback(`+${increment}%${formatTargetPower(targetPower)}`);
+                const adjustedFtp = service.adjustLoad(increment);
+                showFeedback(`+${increment}%${formatAdjustedFtp(adjustedFtp)}`);
                 break;
             }
             case 'down': {
                 const increment = getLoadIncrement();
                 logEvent({ message: 'gesture triggered', gesture: 'swipe-down', action: 'decrease-load', increment, eventSource: 'user' });
-                const targetPower = service.adjustLoad(-increment);
-                showFeedback(`-${increment}%${formatTargetPower(targetPower)}`);
+                const adjustedFtp = service.adjustLoad(-increment);
+                showFeedback(`-${increment}%${formatAdjustedFtp(adjustedFtp)}`);
                 break;
             }
         }


### PR DESCRIPTION
## Summary
- Swipe-up/down feedback during a workout ride previously showed a bare percentage (e.g. "+5%") with no indication of the resulting power target.
- Now shows the adjusted quantity, labelled by which one actually moved:
  - `"+5% (FTP: 220W)"` when the Workout FTP itself was scaled (the normal case).
  - `"+5% (155W)"`, unlabelled, when the current step allows a power range (e.g. 120-170W) and the target is nudged directly within that range instead - FTP isn't touched in that case, so labelling it "FTP" would be misleading.
- The distinction comes from a new `PowerAdjustmentResult` (`{type:'ftp'|'targetPower', value}`) returned by `WorkoutRidePageService.adjustLoad()` in `incyclist-services` (companion PR, same branch name: `feat/workout-swipe-watts-feedback`, already merged into `services` main).

## What changed
- `src/hooks/ride/useWorkoutRideGestures.ts`: new `formatPowerAdjustment()` helper (replaces an earlier `formatAdjustedFtp`) formats the labelled/unlabelled cases; `handleSwipe()` uses it.

## Note
This PR's `tsc --noEmit` will only see the new `PowerAdjustmentResult` type once `node_modules/incyclist-services` is bumped past the version that includes the now-merged services change (services PR #482) - `npm test` (this repo's actual dev-workflow check, transpile-only) already passes cleanly against the current pinned version.

## Test plan
- [x] `npm test` - full suite passing: 87/87 suites, 509/509 tests, including the updated/added cases in `useWorkoutRideGestures.test.ts` (FTP-labelled case, target-power unlabelled case, fractional rounding, fallback when unavailable)

Ref: FIXES_BACKLOG.md item #12
