### PR TITLE
fix: add corner orientation map to GPX StreetView rides

### DIFF
--- a/src/pages/RidePage/GPX/GPXTourPage.stories.tsx
+++ b/src/pages/RidePage/GPX/GPXTourPage.stories.tsx
@@ -58,3 +58,40 @@ export const ActiveRide: Story = {
         },
     },
 };
+
+// GPX route shaped with description/details (route.description.hasGpx + route.details.points),
+// used to exercise the corner orientation map (§1.3.1 of ride-overlay-layout-design.md).
+const gpxRoute = {
+    description: { hasGpx: true, isLoop: false },
+    details: { points: (sydneyRoute as any).points },
+};
+
+export const StreetViewWithCornerMap: Story = {
+    args: {
+        rideObserver: null,
+        displayProps: {
+            rideState: 'Active',
+            rideType: 'GPX',
+            startOverlayProps: null,
+            startGateProps: null,
+            menuProps: null,
+            route: gpxRoute as any,
+            rideView: 'sv' as any,
+        },
+    },
+};
+
+export const MapNoCornerMap: Story = {
+    args: {
+        rideObserver: null,
+        displayProps: {
+            rideState: 'Active',
+            rideType: 'GPX',
+            startOverlayProps: null,
+            startGateProps: null,
+            menuProps: null,
+            route: gpxRoute as any,
+            rideView: 'map' as any,
+        },
+    },
+};

--- a/src/pages/RidePage/GPX/View.test.tsx
+++ b/src/pages/RidePage/GPX/View.test.tsx
@@ -21,8 +21,9 @@ jest.mock('../../../components', () => ({
     },
 }));
 
+const mockUseScreenLayout = jest.fn(() => 'normal');
 jest.mock('../../../hooks', () => ({
-    useScreenLayout: () => 'normal',
+    useScreenLayout: () => mockUseScreenLayout(),
 }));
 
 jest.mock('../../../components/StreetView', () => ({ StreetView: () => null }));
@@ -51,6 +52,24 @@ const baseProps: GPXTourPageViewProps = {
     onCancelStart: () => {},
 };
 
+const activeRouteProps = {
+    hasGpx: true,
+    points: [{ lat: 1, lng: 2 }, { lat: 3, lng: 4 }],
+};
+
+const activeProps = (rideView: 'map' | 'sat' | 'sv'): GPXTourPageViewProps => ({
+    ...baseProps,
+    displayProps: {
+        ...baseProps.displayProps,
+        startOverlayProps: null,
+        rideView,
+        route: {
+            description: { hasGpx: activeRouteProps.hasGpx, isLoop: false },
+            details: { points: activeRouteProps.points },
+        },
+    } as any,
+});
+
 describe('GPXTourPageView — start overlay "Start" button wiring', () => {
     beforeEach(() => {
         mockStartRideDisplay.mockClear();
@@ -67,5 +86,42 @@ describe('GPXTourPageView — start overlay "Start" button wiring', () => {
         // not silently do nothing.
         props.onStart();
         expect(onIgnoreStart).toHaveBeenCalled();
+    });
+});
+
+describe('GPXTourPageView — corner orientation map', () => {
+    beforeEach(() => {
+        mockUseScreenLayout.mockReturnValue('normal');
+    });
+
+    it('shows the corner map when the main view is StreetView', () => {
+        const { queryByTestId } = render(<GPXTourPageView {...activeProps('sv')} />);
+        expect(queryByTestId('gpx-corner-map')).not.toBeNull();
+    });
+
+    it('does not show the corner map when the main view is the Map', () => {
+        const { queryByTestId } = render(<GPXTourPageView {...activeProps('map')} />);
+        expect(queryByTestId('gpx-corner-map')).toBeNull();
+    });
+
+    it('does not show the corner map when the main view is Satellite (still rendered as a full-screen map today)', () => {
+        const { queryByTestId } = render(<GPXTourPageView {...activeProps('sat')} />);
+        expect(queryByTestId('gpx-corner-map')).toBeNull();
+    });
+
+    it('does not show the corner map in compact mode, even in StreetView', () => {
+        mockUseScreenLayout.mockReturnValue('compact');
+        const { queryByTestId } = render(<GPXTourPageView {...activeProps('sv')} />);
+        expect(queryByTestId('gpx-corner-map')).toBeNull();
+    });
+
+    it('does not show the corner map when there is no GPX route data', () => {
+        const props = activeProps('sv');
+        (props.displayProps as any).route = {
+            description: { hasGpx: false, isLoop: false },
+            details: { points: [] },
+        };
+        const { queryByTestId } = render(<GPXTourPageView {...props} />);
+        expect(queryByTestId('gpx-corner-map')).toBeNull();
     });
 });

--- a/src/pages/RidePage/GPX/View.tsx
+++ b/src/pages/RidePage/GPX/View.tsx
@@ -59,6 +59,14 @@ export const GPXTourPageView = (props: GPXTourPageViewProps) => {
     // Derived properties
     const routeData = route?.details;
     const lapMode = route?.description?.isLoop;
+    const hasGpx = route?.description?.hasGpx;
+
+    // Whether the full-screen main view already shows a map, making the corner orientation map
+    // redundant. Deliberately not `rideView !== 'map'`: GPX also renders 'sat' through FreeMap as a
+    // full-screen map today ("currently also draw sv and sat as map - to be replaced later"), so that
+    // predicate would double-render a map on top of a map. Update to
+    // `rideView === 'sv' || rideView === 'sat'` once SatelliteView is a real, distinct view.
+    const mainViewIsNotAMap = rideView === 'sv';
 
     const { width: screenWidth, height: screenHeight } = useWindowDimensions();
     const layout = useScreenLayout();
@@ -87,6 +95,12 @@ export const GPXTourPageView = (props: GPXTourPageViewProps) => {
         width: reservedRight,
     };
     const dashboardDynamicStyle = { height: DASHBOARD_HEIGHT };
+
+    const mapOverlayDynamicStyle = {
+        width: screenWidth * 0.15,
+        height: ELEVATION_PREVIEW_HEIGHT,
+        top: cornerTopOffset,
+    };
 
     const bottomBarStyle = {
         position: 'absolute' as const,
@@ -152,6 +166,25 @@ export const GPXTourPageView = (props: GPXTourPageViewProps) => {
                         </Dynamic>
                     )}
 
+                    {/* Corner orientation map — shown only when the main view above isn't itself a map */}
+                    {!isCompact && mainViewIsNotAMap && hasGpx && !!routeData?.points?.length && (
+                        <View testID='gpx-corner-map' style={[styles.mapOverlay, mapOverlayDynamicStyle]}>
+                            <Dynamic
+                                observer={rideObserver ?? undefined}
+                                event='position-update'
+                                prop='position'
+                                transform={transformPosition}
+                            >
+                                <FreeMap
+                                    points={routeData.points as RoutePoint[]}
+                                    draggable={false}
+                                    followPosition={true}
+                                    colorActive='blue'
+                                    colorInactive='rgba(255,255,255,0.4)'
+                                />
+                            </Dynamic>
+                        </View>
+                    )}
 
                     {/* Dashboard */}
                     <View style={[
@@ -281,6 +314,15 @@ const styles = StyleSheet.create({
         paddingHorizontal: 8,
         justifyContent: 'center',
         alignItems: 'center',
+    },
+    mapOverlay: {
+        position: 'absolute',
+        left: 0,
+        backgroundColor: 'rgba(0,0,0,0.45)',
+        borderRadius: 4,
+        overflow: 'hidden',
+        zIndex: 10,
+        elevation: 10,
     },
     placeholderContainer: {
         ...StyleSheet.absoluteFillObject,


### PR DESCRIPTION
## Summary

- `Video/View.tsx` already renders a small corner orientation-map overlay whenever its main view isn't itself a map. `GPX/View.tsx` had no equivalent, so a StreetView GPX ride gave the rider no orientation map anywhere on screen.
- This is a plain, pre-existing mobile-only bug — not workout-specific, and not gated behind any feature toggle. Every StreetView GPX ride should get this regardless of the in-flight workout/route-combo feature work.
- Implements session 0.3 of `mobile/internal/designs/workout-mobile-session-plan-phase2.md` (finding documented in `ride-overlay-layout-design.md` §1.3.1).

## What changed

`src/pages/RidePage/GPX/View.tsx`:
- Ported the corner map overlay (`left: 0`, ~15% width, ~20% height) from `Video/View.tsx`.
- Added a named `mainViewIsNotAMap` predicate (`rideView === 'sv'` today), with a comment explaining why it must extend to `rideView === 'sv' || rideView === 'sat'` once SatelliteView is a real, distinct view — and why it is deliberately **not** written as `rideView !== 'map'`: `GPX/View.tsx` currently also renders `'sat'` through `FreeMap` as a full-screen map, so that predicate would double-render a map on top of a map.
- Gated the overlay on `!isCompact && mainViewIsNotAMap && hasGpx && points.length`, mirroring `Video/View.tsx`'s condition exactly.
- No `services` change — `rideView` is an existing `GPXRidePageDisplayProps` field, this is a mobile-side read only.
- No behaviour change for `rideView === 'map'`/`'sat'` or compact mode — both already correctly show no corner map, and continue to.

`src/pages/RidePage/GPX/View.test.tsx`:
- StreetView GPX shows the corner map.
- Map GPX does not show it.
- Satellite GPX does not show it (still rendered as a full-screen map today).
- Compact mode does not show it, even in StreetView.
- No corner map when there's no GPX route data.

`src/pages/RidePage/GPX/GPXTourPage.stories.tsx`:
- Added `StreetViewWithCornerMap` and `MapNoCornerMap` stories using a GPX-shaped route fixture (`description.hasGpx` + `details.points`), since the existing `sydneyRoute` fixture used by `ActiveRide` doesn't carry those fields and never exercised this condition.

## Test plan

- [x] `npm test` — all 95 suites / 568 tests pass, including the 5 new corner-map tests.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on touched files — clean.
- [ ] Manual/Storybook visual check of the new stories (not run in this session — reviewer/owner to confirm visually before promoting out of draft).