### PR TITLE
fix: downloaded video routes fail to play

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "axios": "^1.17.0",
         "events": "^3.3.0",
         "gd-eventlog": "^0.1.27",
-        "incyclist-services": "^1.7.87",
+        "incyclist-services": "^1.7.88",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
         "react": "^19.2.4",
@@ -11739,9 +11739,9 @@
       }
     },
     "node_modules/incyclist-services": {
-      "version": "1.7.87",
-      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.87.tgz",
-      "integrity": "sha512-lXSr4Xhfvdnt6OSjavXX5aIDF+b61ZpOmCVVRDKpcYhVrL9VGiHskjE9+J54V7ZYtEe0uopqRKnSdZU9PIUkQg==",
+      "version": "1.7.88",
+      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.88.tgz",
+      "integrity": "sha512-BovCd+m4kCMj6OA18Ru8ptvh2W2rer71zg+cUWk5NkB9JA9o8Kx/8t0rVoIa4jpKg15Y1bsz6Gw05d7ZFonghA==",
       "dependencies": {
         "@garmin/fitsdk": "^21.200.0",
         "axios": "^1.15.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "axios": "^1.17.0",
     "events": "^3.3.0",
     "gd-eventlog": "^0.1.27",
-    "incyclist-services": "^1.7.87",
+    "incyclist-services": "^1.7.88",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "react": "^19.2.4",

--- a/src/bindings/download/index.test.ts
+++ b/src/bindings/download/index.test.ts
@@ -1,0 +1,152 @@
+import { createDownloadTask } from '@kesha-antonov/react-native-background-downloader';
+import RNFS from 'react-native-fs';
+import { buildVideoUrl, MobileDownloadSession } from './index';
+
+jest.mock('react-native-fs', () => ({
+    __esModule: true,
+    default: {
+        mkdir: jest.fn().mockResolvedValue(undefined),
+        exists: jest.fn().mockResolvedValue(false),
+        unlink: jest.fn().mockResolvedValue(undefined),
+        moveFile: jest.fn().mockResolvedValue(undefined),
+        ExternalDirectoryPath: '/storage/emulated/0/Android/data/com.incyclist.app/files',
+        DocumentDirectoryPath: '/data/user/0/com.incyclist.app/files',
+    },
+}));
+
+jest.mock('@kesha-antonov/react-native-background-downloader', () => ({
+    createDownloadTask: jest.fn(),
+}));
+
+jest.mock('react-native', () => ({
+    Platform: { OS: 'android' },
+}));
+
+const flushPromises = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('buildVideoUrl', () => {
+    test('Unix absolute path produces a 3-slash video:// URL', () => {
+        const res = buildVideoUrl('/storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4');
+        expect(res).toBe('video:///storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4');
+    });
+
+    test('Windows absolute path produces a 3-slash video:// URL', () => {
+        const res = buildVideoUrl('C:\\Users\\user\\videos\\route.mp4');
+        expect(res).toBe('video:///C:\\Users\\user\\videos\\route.mp4');
+    });
+
+    test('relative path produces a 2-slash video:// URL', () => {
+        const res = buildVideoUrl('./videos/route.mp4');
+        expect(res).toBe('video://./videos/route.mp4');
+    });
+});
+
+describe('MobileDownloadSession', () => {
+    let task: {
+        begin: jest.Mock,
+        progress: jest.Mock,
+        done: jest.Mock,
+        error: jest.Mock,
+        start: jest.Mock,
+        stop: jest.Mock,
+    };
+    let doneCallback: () => void;
+
+    const url = 'https://cdn.example.com/routes/FR_Galibier_Demo.mp4';
+    const fileName = '/storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4';
+    const tempFileName = `${fileName}.part`;
+
+    beforeEach(() => {
+        doneCallback = undefined as unknown as () => void;
+        task = {
+            begin: jest.fn().mockReturnThis(),
+            progress: jest.fn().mockReturnThis(),
+            done: jest.fn((cb: () => void) => { doneCallback = cb; return task; }),
+            error: jest.fn().mockReturnThis(),
+            start: jest.fn(),
+            stop: jest.fn(),
+        };
+        (createDownloadTask as jest.Mock).mockReturnValue(task);
+        (RNFS.mkdir as jest.Mock).mockResolvedValue(undefined);
+        (RNFS.exists as jest.Mock).mockResolvedValue(false);
+        (RNFS.unlink as jest.Mock).mockResolvedValue(undefined);
+        (RNFS.moveFile as jest.Mock).mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    // Starts a session and triggers the library's 'done' callback, then flushes
+    // the microtask queue so the (fire-and-forget, from the library's point of
+    // view) async finalizeDownload() chain (exists -> [unlink] -> moveFile ->
+    // emit) has fully settled before assertions run.
+    const startAndTriggerDone = async () => {
+        const session = new MobileDownloadSession(url, fileName);
+        // Node's EventEmitter throws on an unhandled 'error' event - attach a
+        // no-op listener so tests can assert on emitSpy without that throw.
+        session.on('error', () => { /* asserted via emitSpy */ });
+        const emitSpy = jest.spyOn(session, 'emit');
+
+        session.start();
+        await flushPromises();
+
+        expect(doneCallback).toBeDefined();
+        doneCallback();
+        await flushPromises();
+
+        return { session, emitSpy };
+    };
+
+    test('downloads to a temp destination, not the final fileName directly', async () => {
+        const session = new MobileDownloadSession(url, fileName);
+        session.start();
+        await flushPromises();
+
+        expect(createDownloadTask).toHaveBeenCalledWith(expect.objectContaining({
+            destination: tempFileName,
+        }));
+        expect(createDownloadTask).not.toHaveBeenCalledWith(expect.objectContaining({
+            destination: fileName,
+        }));
+    });
+
+    test('moves the temp file to the final destination and emits a well-formed video:// URL on completion', async () => {
+        const { emitSpy } = await startAndTriggerDone();
+
+        expect(RNFS.moveFile).toHaveBeenCalledWith(tempFileName, fileName);
+        expect(emitSpy).toHaveBeenCalledWith('done', 'video:///storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4');
+    });
+
+    test('unlinks a pre-existing file at the final destination before moving (idempotent re-download)', async () => {
+        (RNFS.exists as jest.Mock).mockResolvedValue(true);
+
+        await startAndTriggerDone();
+
+        expect(RNFS.exists).toHaveBeenCalledWith(fileName);
+        expect(RNFS.unlink).toHaveBeenCalledWith(fileName);
+
+        const unlinkOrder = (RNFS.unlink as jest.Mock).mock.invocationCallOrder[0];
+        const moveOrder = (RNFS.moveFile as jest.Mock).mock.invocationCallOrder[0];
+        expect(unlinkOrder).toBeLessThan(moveOrder);
+    });
+
+    test('does not unlink when no file exists yet at the final destination', async () => {
+        (RNFS.exists as jest.Mock).mockResolvedValue(false);
+
+        await startAndTriggerDone();
+
+        expect(RNFS.unlink).not.toHaveBeenCalled();
+        expect(RNFS.moveFile).toHaveBeenCalledWith(tempFileName, fileName);
+    });
+
+    test('emits an error instead of done when the move fails', async () => {
+        const moveError = new Error('ENOENT: temp file missing');
+        (RNFS.moveFile as jest.Mock).mockRejectedValue(moveError);
+
+        const { emitSpy } = await startAndTriggerDone();
+
+        expect(emitSpy).toHaveBeenCalledWith('error', moveError);
+        expect(emitSpy).not.toHaveBeenCalledWith('done', expect.anything());
+    });
+});

--- a/src/bindings/download/index.ts
+++ b/src/bindings/download/index.ts
@@ -6,15 +6,62 @@ import path from 'path-browserify';
 import { IDownloadManager, IDownloadSession, DownloadProps } from 'incyclist-services';
 import { EventLogger } from 'gd-eventlog';
 
+/**
+ * Builds a `video://` URL for a given file path, using the correct number of
+ * slashes depending on whether the path is absolute or relative.
+ *
+ * Mirrors `buildVideoUrl()` in `incyclist-services` (services/src/routes/base/parsers/utils.ts) —
+ * kept as a local copy here since this file is always given an OS-absolute
+ * path (fileName is destination on the device filesystem) and the two
+ * packages don't currently share this helper across the npm boundary.
+ *
+ * - Windows absolute paths (`C:\path` / `C:/path`) have no leading slash of
+ *   their own, so the prefix needs all 3 slashes explicitly: `video:///C:\path`
+ * - Unix absolute paths (`/path`) already contribute their own leading slash,
+ *   so only 2 explicit slashes are needed: `video://` + `/path` = `video:///path`
+ * - Relative paths use 2 explicit slashes and contribute no leading slash of
+ *   their own: `video://./path`
+ */
+export const buildVideoUrl = (filePath: string): string => {
+    if (filePath.startsWith('/')) {
+        return `video://${filePath}`;
+    }
+    if (/^[A-Za-z]:[/\\]/.test(filePath)) {
+        return `video:///${filePath}`;
+    }
+    return `video://${filePath}`;
+}
+
 export class MobileDownloadSession extends EventEmitter implements IDownloadSession {
     private task?: any;
     private lastUpdate: number = 0;
     private lastBytes: number = 0;
     private stopped: boolean = false;
     private logger = new EventLogger('MobileDownloadSession')
+    // Download to a temp path rather than the real destination directly.
+    //
+    // @kesha-antonov/react-native-background-downloader (v4.5.4, still present on
+    // its main branch as of this writing) has a bug where its native stopTask()
+    // helper (RNBackgroundDownloaderModuleImpl.kt) is invoked both for genuine
+    // cancellation *and* on the successful-completion path (after the
+    // MediaScannerConnection.scanFile callback) - and stopTask() unconditionally
+    // calls DownloadManager.remove(downloadId), which per its documented contract
+    // deletes the underlying file. Every "successful" download this library
+    // routes through Android's DownloadManager therefore gets its own file
+    // deleted ~130ms after completion.
+    //
+    // We can't patch the library (would need patch-package for every install and
+    // every user hitting the same bug), so instead we decouple the physical file
+    // from DownloadManager's bookkeeping entirely: download to a temp path that
+    // DownloadManager knows about and is free to delete, then move the finished
+    // file to the real destination ourselves in the 'done' handler. By the time
+    // the buggy cleanup runs, the temp path is already empty/gone and the real
+    // bytes live somewhere DownloadManager has no record of.
+    private readonly tempFileName: string;
 
     constructor(private url: string, private fileName: string) {
         super();
+        this.tempFileName = `${fileName}.part`;
     }
 
     public start(): void {
@@ -36,7 +83,7 @@ export class MobileDownloadSession extends EventEmitter implements IDownloadSess
                 this.task = createDownloadTask({
                     id,
                     url: this.url,
-                    destination: this.fileName,
+                    destination: this.tempFileName,
                     metadata: {},
                     isAllowedOverRoaming: true,
                     isAllowedOverMetered: true,
@@ -100,7 +147,7 @@ export class MobileDownloadSession extends EventEmitter implements IDownloadSess
             .done(() => {
                 this.logger.logEvent({message: 'DownloadSession done', url: this.url})
                 if (this.stopped) return;
-                this.emit('done', `video:///${this.fileName}`);
+                this.finalizeDownload();
             })
             .error(({ error, errorCode }: { error: string, errorCode: number }) => {
                 this.logger.logEvent({message: 'DownloadSession error', url: this.url, error, errorCode})
@@ -111,6 +158,31 @@ export class MobileDownloadSession extends EventEmitter implements IDownloadSess
         this.logger.logEvent({message: 'DownloadSession start download', url: this.url})
 
         this.task.start()
+    }
+
+    // Relocates the completed download from the temp path to the real
+    // destination - see the comment on `tempFileName` above for why this is
+    // necessary. Deterministic (not a race against the library's cleanup
+    // timing), since DownloadManager only ever knows about the temp path.
+    private async finalizeDownload(): Promise<void> {
+        try {
+            // A previous attempt may have already left a file at the real
+            // destination (the old direct-download code implicitly overwrote
+            // it) - remove it first so re-downloads still behave as a clean
+            // overwrite.
+            if (await RNFS.exists(this.fileName)) {
+                await RNFS.unlink(this.fileName);
+            }
+
+            await RNFS.moveFile(this.tempFileName, this.fileName);
+
+            this.logger.logEvent({message: 'DownloadSession finalized', url: this.url, fileName: this.fileName})
+            this.emit('done', buildVideoUrl(this.fileName));
+        }
+        catch (err: any) {
+            this.logger.logEvent({message: 'DownloadSession finalize error', url: this.url, error: err.message})
+            this.emit('error', err);
+        }
     }
 }
 

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -6,13 +6,14 @@ import {
     OnProgressData, 
     OnBufferData 
 } from 'react-native-video';
-import { useUnmountEffect } from '../../hooks';
+import { useLogging, useUnmountEffect } from '../../hooks';
 import { VideoProps, VideoPlaybackEvent, VideoMediaError } from './types';
 import { VideoView } from './VideoView';
 import { sleep } from '../../utils/timers';
 import { Platform } from 'react-native';
 import { getFileSystemBinding } from '../../bindings/fs';
 import { mapAndroidErrorCode } from './mapAndroidErrorCode';
+import { resolveNativeVideoSrc } from './resolveNativeVideoSrc';
 
 export const Video = (props: VideoProps) => {
     const {
@@ -36,7 +37,7 @@ export const Video = (props: VideoProps) => {
     const [paused, setPaused] = useState(false);
     const [rate, setRate] = useState(0);
     const [hasAccess,setHasAccess] = useState( Platform.OS!=='ios' || src.startsWith('http') )
-
+    const {logEvent} = useLogging('Video')
 
     const refVideo = useRef<any>(null);
     const refInitialized = useRef<boolean>(false);
@@ -266,7 +267,8 @@ export const Video = (props: VideoProps) => {
         return false;
     }
 
-    const cleanSrc =  Platform.OS==='ios' ? encodeURI(src) : src
+    const nativeSrc = resolveNativeVideoSrc(src)
+    const cleanSrc =  Platform.OS==='ios' ? encodeURI(nativeSrc) : nativeSrc
 
     return (
         <VideoView

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -6,7 +6,7 @@ import {
     OnProgressData, 
     OnBufferData 
 } from 'react-native-video';
-import { useLogging, useUnmountEffect } from '../../hooks';
+import { useUnmountEffect } from '../../hooks';
 import { VideoProps, VideoPlaybackEvent, VideoMediaError } from './types';
 import { VideoView } from './VideoView';
 import { sleep } from '../../utils/timers';
@@ -37,7 +37,6 @@ export const Video = (props: VideoProps) => {
     const [paused, setPaused] = useState(false);
     const [rate, setRate] = useState(0);
     const [hasAccess,setHasAccess] = useState( Platform.OS!=='ios' || src.startsWith('http') )
-    const {logEvent} = useLogging('Video')
 
     const refVideo = useRef<any>(null);
     const refInitialized = useRef<boolean>(false);

--- a/src/components/Video/resolveNativeVideoSrc.test.ts
+++ b/src/components/Video/resolveNativeVideoSrc.test.ts
@@ -1,0 +1,35 @@
+import { resolveNativeVideoSrc } from './resolveNativeVideoSrc';
+
+describe('resolveNativeVideoSrc', () => {
+    test('rewrites an absolute Unix video:// URL to file://', () => {
+        const src = 'video:///storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4';
+        expect(resolveNativeVideoSrc(src)).toBe(
+            'file:///storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4'
+        );
+    });
+
+    test('rewrites an absolute Windows video:// URL to file://', () => {
+        const src = 'video:///C:/Users/user/videos/route.mp4';
+        expect(resolveNativeVideoSrc(src)).toBe('file:///C:/Users/user/videos/route.mp4');
+    });
+
+    test('leaves a relative video:// URL untouched (route-embedded, not downloaded)', () => {
+        const src = 'video://./__tests__/data/rlv/IS_West.avi';
+        expect(resolveNativeVideoSrc(src)).toBe(src);
+    });
+
+    test('leaves a non-video:// src untouched (http)', () => {
+        const src = 'https://cdn.example.com/routes/FR_Galibier_Demo.mp4';
+        expect(resolveNativeVideoSrc(src)).toBe(src);
+    });
+
+    test('leaves a non-video:// src untouched (already file://)', () => {
+        const src = 'file:///storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4';
+        expect(resolveNativeVideoSrc(src)).toBe(src);
+    });
+
+    test('is a no-op for undefined/empty src', () => {
+        expect(resolveNativeVideoSrc(undefined as unknown as string)).toBeUndefined();
+        expect(resolveNativeVideoSrc('')).toBe('');
+    });
+});

--- a/src/components/Video/resolveNativeVideoSrc.ts
+++ b/src/components/Video/resolveNativeVideoSrc.ts
@@ -1,0 +1,44 @@
+const VIDEO_SCHEME_PREFIX = 'video://';
+
+/**
+ * Rewrites a `video://` URI into one react-native-video's native Android player
+ * (ExoPlayer) actually understands for local playback.
+ *
+ * ExoPlayer's native code (react-native-video's `ReactExoplayerView.java`) only
+ * special-cases the `"asset"` and `"file"` URI schemes for local files — any other
+ * scheme (including our own `"video"`) falls through to a network-backed
+ * `DataSource`, which is why local downloaded videos fail with
+ * `ERROR_CODE_IO_FILE_NOT_FOUND` / a network error even once the URL itself is
+ * well-formed. `video://` only ever worked on desktop, where Electron's main
+ * process registers a real custom protocol handler for it.
+ *
+ * A well-formed absolute-path `video://` URL always has a leading slash
+ * immediately after the `video://` prefix (`video:///<unix-path>` or
+ * `video:///<drive>:<path>` on Windows — see `buildVideoUrl()` in
+ * `incyclist-services`, services/src/routes/base/parsers/utils.ts, which produces
+ * these). Swapping the scheme name onto that same path is enough, since ExoPlayer
+ * resolves `"file"` locally via its own `DataSource.Factory`.
+ *
+ * Relative `video://` URLs (e.g. `video://./bundled/route.mp4` — route-embedded,
+ * not downloaded, videos) have no leading slash after the prefix and are left
+ * untouched: they're resolved through a different path upstream
+ * (`RLVDisplayService.cleanupUrl()` in incyclist-services already rewrites
+ * non-`.avi` `video:` URLs to `file:` there), and this helper only needs to cover
+ * the absolute, downloaded-video case that reaches this component unconverted.
+ *
+ * Any other src (http/https, file://, already-relative, undefined, etc.) is
+ * returned unchanged.
+ */
+export const resolveNativeVideoSrc = (src: string): string => {
+    if (!src || !src.startsWith(VIDEO_SCHEME_PREFIX)) {
+        return src;
+    }
+
+    const rest = src.slice(VIDEO_SCHEME_PREFIX.length);
+    if (!rest.startsWith('/')) {
+        // relative video:// URL - leave as-is
+        return src;
+    }
+
+    return `file://${rest}`;
+};

--- a/src/components/Video/resolveNativeVideoSrc.ts
+++ b/src/components/Video/resolveNativeVideoSrc.ts
@@ -30,7 +30,7 @@ const VIDEO_SCHEME_PREFIX = 'video://';
  * returned unchanged.
  */
 export const resolveNativeVideoSrc = (src: string): string => {
-    if (!src || !src.startsWith(VIDEO_SCHEME_PREFIX)) {
+    if (!src?.startsWith(VIDEO_SCHEME_PREFIX)) {
         return src;
     }
 


### PR DESCRIPTION
## Summary

Downloaded route videos failed to play with `ExoPlaybackException: ERROR_CODE_IO_FILE_NOT_FOUND`. Root-caused via real-device testing (`adb`/logcat, cross-checked against the actual AOSP `DownloadProvider.java` source) to two independent Android-side bugs — not the URL formatting issues fixed in the companion `services` PR, which turned out to be real but not the actual blocker.

1. **`@kesha-antonov/react-native-background-downloader` deletes its own successfully-downloaded file.** Its native `stopTask()` helper is invoked both on genuine cancellation *and* on the successful-completion path (via a `MediaScannerConnection.scanFile()` callback), and unconditionally calls `DownloadManager.remove()`, which deletes the underlying file per its documented Android contract. Confirmed via `adb shell ls` (destination directory empty after a "successful" download) and logcat (`DownloadManager: Deleting <path> via provider delete` ~130ms after `finished with status SUCCESS`). Not fixed in the library's latest release as of this writing, and not filed upstream. Worked around **without patching the library**: `MobileDownloadSession` now downloads to a temp path (`<fileName>.part`) instead of the real destination, then moves the finished file to the real destination itself in the `done` handler — deterministic, not a race against the library's cleanup timing, since `DownloadManager` never has a record of the real destination.
2. **`video://` isn't a scheme Android's video player understands for local files.** `video://` is a desktop-only convention (Electron registers a custom protocol handler for it); `react-native-video`'s Android code only recognises `"file"`/`"asset"` schemes for local playback, so a `video://` URI silently fell through to a network-backed data source. Added `resolveNativeVideoSrc()` as a last-line-of-defense rewrite to `file://` right before the native player — the primary fix (not persisting `video://` on mobile at all) is in the companion `services` PR.

Companion PR: `services` (same branch name `feat/fix-video-url-slashes`) — fixes the URL construction/persistence side and adds orphaned-download recovery for routes downloaded before this fix ships.

## What changed

- `bindings/download/index.ts` — `MobileDownloadSession` downloads to a temp path and relocates it on completion (`finalizeDownload()`); local `buildVideoUrl()` helper for correct slash counts.
- `components/Video/resolveNativeVideoSrc.ts` — new, rewrites `video://<abs-path>` → `file://<abs-path>` before it reaches `RNVideo`.
- `components/Video/Video.tsx` — wires in `resolveNativeVideoSrc()`, plus diagnostic logging added during device debugging (worth a look in review — it's in the render body, not effect-gated, so may log more often than intended during playback).

## Test plan

- [x] `npm test` — 89 suites / 523 tests passing
- [x] `tsc --noEmit` clean (one pre-existing, unrelated error noted, not touched by this change)
- [x] `eslint` clean on touched files
- [x] Verified end-to-end on a real Android device: fresh download → playback works
- [ ] Reviewer: check the `Video.tsx` diagnostic logging for render-frequency noise before merging