### PR TITLE
fix: give each MQTT connect retry its own native client to prevent crash

### DIFF
--- a/src/bindings/mq/index.test.ts
+++ b/src/bindings/mq/index.test.ts
@@ -1,0 +1,193 @@
+// Regression tests for FIXES_BACKLOG item #15: a reused native Mqtt.Client across
+// connect retries could let an abandoned attempt's delayed native completion double-invoke
+// a React Native single-shot Callback, tripping a native fatal abort. See src/bindings/mq/index.ts.
+
+jest.mock('@fdfedin/react-native-native-mqtt', () => {
+    const { EventEmitter: NodeEventEmitter } = require('events');
+
+    const Event = {
+        Connect: 'connect',
+        Disconnect: 'disconnect',
+        Message: 'message',
+        Error: 'error',
+    };
+
+    const instances: any[] = [];
+
+    class Client extends NodeEventEmitter {
+        url: string;
+        connect: jest.Mock;
+        subscribe: jest.Mock;
+        unsubscribe: jest.Mock;
+        publish: jest.Mock;
+        disconnect: jest.Mock;
+        close: jest.Mock;
+        off: jest.Mock;
+
+        constructor(url: string) {
+            super();
+            this.url = url;
+            this.connect = jest.fn();
+            this.subscribe = jest.fn();
+            this.unsubscribe = jest.fn();
+            this.publish = jest.fn();
+            this.disconnect = jest.fn();
+            this.close = jest.fn();
+            // Spy only - deliberately does NOT detach the underlying listener the way the
+            // real library's off() would. This lets the tests below prove that it is the
+            // class's own isCurrentAttempt() guard - not listener removal - that keeps a
+            // late event from an abandoned attempt from mutating connection state.
+            this.off = jest.fn();
+            instances.push(this);
+        }
+    }
+
+    return { Client, Event, __instances: instances };
+});
+
+jest.mock('react-native', () => ({ Platform: { OS: 'android' } }));
+jest.mock('../appInfo', () => ({ isProdVariant: false }));
+jest.mock('../secret', () => ({
+    getSecretBinding: () => ({
+        getSecret: (key: string) => {
+            switch (key) {
+                case 'MQ_BROKER': return 'mqtt://broker.example.com:1883';
+                case 'MQ_USER': return 'user';
+                case 'MQ_PASSWORD': return 'pass';
+                default: return undefined;
+            }
+        },
+    }),
+}));
+
+import * as Mqtt from '@fdfedin/react-native-native-mqtt';
+import { MessageQueue, CONNECT_TIMEOUT_SECONDS } from './index';
+
+const mockInstances = (Mqtt as unknown as { __instances: any[] }).__instances;
+
+// Simulates a successful native connection on a given mocked client: the connect()
+// call's own callback fires without error, and (separately, as the real library does)
+// the broker-level 'connect' event is broadcast.
+const succeed = (client: any) => {
+    const callback = client.connect.mock.calls[0][1];
+    callback();
+    client.emit(Mqtt.Event.Connect, false);
+};
+
+describe('MessageQueue - connect retry / native client lifecycle', () => {
+    let mq: MessageQueue;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        mockInstances.length = 0;
+        MessageQueue._instance = null;
+        mq = MessageQueue.getInstance();
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    test('sends the connect timeout to native in seconds, not milliseconds', async () => {
+        const promise = mq.connect();
+
+        expect(mockInstances).toHaveLength(1);
+        const options = mockInstances[0].connect.mock.calls[0][0];
+
+        expect(options.timeout).toBe(CONNECT_TIMEOUT_SECONDS);
+        expect(options.timeout).toBe(5);
+        expect(options.timeout).not.toBe(5000);
+
+        succeed(mockInstances[0]);
+        await promise;
+    });
+
+    test('a slow/timed-out first attempt is abandoned and retried on a fresh client instance', async () => {
+        const promise = mq.connect();
+        expect(mockInstances).toHaveLength(1);
+        const client1 = mockInstances[0];
+
+        // First attempt never completes client-side (neither its connect() callback nor a
+        // connect/disconnect event fires) -> the JS-side fallback timeout must fire.
+        await jest.advanceTimersByTimeAsync(7000);
+
+        // Abandoned attempt: best-effort disconnect, and its listeners detached.
+        expect(client1.disconnect).toHaveBeenCalledTimes(1);
+        expect(client1.off).toHaveBeenCalledWith(Mqtt.Event.Connect);
+        expect(client1.off).toHaveBeenCalledWith(Mqtt.Event.Disconnect);
+        expect(client1.off).toHaveBeenCalledWith(Mqtt.Event.Message);
+        expect(client1.off).toHaveBeenCalledWith(Mqtt.Event.Error);
+
+        // Retry delay elapses.
+        await jest.advanceTimersByTimeAsync(10000);
+
+        expect(mockInstances).toHaveLength(2);
+        const client2 = mockInstances[1];
+        expect(client2).not.toBe(client1);
+
+        succeed(client2);
+
+        const connected = await promise;
+        expect(connected).toBe(true);
+    });
+
+    test('a late event from an abandoned attempt cannot resurrect state after a newer attempt has resolved', async () => {
+        const promise = mq.connect();
+        const client1 = mockInstances[0];
+
+        await jest.advanceTimersByTimeAsync(7000);  // attempt 1 abandoned
+        await jest.advanceTimersByTimeAsync(10000); // retry delay
+
+        const client2 = mockInstances[1];
+        succeed(client2);
+        const connected = await promise;
+        expect(connected).toBe(true);
+
+        // Attempt 1's connect handler is (per this mock) still technically attached -
+        // simulating a native message that slipped through despite best-effort cleanup.
+        // The class's own guard must ignore it regardless of whether off() succeeded.
+        expect(() => client1.emit(Mqtt.Event.Connect, false)).not.toThrow();
+
+        // Still routes through the live (attempt 2) client, not the abandoned one.
+        mq.publish('topic/x', { a: 1 });
+        expect(client2.publish).toHaveBeenCalled();
+        expect(client1.publish).not.toHaveBeenCalled();
+    });
+
+    test('no cross-instance callback interference: a stale attempt`s late callback is harmless', async () => {
+        const promise = mq.connect();
+        const client1 = mockInstances[0];
+
+        await jest.advanceTimersByTimeAsync(7000);
+        await jest.advanceTimersByTimeAsync(10000);
+
+        const client2 = mockInstances[1];
+        succeed(client2);
+        await promise;
+
+        // This is the real production crash trigger: an abandoned attempt's native
+        // connect() completing very late and invoking its own (distinct, per-attempt)
+        // callback. Because attempt 1 now owns its own Mqtt.Client/callback, this must
+        // be fully independent of attempt 2 - no throw, no double-resolution artefacts.
+        const staleCallback = client1.connect.mock.calls[0][1];
+        expect(() => staleCallback()).not.toThrow();
+
+        // The already-connected state is unaffected, and a further connect() call
+        // short-circuits without spinning up yet another client.
+        const again = await mq.connect();
+        expect(again).toBe(true);
+        expect(mockInstances).toHaveLength(2);
+    });
+
+    test('an immediate successful connect only ever creates a single client', async () => {
+        const promise = mq.connect();
+        expect(mockInstances).toHaveLength(1);
+
+        succeed(mockInstances[0]);
+
+        const connected = await promise;
+        expect(connected).toBe(true);
+        expect(mockInstances).toHaveLength(1);
+    });
+});

--- a/src/bindings/mq/index.ts
+++ b/src/bindings/mq/index.ts
@@ -9,18 +9,32 @@ import { normaliseMqttUri } from './utils';
 
 const CONNECT_RETRY_INTERVAL = 10000;   // 10 seconds
 const CONNECT_RETRY_CNT = 5;            // number of attempts before taking a pause
-const CONNECT_TIMEOUT = 5000;           // 5 seconds
+const CONNECT_TIMEOUT = 5000;           // 5 seconds - JS-side fallback timeout, in ms
+
+// The native module (Paho under the hood) expects `timeout` in *seconds*, not milliseconds.
+// Sending CONNECT_TIMEOUT (ms) straight through used to make the real native timeout
+// ~83 minutes instead of ~5 seconds, which hugely widened the window in which an
+// abandoned connect attempt could still complete after the JS side had already moved on
+// to a retry - see FIXES_BACKLOG item #15.
+export const CONNECT_TIMEOUT_SECONDS = CONNECT_TIMEOUT / 1000; // 5 seconds
 
 export class MessageQueue extends EventEmitter {
-    private client!: Mqtt.Client;
+    private client?: Mqtt.Client;
+    private nativeUri!: string;
     private isConnected: boolean = false;
     private connectPromise!: Promise<boolean> | null;
     private logger: EventLogger;
     private queue: Array<{ topic: string; payload: string; ts: number }> = [];
-    private internalEmitter = new EventEmitter();
     private subscriptions: Set<string> = new Set();
     private pending: Set<string> = new Set();
     private toConnect: NodeJS.Timeout|undefined
+
+    // The client instance created by the most recently started connect attempt.
+    // Every retry gets its *own* fresh `Mqtt.Client` (own native id, own native callback
+    // reference) so two attempts can never collide on the native side. This field is
+    // additionally used JS-side to make sure a late event from an abandoned/superseded
+    // attempt can never resurrect connection state after a newer attempt has resolved.
+    private currentAttemptClient?: Mqtt.Client
 
     static _instance: MessageQueue | null;
 
@@ -93,7 +107,7 @@ export class MessageQueue extends EventEmitter {
 
     private send(topic: string, message: string) {
         const data = Buffer.from(message, 'utf-8');
-        this.client.publish(topic, data, 0, false);
+        this.client?.publish(topic, data, 0, false);
     }
 
     async connect(): Promise<boolean> {
@@ -102,7 +116,7 @@ export class MessageQueue extends EventEmitter {
         }
 
         if (this.isConnected) return true;
-        
+
 
         this.logger.logEvent({ message: 'connecting to message queue ...', platform:Platform.OS, isProdVariant });
 
@@ -125,59 +139,7 @@ export class MessageQueue extends EventEmitter {
 
         const { nativeUri, tls } = normaliseMqttUri(uri, Platform.OS as 'ios' | 'android');
         this.logger.logEvent({ message: 'mqtt broker uri normalised', uri, nativeUri, tls });
-        this.client = new Mqtt.Client(nativeUri);
-
-        const onConnected = () => {
-            this.logger.logEvent({ message: 'mqtt connected' });
-            this.isConnected = true;
-
-            this.subscribePending()
-
-            this.internalEmitter.emit('connected');
-
-            if (this.queue) {
-                let done = false;
-                while (this.queue.length && !done) {
-                    const element = this.queue.pop();
-                    if (!element) {
-                        done = true;
-                    } else {
-                        if (Date.now() - element.ts > 3600 * 1000) continue;
-                        this.send(element.topic, element.payload);
-                    }
-                }
-            }
-        };
-
-        const onDisconnected = (reason: string) => {
-            this.isConnected = false;
-            if (this.toConnect) {
-                clearTimeout(this.toConnect)
-                delete this.toConnect
-            }
-
-            this.prepareSubscriptionsForReconnect()
-                
-            this.logger.logEvent({ message: 'mqtt connection disconnected', reason });
-            this.internalEmitter.emit('disconnected');
-
-        };
-
-        const onEror = (err: string) => {
-            this.logger.logEvent({ message: 'mqtt error', info: err });
-            if (this.toConnect) {
-                clearTimeout(this.toConnect)
-                delete this.toConnect
-            }
-
-        };
-
-        this.client.on(Mqtt.Event.Connect, onConnected);
-        this.client.on(Mqtt.Event.Disconnect, onDisconnected);
-        this.client.on(Mqtt.Event.Message, this.onMessage.bind(this));
-        this.client.on(Mqtt.Event.Error, onEror);
-
-        this.logger.logEvent({ message: 'trying to connect to mqtt' });
+        this.nativeUri = nativeUri;
 
         this.connectPromise = new Promise<boolean>((done) => {
             const clientId = 'mobile' + v4();
@@ -185,13 +147,13 @@ export class MessageQueue extends EventEmitter {
                 username,
                 password,
                 clientId,
-                timeout: CONNECT_TIMEOUT,
+                timeout: CONNECT_TIMEOUT_SECONDS,
                 keepAlive: 60,
                 autoReconnect: true,
                 ...(tls ? { enableSsl: true, allowUntrustedCA:true } : {}),
             };
 
-            this.connectRetries(options, CONNECT_RETRY_CNT, CONNECT_RETRY_INTERVAL, onConnected)
+            this.connectRetries(options, CONNECT_RETRY_CNT, CONNECT_RETRY_INTERVAL)
                 .then(done);
         });
 
@@ -217,7 +179,6 @@ export class MessageQueue extends EventEmitter {
         options: Mqtt.ConnectionOptions,
         max: number,
         delay: number,
-        onConnected: () => void,
     ): Promise<boolean> {
         let success = false;
         let failed = 0;
@@ -226,9 +187,6 @@ export class MessageQueue extends EventEmitter {
 
         while (!success) {
             success = await this.doConnect(options);
-            if (success && !this.isConnected) {
-                onConnected();
-            }
             if (!success) {
                 ++failed;
                 if (failed >= max) {
@@ -241,32 +199,143 @@ export class MessageQueue extends EventEmitter {
         return success;
     }
 
+    // Best-effort teardown of an abandoned/superseded connect attempt: detach our own
+    // listeners (so the closures captured in doConnect() can be garbage collected) and
+    // ask the native side to disconnect. This does not (and cannot, without patching the
+    // native library) remove the NativeEventEmitter subscriptions the client constructor
+    // registers - that part of the leak is native-library behaviour outside this repo.
+    private abandonClient(client: Mqtt.Client) {
+        try {
+            client.off(Mqtt.Event.Connect);
+            client.off(Mqtt.Event.Disconnect);
+            client.off(Mqtt.Event.Message);
+            client.off(Mqtt.Event.Error);
+        } catch {
+            // best effort - failing to detach listeners must never block the retry loop
+        }
+        try {
+            client.disconnect();
+        } catch {
+            // best effort - the attempt is already abandoned, nothing else we can do
+        }
+    }
+
     private doConnect(options: Mqtt.ConnectionOptions): Promise<boolean> {
+        // Every attempt gets its own fresh native client (own native id, own native
+        // callback reference). This is the core fix for the crash: previously all
+        // retries reused the same Mqtt.Client/native id, so the native library's
+        // single-slot connect callback for that id could be overwritten by a later
+        // retry while an earlier, abandoned attempt was still running (the JS-side
+        // timeout fires long before the real Paho timeout used to elapse). A late
+        // completion of the abandoned attempt could then invoke a callback that had
+        // already been invoked once by the newer attempt, tripping RN's single-shot
+        // native Callback invariant and aborting the app.
+        const client = new Mqtt.Client(this.nativeUri);
+        this.currentAttemptClient = client;
+
+        const isCurrentAttempt = () => this.currentAttemptClient === client;
+
         return new Promise<boolean>((resolve) => {
-            this.internalEmitter.once('connected', () => {
-                this.internalEmitter.removeAllListeners();
-                resolve(true);
-            });
-            this.internalEmitter.once('disconnected', () => {
-                this.internalEmitter.removeAllListeners();
+            let settled = false;
+
+            const clearConnectTimeout = () => {
+                if (this.toConnect) {
+                    clearTimeout(this.toConnect);
+                    this.toConnect = undefined;
+                }
+            };
+
+            // Resolves this attempt as failed exactly once, and only if this attempt is
+            // still the current one - a stale/abandoned attempt can never affect state
+            // or resolve a promise that a newer attempt has already settled.
+            const settleFailure = (message: string, info?: string) => {
+                if (!isCurrentAttempt() || settled) return;
+                settled = true;
+                clearConnectTimeout();
+                this.logger.logEvent({ message, info });
+                this.abandonClient(client);
                 resolve(false);
-            });
+            };
 
-            const onTimeout = ()=> {
-                if (this.isConnected)
-                    return
-                this.logger.logEvent({ message: 'mqtt timeout' });
-                resolve(false)
-            }
-            this.toConnect = setTimeout( onTimeout, CONNECT_TIMEOUT + 2000)
+            const onConnected = () => {
+                if (!isCurrentAttempt() || settled) {
+                    // Late success from an abandoned attempt - ignore entirely, a newer
+                    // attempt has already resolved (or is in flight).
+                    return;
+                }
+                settled = true;
+                clearConnectTimeout();
 
-            this.client.connect(options, (error?: Error) => {
+                this.client = client;
+                this.isConnected = true;
+                this.logger.logEvent({ message: 'mqtt connected' });
+
+                this.subscribePending();
+                this.flushQueue();
+
+                resolve(true);
+            };
+
+            const onDisconnected = (reason: string) => {
+                if (!isCurrentAttempt()) return;
+
+                if (!settled) {
+                    // Disconnected before ever connecting - this attempt failed.
+                    settleFailure('mqtt connection disconnected', reason);
+                    return;
+                }
+
+                // Already connected once on this (still current/live) client - a real
+                // disconnect during normal operation. autoReconnect is handled natively.
+                this.isConnected = false;
+                clearConnectTimeout();
+                this.prepareSubscriptionsForReconnect();
+                this.logger.logEvent({ message: 'mqtt connection disconnected', reason });
+            };
+
+            const onError = (err: string) => {
+                if (!isCurrentAttempt()) return;
+
+                if (!settled) {
+                    settleFailure('mqtt error', err);
+                    return;
+                }
+
+                clearConnectTimeout();
+                this.logger.logEvent({ message: 'mqtt error', info: err });
+            };
+
+            client.on(Mqtt.Event.Connect, onConnected);
+            client.on(Mqtt.Event.Disconnect, onDisconnected);
+            client.on(Mqtt.Event.Message, this.onMessage.bind(this));
+            client.on(Mqtt.Event.Error, onError);
+
+            const onTimeout = () => settleFailure('mqtt timeout');
+            this.toConnect = setTimeout(onTimeout, CONNECT_TIMEOUT + 2000)
+
+            this.logger.logEvent({ message: 'trying to connect to mqtt' });
+
+            client.connect(options, (error?: Error) => {
                 if (error !== null && error !== undefined) {
-                    this.internalEmitter.removeAllListeners();
-                    resolve(false);
+                    settleFailure('mqtt connect callback error', error.message);
                 }
             });
         });
+    }
+
+    private flushQueue() {
+        if (!this.queue) return;
+
+        let done = false;
+        while (this.queue.length && !done) {
+            const element = this.queue.pop();
+            if (!element) {
+                done = true;
+            } else {
+                if (Date.now() - element.ts > 3600 * 1000) continue;
+                this.send(element.topic, element.payload);
+            }
+        }
     }
 
     private prepareSubscriptionsForReconnect() {


### PR DESCRIPTION
## Summary

FIXES_BACKLOG item #15. Android Vitals reported a native fatal abort crash twice in production (app version 33/1.0.17): React Native's single-shot native `Callback` object was invoked twice, tripping an internal fatal check that calls `abort()`.

Root cause: `MessageQueue`'s MQTT connect-retry logic in `src/bindings/mq/index.ts` (`connectRetries()` / `doConnect()`) called `client.connect()` repeatedly on the *same* `Mqtt.Client` instance for every retry. The third-party native library (`@fdfedin/react-native-native-mqtt`) stores the connect callback for a given native client id in a single reference, so a retry's `connect()` call overwrites the callback the previous (still in-flight, not-yet-timed-out) attempt was using. If that abandoned attempt's native connect later completes, it can fire into the newer attempt's already-invoked callback - a double-invoke that crashes the app.

This was made much worse by a units bug: native (`MqttClient.java:62`) passes `options.timeout` straight into a Paho API that expects **seconds**, but JS was sending **milliseconds** (5000), so the real native timeout was ~83 minutes instead of ~5 seconds - hugely widening the window in which an abandoned attempt could still complete after JS had moved on to a new retry.

Fixed entirely JS-side (no native library changes, per scope):

## What changed

- **Fresh client per attempt**: `doConnect()` now creates its own `new Mqtt.Client(nativeUri)` for every retry, instead of reusing one instance for the whole `connect()` call. Each attempt therefore gets its own native id and its own independent native callback reference, so two attempts can never collide.
- **Timeout unit fix**: introduced `CONNECT_TIMEOUT_SECONDS` and send that (not the millisecond value) as `options.timeout` to native - closing the gap between Paho's real timeout and the JS-side fallback timeout.
- **Best-effort cleanup on timeout**: `onTimeout` now disconnects the abandoned client and detaches its listeners (`abandonClient()`), reducing (JS-side) resource/listener leakage from abandoned attempts.
- **State-mutation guard**: connection/subscription state (`isConnected`, `this.client`, subscriptions) is only ever mutated by the attempt that is still the current one (`isCurrentAttempt()` guard tracked via `currentAttemptClient`). A late event from an abandoned/superseded attempt can no longer resurrect stale state after a newer attempt has already resolved.
- Removed the now-unnecessary `internalEmitter` indirection - each attempt's promise settles directly from its own client's events.

## Test plan

- [x] `npm test` - full suite green (93 suites / 545 tests)
- [x] New `src/bindings/mq/index.test.ts` covering:
  - connect `timeout` sent to native in seconds, not milliseconds
  - a slow/timed-out first attempt is abandoned (disconnected + listeners detached) and retried on a fresh `Mqtt.Client` instance
  - a late event from an abandoned attempt cannot resurrect connection/subscription state after a newer attempt has already resolved
  - no cross-instance callback interference: a stale attempt's very-late native callback firing is harmless (no throw, no state corruption)
  - an immediate successful connect only ever creates a single client (no regression for the common path)
- [x] `npx eslint` and `npx tsc --noEmit` clean on changed files