### PR TITLE
fix: enlarge workout ride graph axis labels on tablets

### DIFF
--- a/src/components/WorkoutGraph/WorkoutGraph.test.tsx
+++ b/src/components/WorkoutGraph/WorkoutGraph.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { View } from 'react-native';
+import { WorkoutGraph } from './WorkoutGraph';
+import { WorkoutGraphView } from './WorkoutGraphView';
+import { MOCK_PLAN } from './WorkoutGraph.mock';
+
+jest.mock('./WorkoutGraphView', () => ({
+    WorkoutGraphView: jest.fn(() => null),
+}));
+
+const layout = (width: number, height: number) => ({
+    nativeEvent: { layout: { x: 0, y: 0, width, height } },
+});
+
+describe('WorkoutGraph', () => {
+    beforeEach(() => {
+        (WorkoutGraphView as jest.Mock).mockClear();
+    });
+
+    it('forwards an explicit axisFontSize to WorkoutGraphView', () => {
+        const { UNSAFE_root } = render(
+            <WorkoutGraph mode="detail" plan={MOCK_PLAN} axisFontSize={15} />
+        );
+        const container = UNSAFE_root.findByType(View);
+        fireEvent(container, 'layout', layout(360, 200));
+
+        expect(WorkoutGraphView).toHaveBeenCalled();
+        const props = (WorkoutGraphView as jest.Mock).mock.calls.at(-1)?.[0];
+        expect(props.axisFontSize).toBe(15);
+    });
+
+    it('leaves axisFontSize undefined when not provided, so WorkoutGraphView keeps its own (phone) default', () => {
+        const { UNSAFE_root } = render(
+            <WorkoutGraph mode="detail" plan={MOCK_PLAN} />
+        );
+        const container = UNSAFE_root.findByType(View);
+        fireEvent(container, 'layout', layout(360, 200));
+
+        expect(WorkoutGraphView).toHaveBeenCalled();
+        const props = (WorkoutGraphView as jest.Mock).mock.calls.at(-1)?.[0];
+        expect(props.axisFontSize).toBeUndefined();
+    });
+});

--- a/src/components/WorkoutGraph/WorkoutGraph.test.tsx
+++ b/src/components/WorkoutGraph/WorkoutGraph.test.tsx
@@ -15,7 +15,7 @@ const layout = (width: number, height: number) => ({
 
 describe('WorkoutGraph', () => {
     beforeEach(() => {
-        (WorkoutGraphView as jest.Mock).mockClear();
+        (WorkoutGraphView as unknown as jest.Mock).mockClear();
     });
 
     it('forwards an explicit axisFontSize to WorkoutGraphView', () => {
@@ -26,7 +26,7 @@ describe('WorkoutGraph', () => {
         fireEvent(container, 'layout', layout(360, 200));
 
         expect(WorkoutGraphView).toHaveBeenCalled();
-        const props = (WorkoutGraphView as jest.Mock).mock.calls.at(-1)?.[0];
+        const props = (WorkoutGraphView as unknown as jest.Mock).mock.calls.at(-1)?.[0];
         expect(props.axisFontSize).toBe(15);
     });
 
@@ -38,7 +38,7 @@ describe('WorkoutGraph', () => {
         fireEvent(container, 'layout', layout(360, 200));
 
         expect(WorkoutGraphView).toHaveBeenCalled();
-        const props = (WorkoutGraphView as jest.Mock).mock.calls.at(-1)?.[0];
+        const props = (WorkoutGraphView as unknown as jest.Mock).mock.calls.at(-1)?.[0];
         expect(props.axisFontSize).toBeUndefined();
     });
 });

--- a/src/components/WorkoutGraph/WorkoutGraph.tsx
+++ b/src/components/WorkoutGraph/WorkoutGraph.tsx
@@ -20,6 +20,7 @@ export const WorkoutGraph = ({
     showAxes,
     showFtpLine,
     height,
+    axisFontSize,
     style,
 }: WorkoutGraphProps) => {
     const [layout, setLayout] = useState({ width: 0, height: 0 });
@@ -45,6 +46,7 @@ export const WorkoutGraph = ({
                     actuals={actuals}
                     showAxes={showAxes}
                     showFtpLine={showFtpLine}
+                    axisFontSize={axisFontSize}
                 />
             )}
         </View>

--- a/src/components/WorkoutGraph/types.ts
+++ b/src/components/WorkoutGraph/types.ts
@@ -47,5 +47,7 @@ export interface WorkoutGraphProps {
     showFtpLine?: boolean;
     /** Fixed height (e.g. strip rows). When omitted the wrapper measures it. */
     height?: number;
+    /** Forwarded to WorkoutGraphView. Omit to keep its default (phone-sized) axis font. */
+    axisFontSize?: number;
     style?: StyleProp<ViewStyle>;
 }

--- a/src/pages/RidePage/Workout/View.test.tsx
+++ b/src/pages/RidePage/Workout/View.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { WorkoutRidePageView, WorkoutRidePageViewProps } from './View';
+
+const mockIsTablet = jest.fn(() => false);
+
+jest.mock('react-native-device-info', () => ({
+    isTablet: () => mockIsTablet(),
+}));
+
+const mockWorkoutGraph = jest.fn(() => null);
+jest.mock('../../../components', () => ({
+    Button: () => null,
+    Dynamic: ({ children }: any) => children,
+    MainBackground: () => null,
+    RideDashboard: () => null,
+    RideMenu: () => null,
+    StartRideDisplay: () => null,
+    WorkoutGestureHintOverlay: () => null,
+    WorkoutGraph: (props: any) => {
+        mockWorkoutGraph(props);
+        return null;
+    },
+    WorkoutStepsList: () => null,
+    WorkoutSwipeFeedback: () => null,
+}));
+
+jest.mock('../../../hooks', () => ({
+    useScreenLayout: () => 'normal',
+}));
+
+const baseDisplayProps = {
+    rideState: 'Active',
+    rideType: 'Workout',
+    startOverlayProps: null,
+    startGateProps: null,
+    menuProps: null,
+    graph: { bars: [], ftp: 200, ftpLine: 200, domain: { x: [0, 0], y: [0, 0] } },
+    steps: { previous: null, current: null, upcoming: [], hasMore: false },
+    dashboard: { text: '', mode: null },
+    title: '',
+    gestureHint: null,
+} as any;
+
+const baseProps: WorkoutRidePageViewProps = {
+    displayProps: baseDisplayProps,
+    rideObserver: null,
+    gesture: undefined,
+    feedback: { visible: false, message: '' },
+    loadIncrementPct: 1,
+    getGraphActuals: () => ({ power: [], heartrate: [], position: 0 }) as any,
+    onMenuOpen: () => {},
+    onMenuClose: () => {},
+    onCloseRidePage: () => {},
+    onRetryStart: () => {},
+    onIgnoreStart: () => {},
+    onCancelStart: () => {},
+    onGestureHintDismissed: () => {},
+};
+
+describe('WorkoutRidePageView — tablet graph font size', () => {
+    beforeEach(() => {
+        mockWorkoutGraph.mockClear();
+        mockIsTablet.mockReturnValue(false);
+    });
+
+    it('does not pass axisFontSize on phones — WorkoutGraph/WorkoutGraphView keep their default', () => {
+        mockIsTablet.mockReturnValue(false);
+        render(<WorkoutRidePageView {...baseProps} />);
+
+        expect(mockWorkoutGraph).toHaveBeenCalled();
+        const props = mockWorkoutGraph.mock.calls.at(-1)?.[0];
+        expect(props.axisFontSize).toBeUndefined();
+    });
+
+    it('passes a larger axisFontSize on tablets', () => {
+        mockIsTablet.mockReturnValue(true);
+        render(<WorkoutRidePageView {...baseProps} />);
+
+        expect(mockWorkoutGraph).toHaveBeenCalled();
+        const props = mockWorkoutGraph.mock.calls.at(-1)?.[0];
+        expect(props.axisFontSize).toBeGreaterThan(10);
+    });
+});

--- a/src/pages/RidePage/Workout/View.test.tsx
+++ b/src/pages/RidePage/Workout/View.test.tsx
@@ -8,7 +8,7 @@ jest.mock('react-native-device-info', () => ({
     isTablet: () => mockIsTablet(),
 }));
 
-const mockWorkoutGraph = jest.fn(() => null);
+const mockWorkoutGraph = jest.fn();
 jest.mock('../../../components', () => ({
     Button: () => null,
     Dynamic: ({ children }: any) => children,

--- a/src/pages/RidePage/Workout/View.tsx
+++ b/src/pages/RidePage/Workout/View.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
+import DeviceInfo from 'react-native-device-info';
 import { IObserver, WorkoutGraphActuals, WorkoutRidePageDisplayProps } from 'incyclist-services';
 import {
     Button,
@@ -23,6 +24,14 @@ import { useScreenLayout, WorkoutRideGestureFeedback } from '../../../hooks';
 // future ride type can supply its own copy). Same gesture content 5.6's now-removed
 // StartRideDisplay legend had.
 const GESTURE_HINT_MESSAGE = 'Start pedalling to start the workout';
+
+// WorkoutGraphView's default axisFontSize (10, phone-tuned) reads as illegibly small on a
+// tablet's much larger physical screen — confirmed unreadable via real tablet ride testing
+// on 2026-07-29 (phone was fine). 1.5x is a reasonable first pass to bring axis tick labels
+// back to a comfortable size; it has not been eyeballed on physical tablet hardware and needs
+// manual visual confirmation there. Phones are untouched — they never pass axisFontSize, so
+// WorkoutGraphView's own default still applies exactly as before.
+const TABLET_GRAPH_AXIS_FONT_SIZE = 15;
 
 // Conditional import — same pattern as WorkoutItemView / useWorkoutRideGestures (session 5.4):
 // keeps Storybook (Vite/web) and any environment without the native module from crashing.
@@ -97,6 +106,10 @@ export const WorkoutRidePageView = (props: WorkoutRidePageViewProps) => {
     const layout = useScreenLayout();
     const isCompact = layout === 'compact';
 
+    // Undefined (not 0/false) on phones — WorkoutGraphView's own default axisFontSize must
+    // apply exactly as it does today; only tablets get an explicit override.
+    const graphAxisFontSize = DeviceInfo.isTablet() ? TABLET_GRAPH_AXIS_FONT_SIZE : undefined;
+
     // Same gesture content 5.6's now-removed StartRideDisplay legend had — reads the live
     // preferences.workouts.loadIncrement setting (never hardcoded), just relocated here since
     // the legend now lives in this overlay instead of the start-overlay dialog.
@@ -157,7 +170,14 @@ export const WorkoutRidePageView = (props: WorkoutRidePageViewProps) => {
                     prop="actuals"
                     transform={getGraphActuals}
                 >
-                    <WorkoutGraph mode="live" plan={graph} showAxes={true} showFtpLine={true} style={styles.graph} />
+                    <WorkoutGraph
+                        mode="live"
+                        plan={graph}
+                        showAxes={true}
+                        showFtpLine={true}
+                        axisFontSize={graphAxisFontSize}
+                        style={styles.graph}
+                    />
                 </Dynamic>
             </View>
 


### PR DESCRIPTION
## Summary
- On the live workout ride screen, the graph's Y-axis (power/heartrate) and X-axis (time) tick labels were unreadable on a tablet, though fine on a phone (confirmed via real tablet ride testing on 2026-07-29).
- Root cause: `WorkoutGraphView` hardcoded `axisFontSize` to a fixed `10` and nothing in the render chain (`WorkoutGraph` wrapper, ride-screen call site) ever overrode it — `axisFontSize` wasn't even exposed on `WorkoutGraphProps`.
- Fix: thread `axisFontSize` through `WorkoutGraphProps` -> `WorkoutGraph` -> `WorkoutGraphView` (the view already supported the prop), and compute a larger size at the ride screen's `WorkoutGraph` call site (`src/pages/RidePage/Workout/View.tsx`) when `DeviceInfo.isTablet()` is true.

## What changed
- `src/components/WorkoutGraph/types.ts` — added `axisFontSize?: number` to `WorkoutGraphProps`.
- `src/components/WorkoutGraph/WorkoutGraph.tsx` — forwards `axisFontSize` to `WorkoutGraphView`.
- `src/pages/RidePage/Workout/View.tsx` — computes `axisFontSize` as `15` (~1.5x the existing default of `10`) when `DeviceInfo.isTablet()` is true, `undefined` otherwise (so phones keep exactly today's default/behavior, unchanged).
- `src/components/WorkoutGraph/WorkoutGraph.test.tsx` (new) — verifies `WorkoutGraph` forwards an explicit `axisFontSize`, and forwards `undefined` (not a default) when the prop is omitted.
- `src/pages/RidePage/Workout/View.test.tsx` (new) — verifies the ride screen passes no `axisFontSize` override on phones and a larger one (`>10`) on tablets, mocking `DeviceInfo.isTablet()`.

## Test plan
- [x] `npm test` — all 92 suites / 535+ tests pass, including the 4 new tests added here.
- [x] `npm run lint` — 0 errors (24 pre-existing warnings, unrelated to this change).
- [ ] **Manual visual verification needed on a real tablet.** The chosen font size (`15px`, ~1.5x the phone default of `10px`) is a reasonable first-pass estimate, not something I could visually confirm — I have no way to render on physical tablet hardware. Please eyeball the live ride graph's axis labels on the tablet used in the original 2026-07-29 test and adjust `TABLET_GRAPH_AXIS_FONT_SIZE` in `src/pages/RidePage/Workout/View.tsx` if it still reads too small/large.