### PR TITLE
Switch to the single getRidePageService() factory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "axios": "^1.17.0",
         "events": "^3.3.0",
         "gd-eventlog": "^0.1.27",
-        "incyclist-services": "^1.7.92",
+        "incyclist-services": "^1.7.96",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
         "react": "^19.2.4",
@@ -11739,9 +11739,9 @@
       }
     },
     "node_modules/incyclist-services": {
-      "version": "1.7.92",
-      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.92.tgz",
-      "integrity": "sha512-5Lia6wlrQSVLKnZBPsgVbewQjIrO6HIxdNTqRtU0l3f2v/YdF70cOLk2nU4ztvYOh3uMHh1x4BFpqdEwb7Ki5A==",
+      "version": "1.7.96",
+      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.96.tgz",
+      "integrity": "sha512-6g9tbRKj1b09Y7AG6e+M0hnAltWVL2+dm0ffXoHKMYMbGl8MJsRHh2A/iIzejWt5xUpr/MhPeSNONEMBrsAI6w==",
       "dependencies": {
         "@garmin/fitsdk": "^21.200.0",
         "axios": "^1.15.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "axios": "^1.17.0",
         "events": "^3.3.0",
         "gd-eventlog": "^0.1.27",
-        "incyclist-services": "^1.7.96",
+        "incyclist-services": "^1.7.97",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
         "react": "^19.2.4",
@@ -11739,9 +11739,9 @@
       }
     },
     "node_modules/incyclist-services": {
-      "version": "1.7.96",
-      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.96.tgz",
-      "integrity": "sha512-6g9tbRKj1b09Y7AG6e+M0hnAltWVL2+dm0ffXoHKMYMbGl8MJsRHh2A/iIzejWt5xUpr/MhPeSNONEMBrsAI6w==",
+      "version": "1.7.97",
+      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.97.tgz",
+      "integrity": "sha512-mrQ59b50t0ScKVzZFNWK0TU0mnPqO67+GisOW1HqYYErNUDKRFr7zUpjvX0I2ejrrcQ8l/9MZLwEYtwlM0G79g==",
       "dependencies": {
         "@garmin/fitsdk": "^21.200.0",
         "axios": "^1.15.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "axios": "^1.17.0",
     "events": "^3.3.0",
     "gd-eventlog": "^0.1.27",
-    "incyclist-services": "^1.7.96",
+    "incyclist-services": "^1.7.97",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "react": "^19.2.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "axios": "^1.17.0",
     "events": "^3.3.0",
     "gd-eventlog": "^0.1.27",
-    "incyclist-services": "^1.7.92",
+    "incyclist-services": "^1.7.96",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "react": "^19.2.4",

--- a/src/components/RideMenu/RideMenu.tsx
+++ b/src/components/RideMenu/RideMenu.tsx
@@ -1,19 +1,23 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { RideMenuProps, ActiveDialog } from './types';
-import { getRidePageService, getWorkoutRidePageService } from 'incyclist-services';
+import { getRidePageService } from 'incyclist-services';
 import { RideMenuView } from './RideMenuView';
 import { useLogging } from '../../hooks';
 
 export const RideMenu = ({ visible, finished, workout = false, onClose, onCloseRidePage=()=>{} }: RideMenuProps) => {
     const { logEvent } = useLogging('RideMenu');
-    const workoutService = workout ? getWorkoutRidePageService() : null;
-    const service = workoutService ?? getRidePageService();
+    // One unconditional call (FIXES_BACKLOG #24) - getRidePageService() resolves to the correct
+    // concrete page service on its own (keyed off the currently selected ride's type), so this no
+    // longer needs a workout-vs-not branch or an `as any` cast to reach menuProps. Workout-only
+    // calls below (onStepBack/onStepForward/onIncreaseLoad/onDecreaseLoad) are safe no-ops when
+    // `service` isn't actually a workout ride.
+    const service = getRidePageService();
     const refInitialized = useRef(false)
 
     const [activeDialog, setActiveDialog] = useState<ActiveDialog>(null);
 
     // menuProps are derived from service display props, which means they reflect current state
-    const menuProps = (service.getPageDisplayProps() as any)?.menuProps;
+    const menuProps = service.getPageDisplayProps()?.menuProps;
     const showResume = menuProps?.showResume ?? false;
     const canStepBack = menuProps?.canStepBack ?? false;
     const canStepForward = menuProps?.canStepForward ?? false;
@@ -68,20 +72,20 @@ export const RideMenu = ({ visible, finished, workout = false, onClose, onCloseR
     }, [showResume, service, logEvent, onClose]);
 
     const handleStepBack = useCallback(() => {
-        workoutService?.onStepBack();
-    }, [workoutService]);
+        service.onStepBack();
+    }, [service]);
 
     const handleStepForward = useCallback(() => {
-        workoutService?.onStepForward();
-    }, [workoutService]);
+        service.onStepForward();
+    }, [service]);
 
     const handleIncreaseLoad = useCallback(() => {
-        workoutService?.onIncreaseLoad();
-    }, [workoutService]);
+        service.onIncreaseLoad();
+    }, [service]);
 
     const handleDecreaseLoad = useCallback(() => {
-        workoutService?.onDecreaseLoad();
-    }, [workoutService]);
+        service.onDecreaseLoad();
+    }, [service]);
 
     // Generic handler to close any active dialog
     const handleDialogClose = useCallback(() => {

--- a/src/components/WorkoutSettingsDialog/WorkoutSettingsDialog.test.tsx
+++ b/src/components/WorkoutSettingsDialog/WorkoutSettingsDialog.test.tsx
@@ -10,8 +10,10 @@ const mockOn = jest.fn((event: string, handler: (...args: any[]) => void) => { c
 const mockOff = jest.fn();
 const mockGetPageObserver = jest.fn(() => ({ on: mockOn, off: mockOff }));
 
+// Single factory (FIXES_BACKLOG #24) - WorkoutSettingsDialog now calls getRidePageService(),
+// same as every other ride page consumer; it always resolves to the workout-shaped service here.
 jest.mock('incyclist-services', () => ({
-    getWorkoutRidePageService: () => ({
+    getRidePageService: () => ({
         getPageDisplayProps: mockGetPageDisplayProps,
         getPageObserver: mockGetPageObserver,
         onSetLoadIncrement: mockOnSetLoadIncrement,

--- a/src/components/WorkoutSettingsDialog/WorkoutSettingsDialog.tsx
+++ b/src/components/WorkoutSettingsDialog/WorkoutSettingsDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { getWorkoutRidePageService, IObserver } from 'incyclist-services';
+import { getRidePageService, IObserver } from 'incyclist-services';
 import { useUnmountEffect } from '../../hooks';
 import { WorkoutSettingsDialogProps } from './types';
 import { WorkoutSettingsDialogView } from './WorkoutSettingsDialogView';
@@ -10,17 +10,22 @@ import { WorkoutSettingsDialogView } from './WorkoutSettingsDialogView';
  * Step Back/Forward/Load.
  *
  * Follows RideSettings' precedent of going through a service rather than a direct
- * useUserSettings() call - here that's WorkoutRidePageService itself (not a dedicated display
- * service like RideSettings' useRideSettingsDisplay(), since the load-increment setting is
- * already a WorkoutRidePageService display-prop/callback pair, session 5.10's services change).
+ * useUserSettings() call - here that's the (workout-resolved) ride page service itself, via the
+ * single getRidePageService() factory (FIXES_BACKLOG #24), not a dedicated display service like
+ * RideSettings' useRideSettingsDisplay() - the load-increment setting is already a display-prop/
+ * callback pair on that service (session 5.10's services change).
  * The page (and its observer) is already open for the duration of the ride, owned by
  * WorkoutRidePage - this dialog only subscribes to page-update, it never calls
  * openPage()/closePage() itself (doing so would tear down and restart the in-progress ride).
  */
 export const WorkoutSettingsDialog = ({ onClose }: WorkoutSettingsDialogProps) => {
-    const service = getWorkoutRidePageService();
+    const service = getRidePageService();
+    // loadIncrement is a Workout-only display prop (optional on the merged AnyRidePageDisplayProps
+    // shape now that one service/factory covers every ride type) - this dialog is only ever reached
+    // from a workout ride's RideMenu, so it is always populated in practice; ?? 1 is just a type-safe
+    // fallback, matching WorkoutRidePageService's own DEFAULT_LOAD_INCREMENT.
     const [loadIncrement, setLoadIncrement] = useState<number>(
-        () => service.getPageDisplayProps().loadIncrement
+        () => service.getPageDisplayProps().loadIncrement ?? 1
     );
     const refObserver = useRef<IObserver | null>(null);
     const refInitialized = useRef(false);
@@ -28,7 +33,7 @@ export const WorkoutSettingsDialog = ({ onClose }: WorkoutSettingsDialogProps) =
     const onUpdate = useCallback(() => {
         const updated = service.getPageDisplayProps();
         if (updated) {
-            setLoadIncrement(updated.loadIncrement);
+            setLoadIncrement(updated.loadIncrement ?? 1);
         }
     }, [service]);
 

--- a/src/hooks/ride/useWorkoutRideGestures.test.ts
+++ b/src/hooks/ride/useWorkoutRideGestures.test.ts
@@ -18,8 +18,10 @@ jest.mock('react-native-device-info', () => ({
     getVersion: () => mockGetVersion(),
 }));
 
+// Single factory (FIXES_BACKLOG #24) - useWorkoutRideGestures now calls getRidePageService(),
+// same as every other ride page consumer; it always resolves to the workout-shaped service here.
 jest.mock('incyclist-services', () => ({
-    getWorkoutRidePageService: () => ({
+    getRidePageService: () => ({
         onStepBack: mockOnStepBack,
         onStepForward: mockOnStepForward,
         adjustLoad: mockAdjustLoad,

--- a/src/hooks/ride/useWorkoutRideGestures.ts
+++ b/src/hooks/ride/useWorkoutRideGestures.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { Platform, Vibration } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
-import { getWorkoutRidePageService, useUserSettings, type PowerAdjustmentResult } from 'incyclist-services';
+import { getRidePageService, useUserSettings, type PowerAdjustmentResult } from 'incyclist-services';
 import { useLogging } from '../logging';
 import { isVersionAtLeast } from '../../utils/version';
 
@@ -98,7 +98,9 @@ export interface UseWorkoutRideGesturesResult {
 export const useWorkoutRideGestures = (): UseWorkoutRideGesturesResult => {
     const { logEvent, logError } = useLogging('WorkoutRideGestures');
     const userSettings = useUserSettings();
-    const service = getWorkoutRidePageService();
+    // Single factory (FIXES_BACKLOG #24) - this hook is only ever used on a workout ride
+    // (WorkoutRidePageView), so getRidePageService() always resolves to WorkoutRidePageService here.
+    const service = getRidePageService();
 
     const [feedback, setFeedback] = useState<WorkoutRideGestureFeedback>({ visible: false, message: '' });
     const feedbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/src/pages/RidePage/GPX/GPXTourPage.tsx
+++ b/src/pages/RidePage/GPX/GPXTourPage.tsx
@@ -4,7 +4,7 @@ import {
     getRidePageService,
     IObserver,
     GPXRidePageDisplayProps,
-    RidePageService,
+    IRidePageService,
     RideType,
 } from 'incyclist-services';
 import { useUnmountEffect } from '../../../hooks';
@@ -22,7 +22,7 @@ interface GPXTourPageProps {
 export const GPXTourPage = ({ simulate = false, onRideTypeChange,onCancelStart,onClose }: GPXTourPageProps) => {
     const [displayProps, setDisplayProps] = useState<GPXRidePageDisplayProps | null>(null);
 
-    const refService = useRef<RidePageService | null>(null);
+    const refService = useRef<IRidePageService | null>(null);
     const refObserver = useRef<IObserver | null>(null);
     const refRideObserver = useRef<IObserver | null>(null);
     const refInitialized = useRef(false);

--- a/src/pages/RidePage/Video/VideoRidePage.tsx
+++ b/src/pages/RidePage/Video/VideoRidePage.tsx
@@ -4,7 +4,7 @@ import {
     getRidePageService,
     IObserver,
     VideoRidePageDisplayProps,
-    RidePageService,
+    IRidePageService,
     RideType
 } from 'incyclist-services';
 import { useUnmountEffect } from '../../../hooks';
@@ -22,7 +22,7 @@ interface VideoRidePageProps {
 export const VideoRidePage = ({ simulate = false, onRideTypeChange, onCancelStart,onClose }: VideoRidePageProps) => {
     const [displayProps, setDisplayProps] = useState<VideoRidePageDisplayProps | null>(null);
 
-    const refService = useRef<RidePageService | null>(null);
+    const refService = useRef<IRidePageService | null>(null);
     const refObserver = useRef<IObserver | null>(null);
     const refRideObserver = useRef<IObserver | null>(null);
     const refInitialized = useRef(false);

--- a/src/pages/RidePage/Workout/WorkoutRidePage.stories.tsx
+++ b/src/pages/RidePage/Workout/WorkoutRidePage.stories.tsx
@@ -128,6 +128,7 @@ const MID_WORKOUT: WorkoutRidePageDisplayProps = {
     title: 'VO2 max (1/3)',
     gestureHint: null,
     loadIncrement: 1,
+    loadButtonMode: 'power',
 };
 
 const AFTER_SKIP_BACK: WorkoutRidePageDisplayProps = {
@@ -147,6 +148,7 @@ const AFTER_SKIP_BACK: WorkoutRidePageDisplayProps = {
     title: 'Cooldown',
     gestureHint: null,
     loadIncrement: 1,
+    loadButtonMode: 'power',
 };
 
 const STARTING: WorkoutRidePageDisplayProps = {
@@ -169,6 +171,7 @@ const STARTING: WorkoutRidePageDisplayProps = {
     title: '',
     gestureHint: null,
     loadIncrement: 1,
+    loadButtonMode: 'power',
 };
 
 /**

--- a/src/pages/RidePage/Workout/WorkoutRidePage.test.tsx
+++ b/src/pages/RidePage/Workout/WorkoutRidePage.test.tsx
@@ -35,10 +35,10 @@ const mockOpenPage = jest.fn(() => {
     };
 });
 
-const mockGoBack = jest.fn();
-
+// Single factory (FIXES_BACKLOG #24) - WorkoutRidePage now calls getRidePageService(), same as
+// VideoRidePage/GPXTourPage; it always resolves to the workout-shaped service in this file's tests.
 jest.mock('incyclist-services', () => ({
-    getWorkoutRidePageService: () => ({
+    getRidePageService: () => ({
         openPage: mockOpenPage,
         closePage: mockClosePage,
         pausePage: mockPausePage,
@@ -64,13 +64,6 @@ jest.mock('../../../hooks', () => ({
         feedback: { visible: false, message: '' },
         loadIncrement: 1,
     }),
-}));
-
-jest.mock('../../../services', () => ({
-    // Indirected through a wrapper (not `goBack: mockGoBack` directly) — this factory runs at
-    // require-time, before the later `const mockGoBack = jest.fn()` assignment further down this
-    // file has executed, so capturing it eagerly here would freeze `goBack` at `undefined`.
-    goBack: (...args: unknown[]) => mockGoBack(...args),
 }));
 
 jest.mock('../../../components', () => {
@@ -134,12 +127,13 @@ describe('WorkoutRidePage', () => {
         expect(getByText('view:Active')).toBeTruthy();
     });
 
-    it('calls navigation.goBack() when the service emits navigate-back', () => {
+    // FIXES_BACKLOG #24, bug 2/2 (fixed): no more 'navigate-back' subscription - the ride
+    // reaching Finished now surfaces via menuProps.finished (getPageDisplayProps()), same as every
+    // other ride type, so RideMenu can render the Activity Summary instead of the page navigating
+    // away on its own. Confirmed no 'navigate-back' handler is ever registered.
+    it('does not subscribe to a navigate-back event', () => {
         render(<WorkoutRidePage onRideTypeChange={noop} onCancelStart={noop} onClose={noop} />);
-        expect(capturedHandlers['navigate-back']).toBeInstanceOf(Function);
-
-        capturedHandlers['navigate-back']();
-        expect(mockGoBack).toHaveBeenCalledTimes(1);
+        expect(capturedHandlers['navigate-back']).toBeUndefined();
     });
 
     it('pauses the page when the app goes to background and resumes on foreground', () => {

--- a/src/pages/RidePage/Workout/WorkoutRidePage.tsx
+++ b/src/pages/RidePage/Workout/WorkoutRidePage.tsx
@@ -1,18 +1,17 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { View, AppState } from 'react-native';
 import {
-    getWorkoutRidePageService,
+    getRidePageService,
     IObserver,
+    IRidePageService,
     RideType,
     WorkoutGraphActuals,
     WorkoutRidePageDisplayProps,
-    WorkoutRidePageService,
 } from 'incyclist-services';
 import { useUnmountEffect, useWorkoutRideGestures } from '../../../hooks';
 import { colors } from '../../../theme';
 import { WorkoutRidePageView } from './View';
 import { MainBackground, ErrorBoundary } from '../../../components';
-import { goBack } from '../../../services';
 
 interface WorkoutRidePageProps {
     simulate?: boolean;
@@ -24,22 +23,20 @@ interface WorkoutRidePageProps {
 const EMPTY_ACTUALS: WorkoutGraphActuals = { power: [], heartrate: [], position: 0 };
 
 /**
- * Smart page for a workout-only ride (workout-mobile-hld.md §3.2/§5, session 5.6). Owns
- * `WorkoutRidePageService`'s lifecycle and app background/foreground handling — mirrors
- * `VideoRidePage`/`GPXTourPage` exactly, except this page's service is a dedicated sibling
- * service (`WorkoutRidePageService`, session 2.2), not the shared `RidePageService` those two
- * ride types use (workout-ride-page-service-design.md §7 #5 — explicit non-goal).
+ * Smart page for a workout-only ride (workout-mobile-hld.md §3.2/§5, session 5.6). Owns the
+ * workout ride page service's lifecycle and app background/foreground handling — mirrors
+ * `VideoRidePage`/`GPXTourPage` exactly, including the single `getRidePageService()` factory
+ * (FIXES_BACKLOG #24): it resolves to the concrete `WorkoutRidePageService` on its own (keyed off
+ * the currently selected ride's type), so this page no longer needs a dedicated getter.
  *
- * One extra subscription vs. Video/GPX: `navigate-back`, emitted when the workout finishes,
- * is stopped, or the underlying ride reaches `Finished` on its own (design doc §5) — the UI
- * calls `navigation.goBack()` directly for that path. The RideMenu's own "End Ride" flow is
- * unchanged (pause + ActivitySummaryDialog review, then `onCloseRidePage` -> this page's
- * `onClose` prop -> the base `RidePageService.onEndRide()`, same as every other ride type).
+ * No `navigate-back` subscription anymore (FIXES_BACKLOG #24, bug 2/2) - the ride-observer
+ * 'Finished' path now converges onto `menuProps.finished`, same as every other completion path;
+ * the RideMenu already renders the Activity Summary overlay off that, same as Video/GPX.
  */
 export const WorkoutRidePage = ({ simulate = false, onRideTypeChange, onCancelStart, onClose }: WorkoutRidePageProps) => {
     const [displayProps, setDisplayProps] = useState<WorkoutRidePageDisplayProps | null>(null);
 
-    const refService = useRef<WorkoutRidePageService | null>(null);
+    const refService = useRef<IRidePageService | null>(null);
     const refObserver = useRef<IObserver | null>(null);
     const refRideObserver = useRef<IObserver | null>(null);
     const refInitialized = useRef(false);
@@ -49,7 +46,11 @@ export const WorkoutRidePage = ({ simulate = false, onRideTypeChange, onCancelSt
     const onUpdate = useCallback(() => {
         const service = refService.current;
         if (service) {
-            const update = service.getPageDisplayProps();
+            // This page only ever mounts for a Workout ride (RidePage.tsx's rideType dispatch) -
+            // getPageDisplayProps() is typed AnyRidePageDisplayProps at the IRidePageService level
+            // since the same call also serves Video/GPX, but it is always the Workout-shaped
+            // WorkoutRidePageDisplayProps here.
+            const update = service.getPageDisplayProps() as WorkoutRidePageDisplayProps;
             setDisplayProps(update);
         }
     }, []);
@@ -58,7 +59,7 @@ export const WorkoutRidePage = ({ simulate = false, onRideTypeChange, onCancelSt
         if (refInitialized.current) return;
         refInitialized.current = true;
 
-        const service = getWorkoutRidePageService();
+        const service = getRidePageService();
         refService.current = service;
 
         // openPage returns the page observer
@@ -69,7 +70,6 @@ export const WorkoutRidePage = ({ simulate = false, onRideTypeChange, onCancelSt
         if (refObserver.current) {
             refObserver.current.on('page-update', onUpdate);
             refObserver.current.on('ride-type-update', onRideTypeChange);
-            refObserver.current.on('navigate-back', goBack);
         }
 
         onUpdate();
@@ -96,7 +96,6 @@ export const WorkoutRidePage = ({ simulate = false, onRideTypeChange, onCancelSt
         if (refObserver.current) {
             refObserver.current.off('page-update', onUpdate);
             refObserver.current.off('ride-type-update', onRideTypeChange);
-            refObserver.current.off('navigate-back', goBack);
         }
         refService.current?.closePage();
         refInitialized.current = false;

--- a/src/pages/RidePage/Workout/WorkoutRidePrototype.stories.tsx
+++ b/src/pages/RidePage/Workout/WorkoutRidePrototype.stories.tsx
@@ -99,6 +99,7 @@ const MID_WORKOUT: WorkoutRidePageDisplayProps = {
     title: 'VO2 max (1/3)',
     gestureHint: null,
     loadIncrement: 1,
+    loadButtonMode: 'power',
 };
 
 const MID_WORKOUT_ACTUALS: WorkoutGraphActuals = MOCK_ACTUALS_MID;
@@ -128,6 +129,7 @@ const AFTER_SKIP_BACK: WorkoutRidePageDisplayProps = {
     title: 'Cooldown',
     gestureHint: null,
     loadIncrement: 1,
+    loadButtonMode: 'power',
 };
 
 const AFTER_SKIP_BACK_ACTUALS: WorkoutGraphActuals = MOCK_ACTUALS_SKIPBACK;

--- a/src/services/Navigation/index.ts
+++ b/src/services/Navigation/index.ts
@@ -12,10 +12,12 @@ export const navigate = (name: string, params?: object) => {
     }
 };
 
-// Used by WorkoutRidePageService's `navigate-back` page-observer event
-// (workout-ride-page-service-design.md §5): "UI calls navigation.goBack()".
-// Distinct from the RideMenu End-Ride flow, which still goes through
-// RidePageService.onEndRide() -> moveToPreviousPage (unchanged for every ride type).
+// No longer used by WorkoutRidePage (FIXES_BACKLOG #24, bug 2/2) - the workout ride-observer's
+// 'Finished' path now converges onto menuProps.finished like every other ride type, instead of
+// the removed 'navigate-back' page-observer event this was originally added for
+// (workout-ride-page-service-design.md §5). Kept as general-purpose navigation infra; the RideMenu
+// End-Ride flow still goes through RidePageService.onEndRide() -> moveToPreviousPage (unchanged
+// for every ride type), not this helper.
 export const goBack = () => {
     if (navigationRef.isReady() && navigationRef.canGoBack()) {
         navigationRef.goBack();


### PR DESCRIPTION
## Summary

Companion PR to `incyclist/services` `feat/unify-ride-page-service` (FIXES_BACKLOG #24), which collapses `RidePageService`/`WorkoutRidePageService` into one page-service factory. This PR updates every mobile call site off the old `getWorkoutRidePageService()`/two-getter pattern.

## What changed

- **`RideMenu.tsx`**: replaced `const workoutService = workout ? getWorkoutRidePageService() : null; const service = workoutService ?? getRidePageService();` (plus an `as any` cast to reach `menuProps`) with one unconditional `getRidePageService()` call. The workout-only calls (`onStepBack`/`onStepForward`/`onIncreaseLoad`/`onDecreaseLoad`) are now always made on `service` directly - safe no-ops when it isn't actually a workout ride.
- **`WorkoutRidePage.tsx`**: switched its import from `getWorkoutRidePageService` to `getRidePageService`; retyped its service ref from the (now-deleted) `WorkoutRidePageService` export to `IRidePageService`. Removed the `'navigate-back'` subscribe/unsubscribe and the `goBack` import - the services-side fix converges the ride-observer `'Finished'` path onto `menuProps.finished`, so `RideMenu` already renders the Activity Summary overlay the same way it does for Video/GPX (confirmed `goBack` had no other consumer anywhere in `mobile/src` before leaving the helper itself in place as general navigation infra, with its now-stale comment corrected).
- **`WorkoutSettingsDialog.tsx`**, **`useWorkoutRideGestures.ts`**: same `getWorkoutRidePageService` → `getRidePageService` switch (not called out by name in the original design note, but same two-getter pattern - found via a full `mobile/src` grep for every touched name).
- **`GPXTourPage.tsx`**, **`VideoRidePage.tsx`**: retyped their service ref from the concrete `RidePageService` class to the `IRidePageService` interface, since the factory's return type is now the merged interface, not either concrete class.
- **Tests**: `WorkoutRidePage.test.tsx` (mock renamed, the `navigate-back` test replaced with one asserting no such subscription exists), `WorkoutSettingsDialog.test.tsx`, `useWorkoutRideGestures.test.ts` (mock rename only). `RideMenu.test.tsx` needed no change - it only exercises the presentational `RideMenuView`, not the smart `RideMenu` component's service wiring.

## Test plan

- [x] `npm test` - full suite passes (95 suites, 553 tests)
- [x] `npx eslint` clean on every touched file
- [ ] Not validated against a real Android build/local dev-mode link in this environment - `incyclist-services` is not bumped/published in the companion PR, and this environment has no local library-link or emulator available. Jest fully mocks `'incyclist-services'` per test file, so behavior is validated; static typing against the real new interface could not be verified here (falls back to careful manual review of every call site, per the design's own contingency plan).

## Notes for reviewers

- `mobile/src/services/index.ts`'s `getRidePageService` wrapper (adds `getSecretsStatus()`) needed no change - it's duck-typed (`as any`) and agnostic to which concrete subclass the underlying factory resolves to.
- `RidePage.tsx`'s existing `rideType`-based screen-component dispatch was **not** touched, per the design - it was already correct.
- Once the `incyclist/services` PR is merged and a new version published, this PR's `package.json` `incyclist-services` version will need bumping separately (not done here).

Ref: FIXES_BACKLOG #24
Depends on: incyclist/services#507