### PR TITLE
feat: ride-screen overlay-arrangement hook (session 3.2)

### DIFF
--- a/src/hooks/render/index.ts
+++ b/src/hooks/render/index.ts
@@ -1,2 +1,3 @@
 export * from './useWhyDidYouRender'
 export * from './useScreenLayout'
+export * from './useRideOverlayLayout'

--- a/src/hooks/render/useRideOverlayLayout.test.ts
+++ b/src/hooks/render/useRideOverlayLayout.test.ts
@@ -1,0 +1,341 @@
+import { renderHook, act } from '@testing-library/react-native'
+import {
+    useRideOverlayLayout,
+    computeRideOverlayLayout,
+    getRideDashboardWidth,
+    RideOverlayArrangement,
+    SIDE_WIDGET_MIN_WIDTH,
+    TILE_COUNT_SETTLE_MS,
+    ARRANGEMENT_HYSTERESIS_PX,
+    DEFAULT_ROUTE_RIDE_TILE_COUNT,
+} from './useRideOverlayLayout'
+
+// Mock useWindowDimensions the same way FilterPanel.test.tsx does, but with a mutable return value
+// so individual tests (and the hook-level rotation/resize tests) can change it between renders.
+const mockDimensions = { width: 1280, height: 800 }
+jest.mock('react-native/Libraries/Utilities/useWindowDimensions', () => ({
+    default: jest.fn(() => mockDimensions),
+}))
+
+const setDimensions = (width: number, height: number) => {
+    mockDimensions.width = width
+    mockDimensions.height = height
+}
+
+describe('getRideDashboardWidth', () => {
+    // Design doc §1.1/§7.1's worked-matrix numbers, pinned exactly.
+    it('matches the 7-tile icon-left width from the worked matrix (895.6)', () => {
+        expect(getRideDashboardWidth({ itemCount: 7, layout: 'icon-left', compact: false, screenWidth: 1280 })).toBeCloseTo(895.6, 5)
+    })
+
+    it('matches the 8-tile icon-top width from the worked matrix (743.0)', () => {
+        expect(getRideDashboardWidth({ itemCount: 8, layout: 'icon-top', compact: false, screenWidth: 1280 })).toBeCloseTo(743.0, 5)
+    })
+
+    it('collapses to screenWidth exactly in compact mode (RideDashboard is alignSelf: stretch there)', () => {
+        expect(getRideDashboardWidth({ itemCount: 7, layout: 'icon-left', compact: true, screenWidth: 844 })).toBe(844)
+    })
+})
+
+describe('computeRideOverlayLayout - the 4 arrangements + fallback (design doc §7.1 worked matrix)', () => {
+    it('1280x800, N=7: block-side (plenty of room beside the whole block)', () => {
+        const result = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        expect(result.arrangement).toBe('block-side')
+        expect(result.inputs.earWidth).toBeCloseTo(184.2, 5)
+        expect(result.workoutDashboard?.width).toBeCloseTo(895.6, 5)
+        expect(result.map).not.toBeNull()
+        expect(result.map?.width).toBeCloseTo(184.2, 5)
+        expect(result.elevation.width).toBeCloseTo(184.2, 5)
+        expect(result.cornerSlotIsToggle).toBe(false)
+    })
+
+    it('1280x800, N=8: block-side, at the icon-top (743.0) width - adding the Gear tile narrows the dashboard', () => {
+        const result = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 8, mapVisible: true })
+        expect(result.arrangement).toBe('block-side')
+        expect(result.inputs.rideDashboardWidth).toBeCloseTo(743.0, 5)
+        expect(result.inputs.earWidth).toBeCloseTo(260.5, 5)
+    })
+
+    it('1194x834 (iPad Air), N=7: t-side - ear narrows below 160, WorkoutDashboard narrows to its minimum (ear -> 429)', () => {
+        const result = computeRideOverlayLayout({ screenWidth: 1194, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        expect(result.arrangement).toBe('t-side')
+        expect(result.workoutDashboard?.width).toBe(320) // WORKOUT_DASH_MIN_WIDTH
+        expect(result.inputs.earWidth).toBeCloseTo(429, 5)
+    })
+
+    it('1112x834 (iPad Pro 10.5), N=7 vs N=8: the highlighted same-device tile-count flip (t-side -> block-side)', () => {
+        const at7 = computeRideOverlayLayout({ screenWidth: 1112, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        expect(at7.arrangement).toBe('t-side')
+        expect(at7.inputs.rideDashboardWidthEffective).toBeCloseTo(895.6, 5)
+
+        const at8 = computeRideOverlayLayout({ screenWidth: 1112, screenHeight: 834, screenLayout: 'normal', itemCount: 8, mapVisible: true })
+        expect(at8.arrangement).toBe('block-side')
+        expect(at8.inputs.rideDashboardWidthEffective).toBeCloseTo(743.0, 5)
+        expect(at8.inputs.earWidth).toBeCloseTo(176.5, 5)
+    })
+
+    it('1024x768, N=7 and N=8: both land in t-side at the same narrowed ear width (344)', () => {
+        const at7 = computeRideOverlayLayout({ screenWidth: 1024, screenHeight: 768, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const at8 = computeRideOverlayLayout({ screenWidth: 1024, screenHeight: 768, screenLayout: 'normal', itemCount: 8, mapVisible: true })
+        expect(at7.arrangement).toBe('t-side')
+        expect(at8.arrangement).toBe('t-side')
+        expect(at7.inputs.earWidth).toBeCloseTo(344, 5)
+        expect(at8.inputs.earWidth).toBeCloseTo(344, 5)
+    })
+
+    // Judgement call (see the long comment above the `wWdT` line in useRideOverlayLayout.ts): the
+    // design doc's §5.5 pseudocode text would send this row (blockPossible === false) through
+    // `min(W_wd_max, W_rd_eff)` = 645, giving an ear of 135.5 and (wrongly) falling through to
+    // 't-below'. The doc's own §7.1 worked matrix pins this row at 't-side' with ear = 298, which
+    // only reproduces under an unconditional WORKOUT_DASH_MIN_WIDTH (320). This test locks in the
+    // worked-matrix number.
+    it('932x430 (large phone landscape), N=7: t-side despite the aspect ceiling forcing blockPossible=false (ear = 298)', () => {
+        const result = computeRideOverlayLayout({ screenWidth: 932, screenHeight: 430, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        expect(result.inputs.blockPossible).toBe(false)
+        expect(result.arrangement).toBe('t-side')
+        expect(result.inputs.earWidth).toBeCloseTo(298, 5)
+    })
+
+    // §5.6's reachability example: aspect ceiling forces a T (blockPossible=false) *and* the
+    // narrowed ear fails (152 < 160) - the one rare path that reaches 't-below'.
+    it('640x420, N=7: t-below - the §5.6 reachability frame', () => {
+        const result = computeRideOverlayLayout({ screenWidth: 640, screenHeight: 420, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        expect(result.inputs.rideDashboardWidthEffective).toBe(640) // clamped (§5.7) - raw W_rd (895.6) would overflow the screen
+        expect(result.inputs.blockPossible).toBe(false)
+        expect(result.arrangement).toBe('t-below')
+        expect(result.map?.left).toBe(0)
+        expect(result.elevation.right).toBe(0)
+    })
+
+    // A narrow-but-tall screen: blockPossible stays true (aspect ceiling isn't the limiter), but
+    // even the minimum-width T's ear fails - the "block-below" cell of the 2x2, reached from the
+    // opposite direction to t-below.
+    it('600x800 narrow-but-tall, N=7: block-below - T narrows to its minimum but still cannot side-fit', () => {
+        const result = computeRideOverlayLayout({ screenWidth: 600, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        expect(result.inputs.blockPossible).toBe(true)
+        expect(result.arrangement).toBe('block-below')
+        expect(result.workoutDashboard?.width).toBeCloseTo(600, 5) // W_rd_eff, clamped to screenWidth
+        expect(result.map?.top).toBe(result.elevation.top)
+    })
+
+    it('844x390 (phone landscape), any N: fallback, because screenLayout is compact', () => {
+        const result = computeRideOverlayLayout({ screenWidth: 844, screenHeight: 390, screenLayout: 'compact', itemCount: 7, mapVisible: true })
+        expect(result.arrangement).toBe('fallback')
+        expect(result.rideDashboard.width).toBe(844) // W_rd === screenWidth exactly in compact (§1.1)
+        expect(result.workoutDashboard).toBeNull()
+        expect(result.map).toBeNull()
+        expect(result.cornerSlotIsToggle).toBe(true)
+        expect(result.elevation.width).toBeCloseTo(844 * 0.20, 5)
+        expect(result.elevation.height).toBeCloseTo(390 * 0.12, 5)
+    })
+})
+
+describe('computeRideOverlayLayout - invariants (design doc §4)', () => {
+    it('invariant 2: arrangement is identical with and without measuredRideDashboardHeight - only positions move', () => {
+        const withoutMeasured = computeRideOverlayLayout({ screenWidth: 1194, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const withMeasured = computeRideOverlayLayout({
+            screenWidth: 1194, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true,
+            measuredRideDashboardHeight: 60, // deliberately far from the 83.4 estimate (0.10 * 834)
+        })
+
+        expect(withMeasured.arrangement).toBe(withoutMeasured.arrangement)
+        // positions do move - measured height only refines them, it must not be silently ignored
+        expect(withMeasured.workoutDashboard?.top).toBe(60)
+        expect(withoutMeasured.workoutDashboard?.top).toBeCloseTo(83.4, 5)
+        expect(withMeasured.workoutDashboard?.top).not.toBe(withoutMeasured.workoutDashboard?.top)
+    })
+
+    it('a compact screenLayout always resolves to fallback, regardless of itemCount/mapVisible', () => {
+        const a = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 390, screenLayout: 'compact', itemCount: 7, mapVisible: true })
+        const b = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 390, screenLayout: 'compact', itemCount: 8, mapVisible: false })
+        expect(a.arrangement).toBe('fallback')
+        expect(b.arrangement).toBe('fallback')
+    })
+
+    // Confirmed explicitly by the design doc's own §7.1 text ("Because both v1 occupants share the
+    // same SIDE_WIDGET_MIN_WIDTH, an empty left ear ... never changes the width verdict"): the right
+    // ear (2 km elevation preview) is always occupied and uses the identical ear-width formula the
+    // left ear (corner map) would use, so in v1 the arrangement decision cannot differ by
+    // `mapVisible` - only whether the `map` rect itself is populated does.
+    it('mapVisible does not change the arrangement decision in v1 - only whether `map` is populated', () => {
+        const withMap = computeRideOverlayLayout({ screenWidth: 1194, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const withoutMap = computeRideOverlayLayout({ screenWidth: 1194, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: false })
+
+        expect(withMap.arrangement).toBe(withoutMap.arrangement)
+        expect(withMap.map).not.toBeNull()
+        expect(withoutMap.map).toBeNull()
+        expect(withoutMap.elevation).toEqual(withMap.elevation) // the always-present occupant is unaffected
+    })
+})
+
+describe('computeRideOverlayLayout - hysteresis (design doc §8.2)', () => {
+    // N=7, screenHeight=800 (blockPossible=true throughout) => W_rd_eff = 895.6. The unrelaxed
+    // block-side boundary is exactly at screenWidth = 895.6 + 2*(160+8) = 1231.6 (ear === 160).
+    const BOUNDARY_SCREEN_WIDTH = 1231.6
+
+    it('a small width change that crosses the normal boundary does NOT flip out of the active arrangement', () => {
+        const result = computeRideOverlayLayout({
+            screenWidth: BOUNDARY_SCREEN_WIDTH - 12, // ear = 154, below the normal 160 minimum
+            screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true,
+            previousArrangement: 'block-side',
+        })
+        expect(result.inputs.earWidth).toBeCloseTo(154, 5)
+        expect(result.arrangement).toBe('block-side') // relaxed minimum is 160 - 24 = 136; 154 still clears it
+    })
+
+    it('a large width change that exceeds the hysteresis cushion DOES flip', () => {
+        // Delta chosen well past the exact 48 px critical width (earWidthOf moves 1:1 with half of
+        // screenWidth, so clearing the 24 px ear cushion needs >= 48 px of screenWidth) - not the
+        // design doc's own worked number, chosen here to demonstrate the mechanism unambiguously.
+        // The 130 figure is the ear the *failed* block-side candidate would have had; the returned
+        // `inputs.earWidth` instead reflects the winning t-side candidate (WORKOUT_DASH_MIN_WIDTH-based).
+        const result = computeRideOverlayLayout({
+            screenWidth: BOUNDARY_SCREEN_WIDTH - 60, // block-side's ear would be 130, below even the relaxed 136 minimum
+            screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true,
+            previousArrangement: 'block-side',
+        })
+        expect(result.arrangement).toBe('t-side')
+        expect(result.inputs.workoutDashboardWidth).toBe(320) // WORKOUT_DASH_MIN_WIDTH
+    })
+
+    it('with no previous arrangement (first render), the normal (unrelaxed) minimum applies', () => {
+        const result = computeRideOverlayLayout({
+            screenWidth: BOUNDARY_SCREEN_WIDTH - 12, // ear = 154 - would stay under hysteresis, but there is no "previous" to relax for
+            screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true,
+            previousArrangement: null,
+        })
+        expect(result.arrangement).toBe('t-side')
+    })
+
+    // Design doc §8.2's own worked example: at 1112x834, 7->8 tiles takes the ear from 100.2 to
+    // 176.5 (clears 160, flips to block-side); 8->7 takes it back to 100.2, which is below even the
+    // relaxed 136 minimum, so it flips straight back - hysteresis alone does not prevent
+    // gear-tile-flap oscillation, the settle window (tested below, at the hook level) is what does.
+    it('the 1112px 7<->8 flip: hysteresis protects the marginal case but not this large a swing', () => {
+        const to8 = computeRideOverlayLayout({
+            screenWidth: 1112, screenHeight: 834, screenLayout: 'normal', itemCount: 8, mapVisible: true, previousArrangement: 't-side',
+        })
+        expect(to8.arrangement).toBe('block-side')
+
+        const backTo7 = computeRideOverlayLayout({
+            screenWidth: 1112, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true, previousArrangement: 'block-side',
+        })
+        expect(backTo7.arrangement).toBe('t-side')
+    })
+})
+
+describe('useRideOverlayLayout - the hook', () => {
+    beforeEach(() => {
+        jest.useFakeTimers()
+        setDimensions(1112, 834)
+    })
+
+    afterEach(() => {
+        jest.useRealTimers()
+    })
+
+    it('resolves synchronously on first render using the itemCount passed in - no settle delay on mount', () => {
+        const { result } = renderHook(() => useRideOverlayLayout({ itemCount: 8, workoutAttached: true, mapVisible: true }))
+        expect(result.current.arrangement).toBe('block-side')
+    })
+
+    it('defaults itemCount to DEFAULT_ROUTE_RIDE_TILE_COUNT when not supplied (§3.2 first-frame value)', () => {
+        const { result } = renderHook(() => useRideOverlayLayout({ workoutAttached: true, mapVisible: true }))
+        expect(result.current.inputs.itemCount).toBe(DEFAULT_ROUTE_RIDE_TILE_COUNT)
+    })
+
+    it('debounces an itemCount change (the Gear tile) - does not re-flow before TILE_COUNT_SETTLE_MS has elapsed', () => {
+        const { result, rerender } = renderHook(
+            (props: { itemCount: number }) => useRideOverlayLayout({ itemCount: props.itemCount, workoutAttached: true, mapVisible: true }),
+            { initialProps: { itemCount: 7 } },
+        )
+        expect(result.current.arrangement).toBe('t-side')
+
+        rerender({ itemCount: 8 })
+        expect(result.current.arrangement).toBe('t-side') // unchanged immediately after the prop flips
+
+        act(() => { jest.advanceTimersByTime(TILE_COUNT_SETTLE_MS - 100) })
+        expect(result.current.arrangement).toBe('t-side') // still not settled
+
+        act(() => { jest.advanceTimersByTime(200) })
+        expect(result.current.arrangement).toBe('block-side') // settled past 2000ms total
+    })
+
+    it('resets the settle timer on a flappy itemCount change - a brief drop of the Gear tile must not re-flow the screen', () => {
+        const { result, rerender } = renderHook(
+            (props: { itemCount: number }) => useRideOverlayLayout({ itemCount: props.itemCount, workoutAttached: true, mapVisible: true }),
+            { initialProps: { itemCount: 7 } },
+        )
+
+        rerender({ itemCount: 8 })
+        act(() => { jest.advanceTimersByTime(1500) })
+        rerender({ itemCount: 7 }) // reverts before settling - timer must restart, not fire the stale 8
+
+        act(() => { jest.advanceTimersByTime(1500) })
+        expect(result.current.arrangement).toBe('t-side') // never settled on 8
+
+        act(() => { jest.advanceTimersByTime(600) })
+        expect(result.current.arrangement).toBe('t-side') // settling back onto its own starting value is a no-op
+    })
+
+    it('recomputes immediately on a mapVisible change - no settle window (§8.2)', () => {
+        setDimensions(1194, 834)
+        const { result, rerender } = renderHook(
+            (props: { mapVisible: boolean }) => useRideOverlayLayout({ itemCount: 7, workoutAttached: true, mapVisible: props.mapVisible }),
+            { initialProps: { mapVisible: true } },
+        )
+        expect(result.current.map).not.toBeNull()
+
+        rerender({ mapVisible: false })
+        expect(result.current.map).toBeNull() // flips on the very next render, no timer advance needed
+    })
+
+    it('recomputes immediately on a screen rotation/resize - no settle window', () => {
+        const { result, rerender } = renderHook(() => useRideOverlayLayout({ itemCount: 7, workoutAttached: true, mapVisible: true }), { initialProps: {} })
+        expect(result.current.arrangement).toBe('t-side')
+
+        act(() => { setDimensions(1280, 800) })
+        rerender({})
+        expect(result.current.arrangement).toBe('block-side')
+    })
+
+    it('applies hysteresis end-to-end: once settled into an arrangement, a small resize does not flip it back out', () => {
+        const { result, rerender } = renderHook(() => useRideOverlayLayout({ itemCount: 7, workoutAttached: true, mapVisible: true }), { initialProps: {} })
+        expect(result.current.arrangement).toBe('t-side')
+
+        // Settle a few px past the exact 1231.6 block-side boundary first (a small margin avoids
+        // floating-point noise right at the boundary - 124.8 * 7 does not land on an exact double).
+        const SETTLED_WIDTH = 1231.6 + 4
+        act(() => { setDimensions(SETTLED_WIDTH, 800) })
+        rerender({})
+        expect(result.current.arrangement).toBe('block-side')
+
+        // A 12px shrink crosses the *normal* boundary but must be absorbed by the 24px cushion,
+        // since block-side is now the active (previous) arrangement.
+        act(() => { setDimensions(SETTLED_WIDTH - 12, 800) })
+        rerender({})
+        expect(result.current.arrangement).toBe('block-side')
+
+        // A larger shrink exceeds the cushion and genuinely flips.
+        act(() => { setDimensions(SETTLED_WIDTH - 60, 800) })
+        rerender({})
+        expect(result.current.arrangement).toBe('t-side')
+    })
+})
+
+// Sanity check the arrangement type union stays in sync with what the pure function actually returns.
+describe('RideOverlayArrangement', () => {
+    it('covers exactly the 5 cells the design doc defines', () => {
+        const all: RideOverlayArrangement[] = ['block-side', 't-side', 'block-below', 't-below', 'fallback']
+        expect(all).toHaveLength(5)
+    })
+})
+
+// Documents SIDE_WIDGET_MIN_WIDTH's role as "the single most consequential number" (design doc §7.2)
+// without hardcoding a duplicate of the production value.
+describe('constants', () => {
+    it('exposes ARRANGEMENT_HYSTERESIS_PX and SIDE_WIDGET_MIN_WIDTH as tunable named exports', () => {
+        expect(typeof ARRANGEMENT_HYSTERESIS_PX).toBe('number')
+        expect(typeof SIDE_WIDGET_MIN_WIDTH).toBe('number')
+    })
+})

--- a/src/hooks/render/useRideOverlayLayout.ts
+++ b/src/hooks/render/useRideOverlayLayout.ts
@@ -1,0 +1,473 @@
+import { useEffect, useRef, useState } from 'react'
+import { useWindowDimensions } from 'react-native'
+import { useScreenLayout, ScreenLayout } from './useScreenLayout'
+
+// Ride-screen-scoped, width-based overlay layout hook.
+//
+// Implements `mobile/internal/designs/ride-overlay-layout-design.md` (session 1.2's spec, consumed
+// by session 3.2 - this file). Layered on top of `useScreenLayout()` (height-based compact/normal,
+// ~20 unrelated consumers app-wide) rather than replacing it - see design doc §5.2/§9 and HLD §5.2.
+//
+// Scope (design doc §2): this hook is only ever used for a route ride with a workout attached and
+// the combo toggle on. Route-only rides never call it - they keep today's rendering untouched, by
+// construction rather than by proving numeric equivalence with it.
+
+// -----------------------------------------------------------------------------------------------
+// §7 - threshold constants. These are v1 hypotheses ("starting hypothesis", design doc §7), meant
+// to be tuned by session 4.1 against real renders - kept as named exports, not inline literals, so
+// they can be adjusted from outside this file without touching the algorithm.
+// -----------------------------------------------------------------------------------------------
+
+/** Below this an ear (2 km elevation preview, or corner map) stops conveying anything. ≈ today's 0.15·1080.
+ *  The single most consequential constant - design doc §7.2: decides block-vs-T across the 1024-1230 px band. */
+export const SIDE_WIDGET_MIN_WIDTH = 160
+/** Same argument, vertically. ≈ today's 0.20·480. */
+export const SIDE_WIDGET_MIN_HEIGHT = 96
+/** Gutter between the column and an ear, and between an ear and the screen edge. Matches the existing 8 dp rhythm. */
+export const SIDE_GUTTER = 8
+/** Gap between stacked occupants on the same ear, and between the column and below-arrangement widgets. */
+export const SLOT_GAP = 8
+/** The narrow-T `WorkoutDashboard` width (step 2 of the cascade, §5.1/§5.5). */
+export const WORKOUT_DASH_MIN_WIDTH = 320
+/** `WorkoutDashboard` height, as a fraction of screenHeight. */
+export const WORKOUT_DASH_HEIGHT_RATIO = 0.30
+/** Floor for `WorkoutDashboard`'s height (description + graph + next steps). */
+export const WORKOUT_DASH_MIN_HEIGHT = 120
+/** Width:height ceiling for the `live` WorkoutGraph - above ~5:1 it is a letterbox. Only affects `t-below`'s reachability (§5.6). */
+export const WORKOUT_DASH_MAX_ASPECT = 5
+/** `RideDashboard`'s height, as a fraction of screenHeight - the existing `DASHBOARD_HEIGHT` on both pages, reused not invented. */
+export const RIDE_DASH_HEIGHT_RATIO = 0.10
+/** The full-route elevation strip + Menu button bottom bar, as a fraction of screenHeight - existing `ELEVATION_FULL_HEIGHT`. */
+export const BOTTOM_BAR_RATIO = 0.12
+/** §8.2 - once an arrangement is in effect, leaving it requires clearing its boundary by this many px. */
+export const ARRANGEMENT_HYSTERESIS_PX = 24
+/** §8.2 - `dashboardItemCount` changes (the Gear tile) are only accepted after this many ms of stability. */
+export const TILE_COUNT_SETTLE_MS = 2000
+/** §3.2 - first-frame fallback tile count, before `RideDashboard`'s first `onMetrics` report. Correct for the common case (no virtual shifting). */
+export const DEFAULT_ROUTE_RIDE_TILE_COUNT = 7
+
+// -----------------------------------------------------------------------------------------------
+// §1.1 / §3.2 - `RideDashboard`'s own analytic width formula, ported (not re-measured - see design
+// doc §1.1: onLayout is unreliable under both Jest and the Storybook react-native-web renderer).
+// These constants mirror `RideDashboardView.tsx`'s own inline ones exactly; kept separate (and not
+// imported from there) because this session is scoped to the new hook only - RideDashboardView.tsx
+// is not touched here. If drift is ever suspected, `getRideDashboardWidth()` below and
+// `RideDashboardView`'s inline `metricsRowWidth` computation should be pinned against each other in
+// a test (design doc §3.2) - a natural follow-up for whichever session extracts the shared module
+// the design doc describes at `src/components/RideDashboard/width.ts`.
+// -----------------------------------------------------------------------------------------------
+
+const RIDE_DASHBOARD_SEPARATOR_WIDTH = 1
+const RIDE_DASHBOARD_CONTAINER_H_PADDING = 8
+const RIDE_DASHBOARD_COL_WIDTH_ICON_TOP = 90
+const RIDE_DASHBOARD_VALUE_SIZE = RIDE_DASHBOARD_COL_WIDTH_ICON_TOP * 0.32
+const RIDE_DASHBOARD_ICON_SIZE_LEFT = RIDE_DASHBOARD_VALUE_SIZE
+const RIDE_DASHBOARD_COL_WIDTH_ICON_LEFT = RIDE_DASHBOARD_COL_WIDTH_ICON_TOP + RIDE_DASHBOARD_ICON_SIZE_LEFT + 6
+
+/** `RideDashboard.tsx:15` - `confirmedLayout = items.length > 7 ? 'icon-top' : layout`. Both ride
+ *  pages request `icon-left`, so this is the tile count above which the layout is force-overridden
+ *  to `icon-top` regardless of what was requested. Named here (not inlined) per the "no magic
+ *  numbers" rule, even though it is existing/fixed behaviour rather than a §7 tunable. */
+export const RIDE_DASHBOARD_ICON_TOP_TILE_THRESHOLD = 7
+
+export type DashboardLayoutMode = 'icon-left' | 'icon-top'
+
+export interface RideDashboardWidthInput {
+    itemCount: number
+    layout: DashboardLayoutMode
+    compact: boolean
+    screenWidth: number
+}
+
+/** §3.2's shared pure function. Compact ⇒ `RideDashboard` is `alignSelf: 'stretch'`
+ *  (`RideDashboardView.tsx:154`), so `W_rd === screenWidth` exactly, with no side region at all
+ *  (§1.1) - this is the structural reason compact always resolves to the phone fallback. */
+export const getRideDashboardWidth = ({ itemCount, layout, compact, screenWidth }: RideDashboardWidthInput): number => {
+    if (compact) {
+        return screenWidth
+    }
+    const colWidth = layout === 'icon-left' ? RIDE_DASHBOARD_COL_WIDTH_ICON_LEFT : RIDE_DASHBOARD_COL_WIDTH_ICON_TOP
+    return itemCount * colWidth + Math.max(0, itemCount - 1) * RIDE_DASHBOARD_SEPARATOR_WIDTH + RIDE_DASHBOARD_CONTAINER_H_PADDING * 2
+}
+
+// -----------------------------------------------------------------------------------------------
+// §6.2(b) - the phone-fallback corner slot reuses the existing 2 km elevation preview box's compact
+// geometry verbatim ("Unchanged geometry"). Named here per the "no magic numbers" rule even though
+// they are pre-existing GPX/View.tsx & Video/View.tsx constants, not new §7 thresholds.
+// -----------------------------------------------------------------------------------------------
+
+export const FALLBACK_ELEVATION_WIDTH_RATIO = 0.20
+export const FALLBACK_ELEVATION_HEIGHT_RATIO = 0.12
+
+// -----------------------------------------------------------------------------------------------
+// §5.8 - output shape
+// -----------------------------------------------------------------------------------------------
+
+export type RideOverlayArrangement = 'block-side' | 't-side' | 'block-below' | 't-below' | 'fallback'
+
+export interface Rect {
+    top: number
+    left?: number
+    right?: number
+    width: number
+    height: number
+}
+
+/** Decision inputs, echoed back so session 4.1's prototype can render them on screen while tuning
+ *  (design doc §5.8: "Phase 1's own prototype sessions found layout issues precisely because the
+ *  numbers were visible"). */
+export interface RideOverlayLayoutInputs {
+    screenWidth: number
+    screenHeight: number
+    screenLayout: ScreenLayout
+    itemCount: number
+    mapVisible: boolean
+    /** W_rd - the raw analytic width `RideDashboard` renders at (may exceed screenWidth, §5.7). */
+    rideDashboardWidth: number
+    /** W_rd_eff - `min(W_rd, screenWidth)`, what the algorithm actually reasons about. */
+    rideDashboardWidthEffective: number
+    /** Whether a block (equal-width) column was geometrically possible at all (aspect ceiling, §5.2). Undefined in 'fallback'. */
+    blockPossible?: boolean
+    /** The ear/half-screen width actually tested for the winning candidate. Undefined in 'fallback'. */
+    earWidth?: number
+    /** W_wd - the `WorkoutDashboard` width used by the winning candidate. Undefined in 'fallback'. */
+    workoutDashboardWidth?: number
+}
+
+export interface RideOverlayLayout {
+    arrangement: RideOverlayArrangement
+    /** Informational - `RideDashboard` sizes itself; this is what it is expected to render at. */
+    rideDashboard: { width: number }
+    workoutDashboard: Rect | null
+    map: Rect | null
+    elevation: Rect
+    /** True iff `arrangement === 'fallback'` (§6). */
+    cornerSlotIsToggle: boolean
+    inputs: RideOverlayLayoutInputs
+}
+
+// -----------------------------------------------------------------------------------------------
+// §5.3 - per-ear fit check
+// -----------------------------------------------------------------------------------------------
+
+const earWidthOf = (screenWidth: number, columnWidth: number): number => (screenWidth - columnWidth) / 2 - SIDE_GUTTER
+
+const availableHeight = (top: number, screenHeight: number): number => screenHeight - top - BOTTOM_BAR_RATIO * screenHeight - SLOT_GAP
+
+/** Both v1 ear occupants (corner map, elevation preview) share `SIDE_WIDGET_MIN_WIDTH`/`_HEIGHT`
+ *  (design doc §7.1: "Because both v1 occupants share the same SIDE_WIDGET_MIN_WIDTH, an empty left
+ *  ear ... never changes the width verdict"), so a single width/height pair fit-checks either ear.
+ *  `relaxed` implements §8's hysteresis: the minimum is relaxed by `ARRANGEMENT_HYSTERESIS_PX` when
+ *  the candidate under test is the one currently in effect. */
+const earFits = (earWidth: number, availableHeightPx: number, relaxed: boolean): boolean => {
+    const effectiveMinWidth = SIDE_WIDGET_MIN_WIDTH - (relaxed ? ARRANGEMENT_HYSTERESIS_PX : 0)
+    return earWidth >= effectiveMinWidth && availableHeightPx >= SIDE_WIDGET_MIN_HEIGHT
+}
+
+const fitsSide = (
+    columnWidth: number,
+    decisionTop: number,
+    candidate: RideOverlayArrangement,
+    previous: RideOverlayArrangement | null | undefined,
+    screenWidth: number,
+    screenHeight: number,
+    mapVisible: boolean,
+): boolean => {
+    const ear = earWidthOf(screenWidth, columnWidth)
+    const avail = availableHeight(decisionTop, screenHeight)
+    const relaxed = candidate === previous
+    const leftOk = !mapVisible || earFits(ear, avail, relaxed) // an empty ear imposes no requirement (§5.3)
+    const rightOk = earFits(ear, avail, relaxed) // the elevation preview is always present (§1.3)
+    return leftOk && rightOk
+}
+
+const fitsBelow = (
+    decisionTop: number,
+    candidate: RideOverlayArrangement,
+    previous: RideOverlayArrangement | null | undefined,
+    screenWidth: number,
+    screenHeight: number,
+    mapVisible: boolean,
+): boolean => {
+    const half = screenWidth / 2 - SIDE_GUTTER
+    const avail = availableHeight(decisionTop, screenHeight)
+    const relaxed = candidate === previous
+    const leftOk = !mapVisible || earFits(half, avail, relaxed)
+    const rightOk = earFits(half, avail, relaxed)
+    return leftOk && rightOk
+}
+
+// -----------------------------------------------------------------------------------------------
+// Rect builders
+// -----------------------------------------------------------------------------------------------
+
+const buildWorkoutDashboardRect = (screenWidth: number, width: number, top: number, height: number): Rect => ({
+    top,
+    left: (screenWidth - width) / 2,
+    width,
+    height,
+})
+
+const buildSideRects = (
+    screenWidth: number,
+    columnWidth: number,
+    top: number,
+    mapVisible: boolean,
+): { map: Rect | null; elevation: Rect } => {
+    const ear = earWidthOf(screenWidth, columnWidth)
+    return {
+        map: mapVisible ? { top, left: 0, width: ear, height: SIDE_WIDGET_MIN_HEIGHT } : null,
+        elevation: { top, right: 0, width: ear, height: SIDE_WIDGET_MIN_HEIGHT },
+    }
+}
+
+const buildBelowRects = (
+    screenWidth: number,
+    top: number,
+    mapVisible: boolean,
+): { map: Rect | null; elevation: Rect } => {
+    const half = screenWidth / 2 - SIDE_GUTTER
+    return {
+        map: mapVisible ? { top, left: 0, width: half, height: SIDE_WIDGET_MIN_HEIGHT } : null,
+        elevation: { top, right: 0, width: half, height: SIDE_WIDGET_MIN_HEIGHT },
+    }
+}
+
+// -----------------------------------------------------------------------------------------------
+// §5.5 - the cascade itself
+// -----------------------------------------------------------------------------------------------
+
+export interface ComputeRideOverlayLayoutInput {
+    screenWidth: number
+    screenHeight: number
+    screenLayout: ScreenLayout
+    /** Defaults to `DEFAULT_ROUTE_RIDE_TILE_COUNT` (§3.2's first-frame value). */
+    itemCount?: number
+    mapVisible: boolean
+    /** Invariant 2 (§4) - refines positions only, never the arrangement decision. */
+    measuredRideDashboardHeight?: number
+    /** The arrangement currently in effect, for §8's hysteresis. `null`/`undefined` on first render. */
+    previousArrangement?: RideOverlayArrangement | null
+}
+
+const buildFallback = (
+    screenWidth: number,
+    screenHeight: number,
+    screenLayout: ScreenLayout,
+    itemCount: number,
+    mapVisible: boolean,
+    rideDashboardWidth: number,
+    measuredRideDashboardHeight: number | undefined,
+): RideOverlayLayout => {
+    const dashboardHeight = measuredRideDashboardHeight ?? RIDE_DASH_HEIGHT_RATIO * screenHeight
+    return {
+        arrangement: 'fallback',
+        rideDashboard: { width: rideDashboardWidth },
+        workoutDashboard: null, // null only for 'fallback' (§5.8)
+        map: null, // no corner map in compact (§1.3), and 'fallback' collapses the "nothing fits" case the same way
+        elevation: {
+            top: dashboardHeight,
+            right: 0,
+            width: FALLBACK_ELEVATION_WIDTH_RATIO * screenWidth,
+            height: FALLBACK_ELEVATION_HEIGHT_RATIO * screenHeight,
+        },
+        cornerSlotIsToggle: true,
+        inputs: {
+            screenWidth,
+            screenHeight,
+            screenLayout,
+            itemCount,
+            mapVisible,
+            rideDashboardWidth,
+            rideDashboardWidthEffective: Math.min(rideDashboardWidth, screenWidth),
+        },
+    }
+}
+
+/**
+ * Pure decision function - design doc §4 invariant 1: a pure function of
+ * `(screenWidth, screenHeight, screenLayout, itemCount, mapVisible)`, all synchronous. No measured
+ * value (besides the position-only refinement of invariant 2), no async value, no device query.
+ * Exported separately from the hook (§9/`useRideOverlayLayout` below) so it is directly unit
+ * testable without React rendering machinery.
+ */
+export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): RideOverlayLayout => {
+    const {
+        screenWidth,
+        screenHeight,
+        screenLayout,
+        mapVisible,
+        measuredRideDashboardHeight,
+        previousArrangement = null,
+    } = input
+    const itemCount = input.itemCount ?? DEFAULT_ROUTE_RIDE_TILE_COUNT
+
+    const dashboardLayout: DashboardLayoutMode = itemCount > RIDE_DASHBOARD_ICON_TOP_TILE_THRESHOLD ? 'icon-top' : 'icon-left'
+    const rideDashboardWidth = getRideDashboardWidth({
+        itemCount,
+        layout: dashboardLayout,
+        compact: screenLayout === 'compact',
+        screenWidth,
+    })
+
+    // §6.1 - compact is not a heuristic: RideDashboard is `alignSelf: 'stretch'` in compact, so
+    // W_rd === screenWidth and there is no side region to arrange at all.
+    if (screenLayout === 'compact') {
+        return buildFallback(screenWidth, screenHeight, screenLayout, itemCount, mapVisible, rideDashboardWidth, measuredRideDashboardHeight)
+    }
+
+    const rideDashboardWidthEffective = Math.min(rideDashboardWidth, screenWidth) // §5.7 clamp
+    const hRdEstimate = RIDE_DASH_HEIGHT_RATIO * screenHeight
+    const hRd = measuredRideDashboardHeight ?? hRdEstimate // rect positioning only (invariant 2)
+    const hWd = Math.max(WORKOUT_DASH_MIN_HEIGHT, WORKOUT_DASH_HEIGHT_RATIO * screenHeight)
+    const wWdMax = WORKOUT_DASH_MAX_ASPECT * hWd
+    const blockPossible = rideDashboardWidthEffective <= wWdMax
+
+    const baseInputs = {
+        screenWidth,
+        screenHeight,
+        screenLayout,
+        itemCount,
+        mapVisible,
+        rideDashboardWidth,
+        rideDashboardWidthEffective,
+        blockPossible,
+    }
+
+    // 1. block, side-fit
+    if (blockPossible && fitsSide(rideDashboardWidthEffective, 0, 'block-side', previousArrangement, screenWidth, screenHeight, mapVisible)) {
+        const { map, elevation } = buildSideRects(screenWidth, rideDashboardWidthEffective, 0, mapVisible)
+        return {
+            arrangement: 'block-side',
+            rideDashboard: { width: rideDashboardWidth },
+            workoutDashboard: buildWorkoutDashboardRect(screenWidth, rideDashboardWidthEffective, hRd, hWd),
+            map,
+            elevation,
+            cornerSlotIsToggle: false,
+            inputs: { ...baseInputs, earWidth: earWidthOf(screenWidth, rideDashboardWidthEffective), workoutDashboardWidth: rideDashboardWidthEffective },
+        }
+    }
+
+    // 2. T, side-fit - narrow WorkoutDashboard to buy ear width.
+    //
+    // Judgement call: the design doc's §5.5 pseudocode writes
+    // `W_wd_t = blockPossible ? WORKOUT_DASH_MIN_WIDTH : min(W_wd_max, W_rd_eff)`, but that
+    // contradicts its own §7.1 worked matrix and §5.6/§7.2 prose. The 932×430 row (blockPossible
+    // false there - W_wd_max=645 < W_rd_eff=895.6) is documented as landing in `t-side` with
+    // `ear = 298`, which only reproduces under `W_wd_t = WORKOUT_DASH_MIN_WIDTH = 320`
+    // (earWidthOf(932, 320) = 298) - the conditional branch would give `ear = 135.5` (not a fit) and
+    // wrongly fall through. Likewise §5.6's own worked 640×420 `t-below` example computes
+    // "ear at min width = 152" for a blockPossible=false screen, i.e. against 320, not against
+    // `min(W_wd_max, W_rd_eff)` = 630. §7.2 independently derives the `t-side` → `-below` boundary
+    // ("the narrowed ear fails at screenWidth < 656") by solving earWidthOf(w, 320) = 160, which
+    // only holds if W_wd_t is unconditionally WORKOUT_DASH_MIN_WIDTH. All three cross-checks agree
+    // with each other and disagree with the literal ternary, so this implementation uses
+    // `W_wd_t = WORKOUT_DASH_MIN_WIDTH` unconditionally.
+    const wWdT = WORKOUT_DASH_MIN_WIDTH
+    const tSideDecisionTop = hRdEstimate + SLOT_GAP // decision uses the estimate (invariant 2)
+    if (wWdT < rideDashboardWidthEffective && fitsSide(wWdT, tSideDecisionTop, 't-side', previousArrangement, screenWidth, screenHeight, mapVisible)) {
+        const tSideRectTop = hRd + SLOT_GAP // rect uses the measured height when available
+        const { map, elevation } = buildSideRects(screenWidth, wWdT, tSideRectTop, mapVisible)
+        return {
+            arrangement: 't-side',
+            rideDashboard: { width: rideDashboardWidth },
+            workoutDashboard: buildWorkoutDashboardRect(screenWidth, wWdT, hRd, hWd),
+            map,
+            elevation,
+            cornerSlotIsToggle: false,
+            inputs: { ...baseInputs, earWidth: earWidthOf(screenWidth, wWdT), workoutDashboardWidth: wWdT },
+        }
+    }
+
+    // 3/4. below - no reason to stay narrow unless the aspect ceiling forces it.
+    const wWdBelow = blockPossible ? rideDashboardWidthEffective : wWdMax
+    const belowLabel: RideOverlayArrangement = blockPossible ? 'block-below' : 't-below'
+    const belowDecisionTop = hRdEstimate + hWd + SLOT_GAP // decision uses the estimate (invariant 2)
+    if (fitsBelow(belowDecisionTop, belowLabel, previousArrangement, screenWidth, screenHeight, mapVisible)) {
+        const belowRectTop = hRd + hWd + SLOT_GAP
+        const { map, elevation } = buildBelowRects(screenWidth, belowRectTop, mapVisible)
+        return {
+            arrangement: belowLabel,
+            rideDashboard: { width: rideDashboardWidth },
+            workoutDashboard: buildWorkoutDashboardRect(screenWidth, wWdBelow, hRd, hWd),
+            map,
+            elevation,
+            cornerSlotIsToggle: false,
+            inputs: { ...baseInputs, earWidth: screenWidth / 2 - SIDE_GUTTER, workoutDashboardWidth: wWdBelow },
+        }
+    }
+
+    // 5. fallback
+    return buildFallback(screenWidth, screenHeight, screenLayout, itemCount, mapVisible, rideDashboardWidth, measuredRideDashboardHeight)
+}
+
+// -----------------------------------------------------------------------------------------------
+// §9 - the hook
+// -----------------------------------------------------------------------------------------------
+
+export interface UseRideOverlayLayoutInput {
+    /** From `RideDashboard`'s `onMetrics` report; defaults to `DEFAULT_ROUTE_RIDE_TILE_COUNT` (§3.2). */
+    itemCount?: number
+    /** Reserved per the design doc's §9 signature. Per §2, this hook is only ever invoked when a
+     *  workout is attached (route-only rides bypass it entirely, by construction) - so it does not
+     *  participate in the arrangement decision (§4 invariant 1 lists only screenWidth, screenHeight,
+     *  screenLayout, itemCount and mapVisible as decision inputs). Kept here for interface parity
+     *  with the design doc and as a documented assumption a caller can rely on. */
+    workoutAttached: boolean
+    mapVisible: boolean
+    measuredRideDashboardHeight?: number
+}
+
+/**
+ * Ride-screen-scoped overlay layout hook (design doc §9). Gathers `screenWidth`/`screenHeight`
+ * (`useWindowDimensions`) and `screenLayout` (`useScreenLayout`) itself, and owns:
+ *  - the §8.2 settle timer for `itemCount` (debounced 2 s of stability before a Gear-tile change is
+ *    allowed to re-flow the screen) - `screenWidth`/`screenHeight`/`mapVisible` changes are applied
+ *    immediately, with no debounce, per §8.2's table;
+ *  - the previous-arrangement ref §8's hysteresis reads.
+ *
+ * §8.1: since the arrangement is a pure function of synchronous inputs, "recompute live" is just
+ * "compute during render" - no effects or subscriptions are needed for the non-debounced inputs.
+ */
+export const useRideOverlayLayout = (input: UseRideOverlayLayoutInput): RideOverlayLayout => {
+    const { width: screenWidth, height: screenHeight } = useWindowDimensions()
+    const screenLayout = useScreenLayout()
+
+    const requestedItemCount = input.itemCount ?? DEFAULT_ROUTE_RIDE_TILE_COUNT
+    const [settledItemCount, setSettledItemCount] = useState(requestedItemCount)
+    const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+    useEffect(() => {
+        if (requestedItemCount === settledItemCount) {
+            return undefined
+        }
+        settleTimerRef.current = setTimeout(() => {
+            setSettledItemCount(requestedItemCount)
+            settleTimerRef.current = null
+        }, TILE_COUNT_SETTLE_MS)
+        return () => {
+            if (settleTimerRef.current) {
+                clearTimeout(settleTimerRef.current)
+                settleTimerRef.current = null
+            }
+        }
+    }, [requestedItemCount, settledItemCount])
+
+    const previousArrangementRef = useRef<RideOverlayArrangement | null>(null)
+
+    const layout = computeRideOverlayLayout({
+        screenWidth,
+        screenHeight,
+        screenLayout,
+        itemCount: settledItemCount,
+        mapVisible: input.mapVisible,
+        measuredRideDashboardHeight: input.measuredRideDashboardHeight,
+        previousArrangement: previousArrangementRef.current,
+    })
+
+    useEffect(() => {
+        previousArrangementRef.current = layout.arrangement
+    }, [layout.arrangement])
+
+    return layout
+}


### PR DESCRIPTION
## Summary
Session 3.2 — `useRideOverlayLayout`, the layout hook implementing `ride-overlay-layout-design.md`'s (session 1.2) 4-arrangement computation (block/T-shape × side-fit/no-fit) plus the phone-fallback threshold and runtime re-evaluation (2s settle + 24px hysteresis).

Found and fixed a real inconsistency in the design doc during implementation: §5.5's pseudocode had a conditional (`W_wd_t = blockPossible ? WORKOUT_DASH_MIN_WIDTH : min(W_wd_max, W_rd_eff)`) that contradicted the doc's own worked matrix (§7.1), §5.6, and §7.2 — all three independently only reproduce under an *unconditional* `W_wd_t = WORKOUT_DASH_MIN_WIDTH`. Implemented the unconditional form (matching all three references) and corrected the design doc itself with a dated note, so it doesn't mislead session 4.1 or later.

**Open item, deliberately not addressed here:** a later review of session 3.1 (`WorkoutDashboard`) found that widget needs to stay much more compact (≤~1.5x `RideDashboard`'s height) than this hook currently budgets for it (`WORKOUT_DASH_HEIGHT_RATIO=0.30`/`MIN_HEIGHT=120`, ~3x `RideDashboard`'s own `0.10` ratio). The repo owner explicitly deferred revisiting these constants until after seeing 3.1 rendered — noted in both the HLD and session plan as a follow-up before/during session 4.1.

## What changed
- `src/hooks/render/useRideOverlayLayout.ts` — the hook, `computeRideOverlayLayout()` (pure decision function), `getRideDashboardWidth()`, and all §7 threshold constants as named exports.
- `src/hooks/render/useRideOverlayLayout.test.ts` — 28 tests covering all 4 arrangements + fallback against the worked matrix, both invariants, and hysteresis/settle-window behavior.
- `src/hooks/render/index.ts` — barrel export.

## Test plan
- [x] `npm test` — 28/28 new tests, full suite green
- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit` — clean