### PR TITLE
feat: render a workout profile instead of a map for route-less workout rides

### DIFF
--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialog.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialog.tsx
@@ -107,12 +107,11 @@ export const ActivitySummaryDialog = ({ onClose, onExit }: ActivitySummaryDialog
         return null;
     }
 
-        // TODO(services release): showWorkoutSummary/workoutGraph aren't in the currently
-        // installed incyclist-services type yet (added in services PR #493, "Ride Summary shows
-        // a map for a route-less workout ride" - pending npm release + a package.json bump here).
-        // Bridge them loosely until then so this screen is ready the moment that lands, without
-        // blocking on it - remove this cast and type displayProps normally once the dependency is
-        // bumped.
+        // showWorkoutSummary/workoutGraph aren't in the currently installed incyclist-services
+        // type yet (added in services PR #493, "Ride Summary shows a map for a route-less
+        // workout ride" - pending npm release + a package.json bump here). Bridged loosely so
+        // this screen is ready the moment that lands, without blocking on it. Once the
+        // dependency is bumped, drop this cast and type displayProps normally.
         const extendedDisplayProps = displayProps as typeof displayProps & {
             showWorkoutSummary?: boolean
             workoutGraph?: ActivitySummaryDialogViewProps['workoutGraph']

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialog.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialog.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback} from 'react';
 import { useActivityRide  } from 'incyclist-services';
 import Share from 'react-native-share';
-import { ActivitySummaryDialogProps } from './types';
+import { ActivitySummaryDialogProps, ActivitySummaryDialogViewProps } from './types';
 import { ActivitySummaryDialogView } from './ActivitySummaryDialogView';
 import { useLogging } from '../../hooks';
 import { ErrorBoundary } from '../ErrorBoundary';
@@ -107,6 +107,17 @@ export const ActivitySummaryDialog = ({ onClose, onExit }: ActivitySummaryDialog
         return null;
     }
 
+        // TODO(services release): showWorkoutSummary/workoutGraph aren't in the currently
+        // installed incyclist-services type yet (added in services PR #493, "Ride Summary shows
+        // a map for a route-less workout ride" - pending npm release + a package.json bump here).
+        // Bridge them loosely until then so this screen is ready the moment that lands, without
+        // blocking on it - remove this cast and type displayProps normally once the dependency is
+        // bumped.
+        const extendedDisplayProps = displayProps as typeof displayProps & {
+            showWorkoutSummary?: boolean
+            workoutGraph?: ActivitySummaryDialogViewProps['workoutGraph']
+        }
+
         return (
             <ErrorBoundary >
                 <ActivitySummaryDialogView
@@ -114,6 +125,8 @@ export const ActivitySummaryDialog = ({ onClose, onExit }: ActivitySummaryDialog
                     showMap={displayProps.showMap ?? false}
                     showSave={displayProps.showSave ?? false}
                     showContinue = {displayProps.showContinue ?? true}
+                    showWorkoutSummary={extendedDisplayProps.showWorkoutSummary ?? false}
+                    workoutGraph={extendedDisplayProps.workoutGraph}
                     preview={displayProps.preview}
                     units={displayProps.units}
                     isSaving={isSaving}

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.test.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.test.tsx
@@ -62,6 +62,10 @@ jest.mock('../ActivityGraph', () => ({
     ActivityGraph: 'ActivityGraph',
 }));
 
+jest.mock('../WorkoutGraph', () => ({
+    WorkoutGraph: 'WorkoutGraph',
+}));
+
 jest.mock('../SecureImage', () => ({
     SecureImage: ({ source, ...props }: any) => {
         const { Image } = require('react-native');
@@ -132,5 +136,51 @@ describe('ActivitySummaryDialogView', () => {
     });
     it('renders with showMap=true', () => {
         render(<ActivitySummaryDialogView {...MOCK_PROPS} showMap={true} compact={false} />);
+    });
+
+    describe('route-less workout summary', () => {
+        const MOCK_WORKOUT_GRAPH = {
+            plan: { bars: [], ftp: 200, ftpLine: 200, domain: { x: [0, 60], y: [0, 220] } },
+            actuals: { power: [], heartrate: [], position: -1 },
+        } as any;
+
+        it('renders WorkoutGraph instead of the map when showWorkoutSummary is set', () => {
+            const { UNSAFE_root, UNSAFE_queryAllByType } = render(
+                <ActivitySummaryDialogView
+                    {...MOCK_PROPS}
+                    showMap={false}
+                    showWorkoutSummary={true}
+                    workoutGraph={MOCK_WORKOUT_GRAPH}
+                />
+            );
+            expect(UNSAFE_queryAllByType('WorkoutGraph' as any).length).toBe(1);
+            expect(UNSAFE_queryAllByType('FreeMap' as any).length).toBe(0);
+            expect(UNSAFE_root).toBeTruthy();
+        });
+
+        it('falls back to the map/preview when showWorkoutSummary is set but no graph data is available', () => {
+            const { UNSAFE_queryAllByType } = render(
+                <ActivitySummaryDialogView
+                    {...MOCK_PROPS}
+                    showMap={true}
+                    showWorkoutSummary={true}
+                    workoutGraph={undefined}
+                />
+            );
+            expect(UNSAFE_queryAllByType('WorkoutGraph' as any).length).toBe(0);
+            expect(UNSAFE_queryAllByType('FreeMap' as any).length).toBe(1);
+        });
+
+        it('does not render WorkoutGraph when showWorkoutSummary is false, even if graph data is present', () => {
+            const { UNSAFE_queryAllByType } = render(
+                <ActivitySummaryDialogView
+                    {...MOCK_PROPS}
+                    showMap={false}
+                    showWorkoutSummary={false}
+                    workoutGraph={MOCK_WORKOUT_GRAPH}
+                />
+            );
+            expect(UNSAFE_queryAllByType('WorkoutGraph' as any).length).toBe(0);
+        });
     });
 });

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.tsx
@@ -6,10 +6,38 @@ import { FreeMap } from '../FreeMap';
 import { ActivityGraph } from '../ActivityGraph';
 import { WorkoutGraph } from '../WorkoutGraph';
 import { ActivitySummaryDialogViewProps, isFormattedNumber } from './types';
+import { ButtonProps } from '../ButtonBar/types';
 import { colors, textSizes } from '../../theme';
 import { useScreenLayout } from '../../hooks';
 import { ErrorBoundary } from '../ErrorBoundary';
 import { SecureImage } from '../SecureImage';
+
+const buildDialogButtons = (props: {
+    isSaved: boolean;
+    showSave: boolean;
+    isSaving: boolean;
+    showContinue: boolean;
+    onClose: () => void;
+    onSave: () => void;
+    onDelete: () => void;
+}): ButtonProps[] => {
+    const { isSaved, showSave, isSaving, showContinue, onClose, onSave, onDelete } = props;
+
+    if (isSaved) {
+        return [{ label: 'Close', onClick: onClose, primary: true }];
+    }
+
+    const buttons: ButtonProps[] = [];
+    if (showSave) {
+        buttons.push({ label: isSaving ? 'Saving...' : 'Save', onClick: onSave, primary: true, disabled: isSaving });
+    }
+    buttons.push({ label: 'Delete', onClick: onDelete, primary: false, disabled: false });
+    if (showContinue) {
+        buttons.push({ label: 'Close', onClick: onClose, primary: false, disabled: false });
+    }
+
+    return buttons;
+};
 
 const safeNum = (v: any): number | undefined => {
     try {
@@ -51,23 +79,7 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
     const graphMinHeight = Math.round(screenWidth * 3 / 4);
     const graphContainerStyle = { ...styles.graphContainer, minHeight: graphMinHeight };
 
-    const dialogButtons = isSaved
-        ? [{ label: 'Close', onClick: onClose, primary: true }]
-        : [
-            ...(showSave ? [{
-                label: isSaving ? 'Saving...' : 'Save',
-                onClick: onSave,
-                primary: true,
-                disabled: isSaving,
-            }] : []),
-            { label: 'Delete', onClick: onDelete, primary:false, disabled:false },
-        ];
-
-    if ( showContinue && !isSaved) {
-        dialogButtons.push(
-            { label: 'Close', onClick: onClose, primary:false, disabled:false }
-        )
-    } 
+    const dialogButtons = buildDialogButtons({ isSaved, showSave, isSaving, showContinue, onClose, onSave, onDelete });
 
     const renderKeyFact = (label: string, value: any, unitKey?: 'distance' | 'elevation' | 'speed' | 'time' | 'power') => {
         let displayValue: string;
@@ -250,16 +262,24 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
 
     const showWorkoutSummaryPreview = showWorkoutSummary && !!WorkoutSummaryPreview;
 
+    // Which preview area to show (workout summary graph / map / static preview / none) is decided
+    // once here, rather than repeating the same ternary in both the compact and normal layouts
+    // below.
+    const renderPreviewArea = () => {
+        if (showWorkoutSummaryPreview) return WorkoutSummaryPreview;
+        return (showMap || preview) ? MapPreview : null;
+    };
+
     const MainContent = isCompact ? (
         <ScrollView style={styles.scrollContainer} contentContainerStyle={styles.scrollContent}>
             {StatsContent}
-            {showWorkoutSummaryPreview ? WorkoutSummaryPreview : (showMap || preview) && MapPreview}
+            {renderPreviewArea()}
             {GraphContent}
         </ScrollView>
     ) : (
         <ScrollView style={styles.scrollContainer} contentContainerStyle={styles.scrollContent}>
             <View style={styles.topRow}>
-                {showWorkoutSummaryPreview ? WorkoutSummaryPreview : (showMap || preview) && MapPreview}
+                {renderPreviewArea()}
                 <View style={styles.statsWrapper}>
                     {StatsContent}
                 </View>

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.tsx
@@ -4,6 +4,7 @@ import { formatTime, useUnitConverter } from 'incyclist-services';
 import { Dialog } from '../Dialog';
 import { FreeMap } from '../FreeMap';
 import { ActivityGraph } from '../ActivityGraph';
+import { WorkoutGraph } from '../WorkoutGraph';
 import { ActivitySummaryDialogViewProps, isFormattedNumber } from './types';
 import { colors, textSizes } from '../../theme';
 import { useScreenLayout } from '../../hooks';
@@ -26,6 +27,8 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
         showMap,
         showSave,
         showContinue,
+        showWorkoutSummary,
+        workoutGraph,
         preview,
         units,
         isSaving,
@@ -230,16 +233,33 @@ export const ActivitySummaryDialogView = (props: ActivitySummaryDialogViewProps)
         </View>
     );
 
+    // Route-less workout (no GPS/route at all) - a map/preview makes no sense here, show the
+    // ridden power/HR trace against the plan instead, reusing WorkoutGraph's 'detail' mode (same
+    // component the live ride screen uses, just without a live position marker - see item #19).
+    const WorkoutSummaryPreview = workoutGraph ? (
+        <View style={isCompact ? styles.compactMapContainer : styles.mapContainer}>
+            <WorkoutGraph
+                mode="detail"
+                plan={workoutGraph.plan}
+                actuals={workoutGraph.actuals}
+                showAxes
+                showFtpLine
+            />
+        </View>
+    ) : null;
+
+    const showWorkoutSummaryPreview = showWorkoutSummary && !!WorkoutSummaryPreview;
+
     const MainContent = isCompact ? (
         <ScrollView style={styles.scrollContainer} contentContainerStyle={styles.scrollContent}>
             {StatsContent}
-            {(showMap || preview) && MapPreview}
+            {showWorkoutSummaryPreview ? WorkoutSummaryPreview : (showMap || preview) && MapPreview}
             {GraphContent}
         </ScrollView>
     ) : (
         <ScrollView style={styles.scrollContainer} contentContainerStyle={styles.scrollContent}>
             <View style={styles.topRow}>
-                {(showMap || preview) && MapPreview}
+                {showWorkoutSummaryPreview ? WorkoutSummaryPreview : (showMap || preview) && MapPreview}
                 <View style={styles.statsWrapper}>
                     {StatsContent}
                 </View>

--- a/src/components/ActivitySummaryDialog/types.ts
+++ b/src/components/ActivitySummaryDialog/types.ts
@@ -1,8 +1,13 @@
-import { ActivityDetailsUI, FormattedNumber } from 'incyclist-services';
+import { ActivityDetailsUI, FormattedNumber, WorkoutGraphActuals, WorkoutGraphPlan } from 'incyclist-services';
 
 export interface ActivitySummaryDialogProps {
     onClose: () => void;   // dismiss -> back to RideMenu (caller's responsibility)
     onExit: () => void;    // navigate away (caller's responsibility)
+}
+
+export interface ActivityWorkoutSummaryGraph {
+    plan: WorkoutGraphPlan;
+    actuals: WorkoutGraphActuals;
 }
 
 export interface ActivitySummaryDialogViewProps {
@@ -10,6 +15,12 @@ export interface ActivitySummaryDialogViewProps {
     showMap: boolean;
     showSave: boolean;
     showContinue: boolean,
+    // true for a route-less workout (no GPS/route data at all) - render workoutGraph instead of
+    // the map/preview. Mutually exclusive with showMap in practice, but kept as its own flag
+    // (rather than inferred from showMap being false) since "no map, no preview either" is also a
+    // valid state (e.g. workoutGraph itself unavailable).
+    showWorkoutSummary?: boolean;
+    workoutGraph?: ActivityWorkoutSummaryGraph;
     preview?: string;
     units?: Record<string, string>;
     isSaving: boolean;

--- a/src/components/WorkoutGraph/WorkoutGraphView.test.tsx
+++ b/src/components/WorkoutGraph/WorkoutGraphView.test.tsx
@@ -123,10 +123,36 @@ describe('WorkoutGraphView', () => {
             expect(countByType(UNSAFE_root, 'Circle')).toBe(0);
         });
 
-        it('ignores actuals for non-live modes', () => {
+        it('detail mode also overlays actuals (completed-ride summary reuse)', () => {
             const { UNSAFE_root } = render(
                 <WorkoutGraphView
                     mode="detail"
+                    plan={MOCK_PLAN_LIVE_MID}
+                    actuals={MOCK_ACTUALS_MID}
+                    width={360}
+                    height={200}
+                />
+            );
+            expect(countByType(UNSAFE_root, 'Circle')).toBe(1);
+        });
+
+        it('detail mode omits the position marker when actuals.position is outside the domain (completed ride, no live cursor)', () => {
+            const { UNSAFE_root } = render(
+                <WorkoutGraphView
+                    mode="detail"
+                    plan={MOCK_PLAN_LIVE_MID}
+                    actuals={{ ...MOCK_ACTUALS_MID, position: -1 }}
+                    width={360}
+                    height={200}
+                />
+            );
+            expect(countByType(UNSAFE_root, 'Circle')).toBe(0);
+        });
+
+        it('strip mode still ignores actuals entirely (plan-only, no summary/live reuse)', () => {
+            const { UNSAFE_root } = render(
+                <WorkoutGraphView
+                    mode="strip"
                     plan={MOCK_PLAN_LIVE_MID}
                     actuals={MOCK_ACTUALS_MID}
                     width={360}

--- a/src/components/WorkoutGraph/WorkoutGraphView.tsx
+++ b/src/components/WorkoutGraph/WorkoutGraphView.tsx
@@ -251,10 +251,12 @@ const formatTime = (sec: number): string => {
  * Pure, presized WorkoutGraph renderer. Draws the zone-colored plan bars for
  * every mode — in `live` mode these span the whole current (skip-adjusted)
  * workout, ridden and remaining alike; `detail` adds an FTP reference line and
- * light axes. `live` additionally overlays `actuals` (Power + HR lines +
+ * light axes. `live` and `detail` both overlay `actuals` (Power + HR lines +
  * position marker, plus a color legend) on top of the bars via
  * `ActualsOverlay`/`ActualsLegend`, without greying out or suppressing the
- * already-ridden bars underneath.
+ * already-ridden bars underneath — a completed-ride summary (`detail` +
+ * actuals with `position` outside the domain) reuses this exact overlay,
+ * just without a live marker.
  */
 export const WorkoutGraphView = React.memo((props: WorkoutGraphViewProps) => {
     const {
@@ -279,11 +281,15 @@ export const WorkoutGraphView = React.memo((props: WorkoutGraphViewProps) => {
     // off would leave every live-mode caller unreadable unless it remembers to opt in.
     const axes = showAxes ?? (isDetail || isLive);
     const ftpLine = showFtpLine ?? isDetail;
-    const showLegend = isLive && !!actuals;
+    // detail mode overlays actuals too (completed-ride summary use case: the same plan-vs-actuals
+    // trace as live, minus the position marker - callers pass actuals.position outside the domain
+    // so ActualsOverlay's marker rendering is a no-op) - only strip stays plan-only.
+    const showActuals = (isLive || isDetail) && !!actuals;
+    const showLegend = showActuals;
     // Bpm has no relation to the plan's Watt-based y-domain, so Heartrate gets its
     // own axis (right side, colored to match its line) — computed once here and
     // shared with ActualsOverlay so the line and its axis always agree on scale.
-    const hrDomain = isLive ? computeHrDomain(actuals?.heartrate ?? []) : null;
+    const hrDomain = showActuals ? computeHrDomain(actuals?.heartrate ?? []) : null;
     const showHrAxis = axes && !!hrDomain;
 
     let marginRight = 0;
@@ -456,7 +462,7 @@ export const WorkoutGraphView = React.memo((props: WorkoutGraphViewProps) => {
     return (
         <Svg width={width} height={height} style={svgStyle}>
             <PlanBars plan={plan} offsetX={offsetX} offsetY={offsetY} plotWidth={plotWidth} plotHeight={plotHeight} />
-            {isLive && actuals && (
+            {showActuals && actuals && (
                 <ActualsOverlay
                     actuals={actuals}
                     domain={plan.domain}


### PR DESCRIPTION
## Summary
- Real-device testing: Ride Summary tried to render a map for a route-less structured/ERG workout (no GPS/route at all) - nothing to show. Root cause + `showWorkoutSummary`/`workoutGraph` display props added in `incyclist-services` PR #493 (paired branch, same name: `feat/routeless-workout-summary`).
- Design decision (confirmed with product owner): reuse `WorkoutGraph` in a summary/completed mode rather than a new visualization.

## What changed
- `WorkoutGraphView`: actuals overlay (Power/HR lines + legend) now also renders in `'detail'` mode, not just `'live'` - a completed ride passes `actuals.position` outside the plan domain, so the live position-marker rendering is naturally a no-op. `'strip'` mode is unaffected (still plan-only).
- `ActivitySummaryDialogView`: renders `<WorkoutGraph mode="detail" .../>` in place of the map/preview when `showWorkoutSummary` is set and graph data is available; falls back to the existing map/preview behavior otherwise (including if `workoutGraph` is ever missing).
- `ActivitySummaryDialog.tsx` (container): bridges the two new services fields with a documented, temporary loose cast - see the TODO comment - since they aren't in the currently-installed `incyclist-services` npm version yet.
- Tests added for both the `WorkoutGraphView` mode change and the new `ActivitySummaryDialogView` rendering branch (including the "flag set but no data" fallback).

## Dependency / follow-up (blocking merge, not blocking review)
This depends on `incyclist-services` PR #493 merging + publishing + a version bump in this repo's `package.json` before `showWorkoutSummary`/`workoutGraph` are ever populated at runtime. Until then this PR's new code paths are dormant (the container's bridge defaults `showWorkoutSummary` to `false`).

## web-ui investigation (read-only, per task scope)
Checked `web-ui`'s `src/components/modules/Ride/summary/ActivitySummary.jsx` (via `wrapper.jsx`, which calls the same shared `getActivitySummaryDisplayProperties()`):
- It renders `showMap ? <FreeMap/> : null` and `preview ? <Image/> : null` independently, with no third state - so once the services fix ships, a route-less workout there will simply render an **empty box** (no map, no preview) instead of the previous broken/misleading map. Not a crash, and strictly better than before, but no workout-graph replacement.
- web-ui does have its own `WorkoutGraph`/`WorkoutRideGraph` components (`src/components/molecules/WorkoutGraph`, `.../WorkoutRideGraph`) that could plausibly be wired into `ActivitySummary.jsx` the same way this PR wires mobile's - but that wiring is a distinct, non-trivial follow-up (different component API, different container structure) and is **out of scope for this PR**. Flagging as a follow-up item rather than attempting it here.

## Test plan
- [x] `npm test` — full suite passes (536 tests)
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npx tsc --noEmit` — clean