### PR TITLE
fix: Start button on ride overlay was a no-op when a sensor failed

### DIFF
--- a/src/pages/RidePage/GPX/View.test.tsx
+++ b/src/pages/RidePage/GPX/View.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { GPXTourPageView, GPXTourPageViewProps } from './View';
+
+jest.mock('react-native-device-info', () => ({
+    isTablet: () => false,
+}));
+
+const mockStartRideDisplay = jest.fn();
+jest.mock('../../../components', () => ({
+    Button: () => null,
+    Dynamic: ({ children }: any) => children,
+    ElevationGraph: () => null,
+    FreeMap: () => null,
+    MainBackground: () => null,
+    RideDashboard: () => null,
+    RideMenu: () => null,
+    StartRideDisplay: (props: any) => {
+        mockStartRideDisplay(props);
+        return null;
+    },
+}));
+
+jest.mock('../../../hooks', () => ({
+    useScreenLayout: () => 'normal',
+}));
+
+jest.mock('../../../components/StreetView', () => ({ StreetView: () => null }));
+
+const baseProps: GPXTourPageViewProps = {
+    displayProps: {
+        startOverlayProps: {
+            devices: [
+                { udid: 'trainer-1', name: 'Smart Trainer', isControl: true, status: 'Started' },
+                { udid: 'hrm-1', name: 'HRM', isControl: false, status: 'Error' },
+            ],
+            rideState: 'Starting',
+            readyToStart: true,
+        },
+        menuProps: null,
+        rideView: 'map',
+        route: undefined,
+        displayObserver: undefined,
+    } as any,
+    rideObserver: null,
+    onMenuOpen: () => {},
+    onMenuClose: () => {},
+    onCloseRidePage: () => {},
+    onRetryStart: () => {},
+    onIgnoreStart: () => {},
+    onCancelStart: () => {},
+};
+
+describe('GPXTourPageView — start overlay "Start" button wiring', () => {
+    beforeEach(() => {
+        mockStartRideDisplay.mockClear();
+    });
+
+    it('wires the Start button to a handler that actually starts the ride (ignoring failed sensors), not a no-op', () => {
+        const onIgnoreStart = jest.fn();
+        render(<GPXTourPageView {...baseProps} onIgnoreStart={onIgnoreStart} />);
+
+        expect(mockStartRideDisplay).toHaveBeenCalled();
+        const props = mockStartRideDisplay.mock.calls.at(-1)?.[0];
+
+        // Pressing "Start" when ready must proceed the ride (same action as "Ignore" sensors),
+        // not silently do nothing.
+        props.onStart();
+        expect(onIgnoreStart).toHaveBeenCalled();
+    });
+});

--- a/src/pages/RidePage/GPX/View.tsx
+++ b/src/pages/RidePage/GPX/View.tsx
@@ -33,8 +33,6 @@ export interface GPXTourPageViewProps {
     onCancelStart: () => void;
 }
 
-const noop = () => {};
-
 const MenuButton = React.memo(({ onPress }: { onPress: () => void }) => (
     <Button id='menu' label='Menu' primary={true} onClick={onPress} />
 ));
@@ -220,7 +218,7 @@ export const GPXTourPageView = (props: GPXTourPageViewProps) => {
             {startOverlayProps && (
                 <StartRideDisplay
                     {...startOverlayProps}
-                    onStart={noop}
+                    onStart={onIgnoreStart}
                     onRetry={onRetryStart}
                     onIgnore={onIgnoreStart}
                     onCancel={onCancelStart}

--- a/src/pages/RidePage/Video/View.test.tsx
+++ b/src/pages/RidePage/Video/View.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { VideoRidePageView } from './View';
+
+jest.mock('react-native-device-info', () => ({
+    isTablet: () => false,
+}));
+
+const mockStartRideDisplay = jest.fn();
+jest.mock('../../../components', () => ({
+    Video: () => null,
+    Button: () => null,
+    Dynamic: ({ children }: any) => children,
+    ElevationGraph: () => null,
+    InfoText: () => null,
+    FreeMap: () => null,
+    MainBackground: () => null,
+    RideDashboard: () => null,
+    RideMenu: () => null,
+    StartRideDisplay: (props: any) => {
+        mockStartRideDisplay(props);
+        return null;
+    },
+}));
+
+jest.mock('../../../hooks', () => ({
+    useScreenLayout: () => 'normal',
+}));
+
+const baseProps: any = {
+    displayProps: {
+        startOverlayProps: {
+            devices: [
+                { udid: 'trainer-1', name: 'Smart Trainer', isControl: true, status: 'Started' },
+                { udid: 'hrm-1', name: 'HRM', isControl: false, status: 'Error' },
+            ],
+            rideState: 'Starting',
+            readyToStart: true,
+            videoState: 'Started',
+        },
+        menuProps: null,
+        video: null,
+        videos: [],
+        route: undefined,
+    },
+    rideObserver: null,
+    onMenuOpen: () => {},
+    onMenuClose: () => {},
+    onCloseRidePage: () => {},
+    onRetryStart: () => {},
+    onIgnoreStart: () => {},
+    onCancelStart: () => {},
+};
+
+describe('VideoRidePageView — start overlay "Start" button wiring', () => {
+    beforeEach(() => {
+        mockStartRideDisplay.mockClear();
+    });
+
+    it('wires the Start button to a handler that actually starts the ride (ignoring failed sensors), not a no-op', () => {
+        const onIgnoreStart = jest.fn();
+        render(<VideoRidePageView {...baseProps} onIgnoreStart={onIgnoreStart} />);
+
+        expect(mockStartRideDisplay).toHaveBeenCalled();
+        const props = mockStartRideDisplay.mock.calls.at(-1)?.[0];
+
+        props.onStart();
+        expect(onIgnoreStart).toHaveBeenCalled();
+    });
+});

--- a/src/pages/RidePage/Video/View.tsx
+++ b/src/pages/RidePage/Video/View.tsx
@@ -28,8 +28,6 @@ interface VideoRidePageViewProps {
     onCancelStart: () => void;
 }
 
-const noop = () => {};
-
 const MenuButton = React.memo(({ onPress }: { onPress: () => void }) => (
     <Button id='menu' label='Menu' primary={true} onClick={onPress} />
 ));
@@ -218,7 +216,7 @@ export const VideoRidePageView = (props: VideoRidePageViewProps) => {
             {startOverlayProps && (
                 <StartRideDisplay
                     {...startOverlayProps}
-                    onStart={noop}
+                    onStart={onIgnoreStart}
                     onRetry={onRetryStart}
                     onIgnore={onIgnoreStart}
                     onCancel={onCancelStart}

--- a/src/pages/RidePage/Workout/View.test.tsx
+++ b/src/pages/RidePage/Workout/View.test.tsx
@@ -9,13 +9,17 @@ jest.mock('react-native-device-info', () => ({
 }));
 
 const mockWorkoutGraph = jest.fn();
+const mockStartRideDisplay = jest.fn();
 jest.mock('../../../components', () => ({
     Button: () => null,
     Dynamic: ({ children }: any) => children,
     MainBackground: () => null,
     RideDashboard: () => null,
     RideMenu: () => null,
-    StartRideDisplay: () => null,
+    StartRideDisplay: (props: any) => {
+        mockStartRideDisplay(props);
+        return null;
+    },
     WorkoutGestureHintOverlay: () => null,
     WorkoutGraph: (props: any) => {
         mockWorkoutGraph(props);
@@ -80,5 +84,38 @@ describe('WorkoutRidePageView — tablet graph font size', () => {
         expect(mockWorkoutGraph).toHaveBeenCalled();
         const props = mockWorkoutGraph.mock.calls.at(-1)?.[0];
         expect(props.axisFontSize).toBeGreaterThan(10);
+    });
+});
+
+describe('WorkoutRidePageView — start overlay "Start" button wiring', () => {
+    beforeEach(() => {
+        mockStartRideDisplay.mockClear();
+    });
+
+    it('wires the Start button to a handler that actually starts the ride (ignoring failed sensors), not a no-op', () => {
+        const onIgnoreStart = jest.fn();
+        const props = {
+            ...baseProps,
+            displayProps: {
+                ...baseDisplayProps,
+                startOverlayProps: {
+                    devices: [
+                        { udid: 'trainer-1', name: 'Smart Trainer', isControl: true, status: 'Started' },
+                        { udid: 'hrm-1', name: 'HRM', isControl: false, status: 'Error' },
+                    ],
+                    rideState: 'Starting',
+                    readyToStart: true,
+                },
+            },
+            onIgnoreStart,
+        };
+
+        render(<WorkoutRidePageView {...props} />);
+
+        expect(mockStartRideDisplay).toHaveBeenCalled();
+        const startRideDisplayProps = mockStartRideDisplay.mock.calls.at(-1)?.[0];
+
+        startRideDisplayProps.onStart();
+        expect(onIgnoreStart).toHaveBeenCalled();
     });
 });

--- a/src/pages/RidePage/Workout/View.tsx
+++ b/src/pages/RidePage/Workout/View.tsx
@@ -66,8 +66,6 @@ export interface WorkoutRidePageViewProps {
     onGestureHintDismissed: (props: { dontShowAgain: boolean }) => void;
 }
 
-const noop = () => {};
-
 const MenuButton = React.memo(({ onPress }: { onPress: () => void }) => (
     <Button id="menu" label="Menu" primary={true} onClick={onPress} />
 ));
@@ -222,7 +220,7 @@ export const WorkoutRidePageView = (props: WorkoutRidePageViewProps) => {
             {startOverlayProps && (
                 <StartRideDisplay
                     {...startOverlayProps}
-                    onStart={noop}
+                    onStart={onIgnoreStart}
                     onRetry={onRetryStart}
                     onIgnore={onIgnoreStart}
                     onCancel={onCancelStart}


### PR DESCRIPTION
## Summary
- On mobile, if a non-control sensor (e.g. HRM) fails to start while the smart trainer starts fine, the pre-ride overlay's "Start" button did nothing — the app appeared to hang.
- Root cause: `StartRideDisplay`'s "Start" button (rendered once `readyToStart` is true, which only checks the control/trainer device) was wired to a hard-coded `noop` in all three ride views. The real recovery path (`startWithMissingSensors()`, reached elsewhere via the sensor-error dialog's "Ignore" button) was never invoked.
- Web-ui hits the identical shared-service state (from `incyclist-services`) but works correctly, because its equivalent "Start" button is wired to the same handler as "Ignore" (`onStartIgnore` → `startWithMissingSensors()`). This PR mirrors that wiring on mobile.

## What changed
- `src/pages/RidePage/GPX/View.tsx`, `Video/View.tsx`, `Workout/View.tsx`: `onStart={noop}` → `onStart={onIgnoreStart}` (removed the now-unused `noop` helper in each).
- Added regression tests in `GPX/View.test.tsx`, `Video/View.test.tsx`, and `Workout/View.test.tsx` that render the overlay in a trainer-started/HRM-errored state and assert pressing Start invokes the ignore-and-proceed handler.

## Test plan
- [x] `npx jest src/pages/RidePage` — new tests fail on `main` (confirmed against the noop wiring), pass after the fix
- [x] Full suite: `npx jest` — 553/553 passing, no regressions
- [ ] Manual verification on a device with a trainer + a HRM that fails to connect