### PR TITLE
feat(workouts): tag placeholder page-shown events with pageType

### DIFF
--- a/src/pages/WorkoutsPage/WorkoutsPlaceholderView.tsx
+++ b/src/pages/WorkoutsPage/WorkoutsPlaceholderView.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, Text, StyleSheet, useWindowDimensions } from 'react-native';
 import { MainBackground, NavigationBar, TNavigationItem } from '../../components';
 import { Button } from '../../components/ButtonBar';
 import { WorkoutTrainerIllustration } from './WorkoutTrainerIllustration';
 import { colors, textSizes } from '../../theme';
+import { useLogging } from '../../hooks';
 
 export interface WorkoutsPlaceholderViewProps {
     onNavigate: (item: TNavigationItem) => void;
@@ -12,6 +13,16 @@ export interface WorkoutsPlaceholderViewProps {
 export const WorkoutsPlaceholderView = ({ onNavigate }: WorkoutsPlaceholderViewProps) => {
     const { height } = useWindowDimensions();
     const compact = height < 420;
+    const { logEvent } = useLogging('WorkoutsPlaceholderView');
+
+    // Distinguishes a placeholder view from the real Workouts list in the
+    // shared `page shown`/page:'Workouts' event (services/src/workouts/page/
+    // service.ts:59), which fires unconditionally for both and can't tell
+    // them apart on its own — see the Kibana "Mobile Workouts" dashboard's
+    // "Placeholder shown" panel, which filters on this pageType field.
+    useEffect(() => {
+        logEvent({ message: 'page shown', page: 'Workouts', pageType: 'placeholder' });
+    }, [logEvent]);
 
     return (
         <MainBackground>


### PR DESCRIPTION
## Summary
`services/src/workouts/page/service.ts`'s `page shown`/`page:'Workouts'` event fires unconditionally whether the user sees the real Workouts list or this placeholder (the `MOBILE_WORKOUTS` toggle check happens one level up, purely for rendering) — so there was no way to tell placeholder-views from real-views in the logs/Kibana.

## What changed
- `WorkoutsPlaceholderView.tsx` now logs `{message:'page shown', page:'Workouts', pageType:'placeholder'}` on mount, via the same `useLogging` pattern used elsewhere in this screen's components.

## Why
Feeds the new "Mobile Workouts" Kibana dashboard's daily-usage panel, which needs to separate "opened (real+placeholder)" from "saw only the placeholder" — see the paired `services` PR for the counterpart.

## Test plan
- `npx tsc --noEmit` and `npx eslint` scoped to this file — clean.
- No existing test/story file for this component to update.