### PR TITLE
fix: workout swipe gesture means gear shift (or disabled) in SIM mode

### DIFF
--- a/src/hooks/ride/useWorkoutRideGestures.test.ts
+++ b/src/hooks/ride/useWorkoutRideGestures.test.ts
@@ -4,6 +4,7 @@ import {
     useWorkoutRideGestures,
     classifySwipe,
     formatPowerAdjustment,
+    formatSwipeFeedback,
     DEFAULT_WORKOUT_LOAD_INCREMENT,
     WORKOUT_LOAD_INCREMENT_SETTING_KEY,
 } from './useWorkoutRideGestures';
@@ -11,6 +12,7 @@ import {
 const mockOnStepBack = jest.fn();
 const mockOnStepForward = jest.fn();
 const mockAdjustLoad = jest.fn();
+const mockGetLoadButtonMode = jest.fn(() => 'power');
 const mockGetValue = jest.fn((_key: string, def: any) => def);
 const mockGetVersion = jest.fn(() => '1.0.19');
 
@@ -23,6 +25,7 @@ jest.mock('incyclist-services', () => ({
         onStepBack: mockOnStepBack,
         onStepForward: mockOnStepForward,
         adjustLoad: mockAdjustLoad,
+        getLoadButtonMode: mockGetLoadButtonMode,
     }),
     useUserSettings: () => ({ getValue: mockGetValue }),
 }));
@@ -65,6 +68,26 @@ describe('formatPowerAdjustment', () => {
     });
 });
 
+// FIXES_BACKLOG #37: in SIM/Resistance mode with virtual shifting enabled, adjustLoad() performs a
+// gear shift instead of a power/FTP nudge - the swipe feedback must say so.
+describe('formatSwipeFeedback', () => {
+    it('shows a gear-shift result as "+N gear", not a "%" power adjustment', () => {
+        expect(formatSwipeFeedback('+', 1, { type: 'gear', value: 1 })).toBe('+1 gear');
+    });
+
+    it('shows a gear-shift-down result as "-N gear"', () => {
+        expect(formatSwipeFeedback('-', 5, { type: 'gear', value: -5 })).toBe('-5 gear');
+    });
+
+    it('falls back to the existing "%"-based message for power-mode results', () => {
+        expect(formatSwipeFeedback('+', 5, { type: 'ftp', value: 220 })).toBe('+5% (FTP: 220W)');
+    });
+
+    it('falls back to the existing "%"-based message when there is no result at all', () => {
+        expect(formatSwipeFeedback('+', 5, undefined)).toBe('+5%');
+    });
+});
+
 describe('classifySwipe', () => {
     it('returns null for movement below both thresholds', () => {
         expect(classifySwipe(10, 5, 50, 50)).toBeNull();
@@ -96,6 +119,7 @@ describe('useWorkoutRideGestures', () => {
         jest.clearAllMocks();
         mockGetValue.mockImplementation((_key: string, def: any) => def);
         mockAdjustLoad.mockReturnValue(undefined);
+        mockGetLoadButtonMode.mockReturnValue('power');
         mockGetVersion.mockReturnValue('1.0.19');
         Platform.OS = 'ios';
         jest.useFakeTimers();
@@ -288,5 +312,101 @@ describe('useWorkoutRideGestures', () => {
             jest.advanceTimersByTime(1200);
         });
         expect(result.current.feedback).toEqual({ visible: false, message: '' });
+    });
+
+    // FIXES_BACKLOG #37: SIM/Resistance mode with virtual shifting enabled - swipe up/down performs
+    // a gear shift (WorkoutRideService.gearChange(), reached via adjustLoad()) instead of a
+    // power/FTP nudge, and the feedback must say "gear", not "%".
+    describe('loadButtonMode="gear" (SIM/Resistance, virtual shifting enabled)', () => {
+        beforeEach(() => {
+            mockGetLoadButtonMode.mockReturnValue('gear');
+        });
+
+        it('still calls adjustLoad on an upward swipe (routing to gear shift happens in the service layer)', () => {
+            mockGetValue.mockImplementation(() => 1);
+            mockAdjustLoad.mockReturnValue({ type: 'gear', value: 1 });
+            const { result } = renderHook(() => useWorkoutRideGestures());
+
+            act(() => {
+                capturedOnEnd!({ translationX: 0, translationY: -100, velocityX: 0, velocityY: 0 });
+            });
+
+            expect(mockAdjustLoad).toHaveBeenCalledWith(1);
+            expect(result.current.feedback.message).toBe('+1 gear');
+        });
+
+        it('shows "-N gear" feedback on a downward swipe', () => {
+            mockGetValue.mockImplementation(() => 5);
+            mockAdjustLoad.mockReturnValue({ type: 'gear', value: -5 });
+            const { result } = renderHook(() => useWorkoutRideGestures());
+
+            act(() => {
+                capturedOnEnd!({ translationX: 0, translationY: 100, velocityX: 0, velocityY: 0 });
+            });
+
+            expect(mockAdjustLoad).toHaveBeenCalledWith(-5);
+            expect(result.current.feedback.message).toBe('-5 gear');
+        });
+
+        it('still vibrates and steps back/forward normally - only the load-adjust feedback text changes', () => {
+            const vibrateSpy = jest.spyOn(Vibration, 'vibrate');
+            const { result } = renderHook(() => useWorkoutRideGestures());
+
+            act(() => {
+                capturedOnEnd!({ translationX: -100, translationY: 0, velocityX: 0, velocityY: 0 });
+            });
+
+            expect(vibrateSpy).toHaveBeenCalled();
+            expect(mockOnStepBack).toHaveBeenCalledTimes(1);
+            expect(result.current.feedback).toEqual({ visible: true, message: '◀ Step Back' });
+        });
+    });
+
+    // FIXES_BACKLOG #37: SIM/Resistance mode with virtual shifting disabled - there is no gear
+    // concept and no power target to nudge, so the load-adjust gesture is disabled outright (no
+    // service call, no vibration, no feedback) rather than showing a misleading "no effect" toast.
+    describe('loadButtonMode="hidden" (SIM/Resistance, virtual shifting disabled)', () => {
+        beforeEach(() => {
+            mockGetLoadButtonMode.mockReturnValue('hidden');
+        });
+
+        it('ignores an upward swipe entirely: no adjustLoad call, no vibration, no feedback', () => {
+            const vibrateSpy = jest.spyOn(Vibration, 'vibrate');
+            const { result } = renderHook(() => useWorkoutRideGestures());
+
+            act(() => {
+                capturedOnEnd!({ translationX: 0, translationY: -100, velocityX: 0, velocityY: 0 });
+            });
+
+            expect(mockAdjustLoad).not.toHaveBeenCalled();
+            expect(vibrateSpy).not.toHaveBeenCalled();
+            expect(result.current.feedback).toEqual({ visible: false, message: '' });
+        });
+
+        it('ignores a downward swipe entirely', () => {
+            const { result } = renderHook(() => useWorkoutRideGestures());
+
+            act(() => {
+                capturedOnEnd!({ translationX: 0, translationY: 100, velocityX: 0, velocityY: 0 });
+            });
+
+            expect(mockAdjustLoad).not.toHaveBeenCalled();
+            expect(result.current.feedback.visible).toBe(false);
+        });
+
+        it('leaves step back/forward (left/right swipes) unaffected', () => {
+            const { result } = renderHook(() => useWorkoutRideGestures());
+
+            act(() => {
+                capturedOnEnd!({ translationX: -100, translationY: 0, velocityX: 0, velocityY: 0 });
+            });
+            expect(mockOnStepBack).toHaveBeenCalledTimes(1);
+            expect(result.current.feedback).toEqual({ visible: true, message: '◀ Step Back' });
+
+            act(() => {
+                capturedOnEnd!({ translationX: 100, translationY: 0, velocityX: 0, velocityY: 0 });
+            });
+            expect(mockOnStepForward).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/src/hooks/ride/useWorkoutRideGestures.ts
+++ b/src/hooks/ride/useWorkoutRideGestures.ts
@@ -80,6 +80,18 @@ export const formatPowerAdjustment = (result: PowerAdjustmentResult | undefined)
     return result.type === 'ftp' ? ` (FTP: ${watts}W)` : ` (${watts}W)`;
 };
 
+// FIXES_BACKLOG #37: in SIM/Resistance mode with virtual shifting enabled, adjustLoad() performs a
+// gear shift instead of a power/FTP nudge (WorkoutRideService.powerUp()/powerDown(), gear mode) -
+// the swipe feedback must say so, not claim a "%" power adjustment that didn't happen. `increment`
+// is always the raw magnitude actually applied (== the gearDelta WorkoutRideService.gearChange()
+// was called with), so it doubles as the gear-step count here.
+export const formatSwipeFeedback = (sign: '+' | '-', increment: number, result: PowerAdjustmentResult | undefined): string => {
+    if (result?.type === 'gear') {
+        return `${sign}${increment} gear`;
+    }
+    return `${sign}${increment}%${formatPowerAdjustment(result)}`;
+};
+
 export interface WorkoutRideGestureFeedback {
     visible: boolean;
     message: string;
@@ -119,6 +131,17 @@ export const useWorkoutRideGestures = (): UseWorkoutRideGesturesResult => {
     }, [userSettings]);
 
     const handleSwipe = useCallback((direction: SwipeDirection) => {
+        // FIXES_BACKLOG #37: in SIM/Resistance mode with virtual shifting disabled there is no
+        // gear concept and no power target to nudge, so a load-adjust swipe would be a silent
+        // no-op. Disable the gesture outright in that case (rather than a "no effect" toast, which
+        // has no existing precedent here) - avoids training the rider that swiping up/down does
+        // something in this mode. Step back/forward (left/right) are unaffected - re-check fresh on
+        // every swipe, since the rider can toggle ERG/SIM mid-ride.
+        if ((direction === 'up' || direction === 'down') && service.getLoadButtonMode() === 'hidden') {
+            logEvent({ message: 'gesture ignored', gesture: `swipe-${direction}`, reason: 'loadButtonMode=hidden', eventSource: 'user' });
+            return;
+        }
+
         // Vibration.vibrate() can throw natively (missing permission, no vibrator motor on this
         // device) - that must never take down an in-progress ride over haptic feedback.
         if (canVibrate()) {
@@ -145,14 +168,14 @@ export const useWorkoutRideGestures = (): UseWorkoutRideGesturesResult => {
                 const increment = getLoadIncrement();
                 logEvent({ message: 'gesture triggered', gesture: 'swipe-up', action: 'increase-load', increment, eventSource: 'user' });
                 const result = service.adjustLoad(increment);
-                showFeedback(`+${increment}%${formatPowerAdjustment(result)}`);
+                showFeedback(formatSwipeFeedback('+', increment, result));
                 break;
             }
             case 'down': {
                 const increment = getLoadIncrement();
                 logEvent({ message: 'gesture triggered', gesture: 'swipe-down', action: 'decrease-load', increment, eventSource: 'user' });
                 const result = service.adjustLoad(-increment);
-                showFeedback(`-${increment}%${formatPowerAdjustment(result)}`);
+                showFeedback(formatSwipeFeedback('-', increment, result));
                 break;
             }
         }


### PR DESCRIPTION
## Summary

Implements the mobile side of FIXES_BACKLOG #37. `useWorkoutRideGestures.ts`'s swipe-up/down handler always assumed ERG-mode %/W power semantics, regardless of the rider's cycling mode. Depends on a companion `incyclist-services` change (services PR: https://github.com/incyclist/services/pull/508) that adds `WorkoutRidePageService.getLoadButtonMode(): 'power'|'gear'|'hidden'`.

## What changed

- `useWorkoutRideGestures.ts`: `handleSwipe()` now calls `service.getLoadButtonMode()` fresh on every up/down swipe (cycling mode can change mid-ride via the ERG/SIM toggle, so this is intentionally not cached).
  - `'hidden'` (SIM/Resistance, virtual shifting off): the swipe is now a complete no-op - no `adjustLoad()` call, no vibration, no feedback toast. Left/right (step back/forward) are unaffected.
  - `'gear'` (SIM/Resistance, virtual shifting on): `adjustLoad()` already routes to a real gear shift via the services-side fix with zero changes needed here - only the feedback text changes, via new `formatSwipeFeedback()`, from `"+N%"` to `"+N gear"` (and equivalent for decrease), since claiming a "%" adjustment happened would be wrong once gear mode routes there instead.
  - `'power'` (ERG, unaffected): identical behaviour to before.
- `WorkoutRidePageService.onIncreaseLoad()`/`onDecreaseLoad()` needed **no changes** - they already delegate to `adjustLoad()` → `WorkoutRideService.powerUp()`/`powerDown()`, which is now mode-aware entirely on the services side.

## My call on the open UX question (per the backlog item, not blocking, flagged for review)

Backlog left "disable the gesture outright, or leave it active with a 'no effect' toast" as an implementation-time call. **I disabled the gesture outright** in `'hidden'` mode: today's swipe already shows a post-hoc toast for every other action, but a "no effect" toast has no existing precedent in this hook, and I judged that showing *any* toast on a swipe that does nothing risks training the rider that swiping up/down does something in a mode where it categorically never will. Low-risk either way per the backlog - happy to switch to a "no effect" toast if reviewers prefer it, the swap is contained to the new early-return in `handleSwipe()`.

## Known limitation

`incyclist-services` isn't bumped/published as part of this change (per instructions), so the installed npm package's types don't yet include `getLoadButtonMode()` / the `'gear'` result type. `npx tsc --noEmit` in this worktree shows exactly 4 errors, all confined to this new API surface (`PowerAdjustmentResult['type']` missing `'gear'`, `WorkoutRidePageService` missing `getLoadButtonMode()`) - these will resolve automatically once `services` publishes a version containing PR #508. Jest doesn't type-check (Babel-transformed), so all tests below ran and passed regardless.

## Test plan

- [x] `npx jest src/hooks/ride/useWorkoutRideGestures.test.ts` - 37/37 passing (13 new: `formatSwipeFeedback` unit tests, `loadButtonMode="gear"` describe block, `loadButtonMode="hidden"` describe block covering no-op behaviour and left/right unaffected)
- [x] `npx jest` (full suite) - 95 suites / 563 tests passing, no regressions
- [x] `npx eslint src/hooks/ride/useWorkoutRideGestures.ts src/hooks/ride/useWorkoutRideGestures.test.ts` - clean
- [x] `npx tsc --noEmit` - 4 expected errors, all pending the services publish described above; no other errors

## Reviewer attention

- The UX call above (disable vs. toast) is worth a deliberate look/decision, not just a rubber stamp.
- `RideMenu`'s "Increase/Decrease Load" menu items (a second, button-based path to the same `onIncreaseLoad()`/`onDecreaseLoad()` calls) were **left untouched** - not named in the backlog item's explicit scope. They already inherit correct gear-shift routing for free via the services fix, but don't yet hide/relabel themselves in `'hidden'`/`'gear'` mode the way this gesture hook and web-ui's load buttons now do (tapping "Increase Load" in `'hidden'` mode is currently a silent no-op via the menu, same as the swipe was before this fix). Flagging as a deliberate follow-up rather than pulling it into this PR's scope.