### PR TITLE
Session 4.1: ride-overlay Storybook prototype + layout retune

### DIFF
--- a/src/hooks/render/useRideOverlayLayout.test.ts
+++ b/src/hooks/render/useRideOverlayLayout.test.ts
@@ -8,10 +8,18 @@ import {
     TILE_COUNT_SETTLE_MS,
     ARRANGEMENT_HYSTERESIS_PX,
     DEFAULT_ROUTE_RIDE_TILE_COUNT,
+    WORKOUT_DASH_MIN_WIDTH,
 } from './useRideOverlayLayout'
 
-// Mock useWindowDimensions the same way FilterPanel.test.tsx does, but with a mutable return value
-// so individual tests (and the hook-level rotation/resize tests) can change it between renders.
+// Retuned by session 4.1 (the Wave 4 prototype) - see `RideOverlayPrototype.stories.tsx` and HLD
+// §8. Two things changed that these tests had to follow:
+//  - the constants (SIDE_WIDGET_MIN_WIDTH 160 -> 200, WORKOUT_DASH_MIN_WIDTH 320 -> 480, the
+//    WorkoutDashboard height model, and the removal of the aspect ceiling);
+//  - the cascade's shape: the T no longer narrows WorkoutDashboard to its floor to buy ear width.
+//    Ears get their floor first and the dashboard takes the rest, so the T is shallow rather than
+//    narrow, and 'block-below'/'t-below' became a single 'column-only' that drops the corner widgets
+//    instead of relocating them under the column.
+
 const mockDimensions = { width: 1280, height: 800 }
 jest.mock('react-native/Libraries/Utilities/useWindowDimensions', () => ({
     default: jest.fn(() => mockDimensions),
@@ -23,7 +31,7 @@ const setDimensions = (width: number, height: number) => {
 }
 
 describe('getRideDashboardWidth', () => {
-    // Design doc §1.1/§7.1's worked-matrix numbers, pinned exactly.
+    // Design doc §1.1/§7.1's worked-matrix numbers, pinned exactly. Unaffected by the retune.
     it('matches the 7-tile icon-left width from the worked matrix (895.6)', () => {
         expect(getRideDashboardWidth({ itemCount: 7, layout: 'icon-left', compact: false, screenWidth: 1280 })).toBeCloseTo(895.6, 5)
     })
@@ -37,85 +45,74 @@ describe('getRideDashboardWidth', () => {
     })
 })
 
-describe('computeRideOverlayLayout - the 4 arrangements + fallback (design doc §7.1 worked matrix)', () => {
-    it('1280x800, N=7: block-side (plenty of room beside the whole block)', () => {
-        const result = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+describe('computeRideOverlayLayout - the arrangements', () => {
+    // `block-side` needs the ears to clear their floor beside the FULL-width dashboard, i.e.
+    // screenWidth >= W_rd_eff + 2*(200 + 8): 1311.6 at 7 tiles, 1159.0 at 8.
+    it('1400x900, N=7: block-side - the ears clear their floor beside the whole block', () => {
+        const result = computeRideOverlayLayout({ screenWidth: 1400, screenHeight: 900, screenLayout: 'normal', itemCount: 7, mapVisible: true })
         expect(result.arrangement).toBe('block-side')
-        expect(result.inputs.earWidth).toBeCloseTo(184.2, 5)
         expect(result.workoutDashboard?.width).toBeCloseTo(895.6, 5)
+        expect(result.inputs.earWidth).toBeCloseTo(244.2, 5)
         expect(result.map).not.toBeNull()
-        expect(result.map?.width).toBeCloseTo(184.2, 5)
-        expect(result.elevation.width).toBeCloseTo(184.2, 5)
+        expect(result.map?.top).toBe(0) // beside the whole block, from the top of the screen
         expect(result.cornerSlotIsToggle).toBe(false)
     })
 
-    it('1280x800, N=8: block-side, at the icon-top (743.0) width - adding the Gear tile narrows the dashboard', () => {
-        const result = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 8, mapVisible: true })
-        expect(result.arrangement).toBe('block-side')
-        expect(result.inputs.rideDashboardWidth).toBeCloseTo(743.0, 5)
-        expect(result.inputs.earWidth).toBeCloseTo(260.5, 5)
+    it('1280x800, N=7: t-side - a SHALLOW T (864 wide), not the old narrow 320 one', () => {
+        const result = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        expect(result.arrangement).toBe('t-side')
+        expect(result.workoutDashboard?.width).toBe(864) // 1280 - 2*(200+8)
+        expect(result.inputs.earWidth).toBe(200) // exactly the floor, by construction
+        expect(result.workoutDashboard?.width).toBeLessThan(result.inputs.rideDashboardWidthEffective)
     })
 
-    it('1194x834 (iPad Air), N=7: t-side - ear narrows below 160, WorkoutDashboard narrows to its minimum (ear -> 429)', () => {
+    it('1194x834 (iPad Air), N=7: t-side at 778 wide, ears at their floor', () => {
         const result = computeRideOverlayLayout({ screenWidth: 1194, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true })
         expect(result.arrangement).toBe('t-side')
-        expect(result.workoutDashboard?.width).toBe(320) // WORKOUT_DASH_MIN_WIDTH
-        expect(result.inputs.earWidth).toBeCloseTo(429, 5)
+        expect(result.workoutDashboard?.width).toBe(778)
+        expect(result.inputs.earWidth).toBe(200)
+        expect(result.map?.top).toBeCloseTo(91.4, 5) // below RideDashboard's bottom edge (0.10*834 + 8)
     })
 
-    it('1112x834 (iPad Pro 10.5), N=7 vs N=8: the highlighted same-device tile-count flip (t-side -> block-side)', () => {
-        const at7 = computeRideOverlayLayout({ screenWidth: 1112, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true })
-        expect(at7.arrangement).toBe('t-side')
-        expect(at7.inputs.rideDashboardWidthEffective).toBeCloseTo(895.6, 5)
-
-        const at8 = computeRideOverlayLayout({ screenWidth: 1112, screenHeight: 834, screenLayout: 'normal', itemCount: 8, mapVisible: true })
-        expect(at8.arrangement).toBe('block-side')
-        expect(at8.inputs.rideDashboardWidthEffective).toBeCloseTo(743.0, 5)
-        expect(at8.inputs.earWidth).toBeCloseTo(176.5, 5)
-    })
-
-    it('1024x768, N=7 and N=8: both land in t-side at the same narrowed ear width (344)', () => {
+    it('1024x768, N=7 and N=8: both t-side, and at the same geometry - the tile count cannot reach it', () => {
         const at7 = computeRideOverlayLayout({ screenWidth: 1024, screenHeight: 768, screenLayout: 'normal', itemCount: 7, mapVisible: true })
         const at8 = computeRideOverlayLayout({ screenWidth: 1024, screenHeight: 768, screenLayout: 'normal', itemCount: 8, mapVisible: true })
         expect(at7.arrangement).toBe('t-side')
         expect(at8.arrangement).toBe('t-side')
-        expect(at7.inputs.earWidth).toBeCloseTo(344, 5)
-        expect(at8.inputs.earWidth).toBeCloseTo(344, 5)
+        expect(at7.workoutDashboard?.width).toBe(608)
+        expect(at8.workoutDashboard?.width).toBe(608)
     })
 
-    // Judgement call (see the long comment above the `wWdT` line in useRideOverlayLayout.ts): the
-    // design doc's §5.5 pseudocode text would send this row (blockPossible === false) through
-    // `min(W_wd_max, W_rd_eff)` = 645, giving an ear of 135.5 and (wrongly) falling through to
-    // 't-below'. The doc's own §7.1 worked matrix pins this row at 't-side' with ear = 298, which
-    // only reproduces under an unconditional WORKOUT_DASH_MIN_WIDTH (320). This test locks in the
-    // worked-matrix number.
-    it('932x430 (large phone landscape), N=7: t-side despite the aspect ceiling forcing blockPossible=false (ear = 298)', () => {
+    it('932x430 (large phone landscape), N=7: t-side - the old aspect ceiling no longer forces anything', () => {
         const result = computeRideOverlayLayout({ screenWidth: 932, screenHeight: 430, screenLayout: 'normal', itemCount: 7, mapVisible: true })
-        expect(result.inputs.blockPossible).toBe(false)
         expect(result.arrangement).toBe('t-side')
-        expect(result.inputs.earWidth).toBeCloseTo(298, 5)
+        expect(result.workoutDashboard?.width).toBe(516)
+        expect(result.inputs.earWidth).toBe(200)
     })
 
-    // §5.6's reachability example: aspect ceiling forces a T (blockPossible=false) *and* the
-    // narrowed ear fails (152 < 160) - the one rare path that reaches 't-below'.
-    it('640x420, N=7: t-below - the §5.6 reachability frame', () => {
-        const result = computeRideOverlayLayout({ screenWidth: 640, screenHeight: 420, screenLayout: 'normal', itemCount: 7, mapVisible: true })
-        expect(result.inputs.rideDashboardWidthEffective).toBe(640) // clamped (§5.7) - raw W_rd (895.6) would overflow the screen
-        expect(result.inputs.blockPossible).toBe(false)
-        expect(result.arrangement).toBe('t-below')
-        expect(result.map?.left).toBe(0)
-        expect(result.elevation.right).toBe(0)
+    // Below the 't-side' floor: screenWidth < 2*(200+8) + 480 = 896. Every frame here is landscape
+    // (width > height) - the app is orientation-locked to landscape (`Loader.tsx`), so a portrait
+    // frame is not a state it can be in and must not be used to justify an arrangement.
+    it('640x430, N=7: column-only - no side arrangement fits, so the corner widgets are dropped', () => {
+        const result = computeRideOverlayLayout({ screenWidth: 640, screenHeight: 430, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        expect(result.inputs.rideDashboardWidthEffective).toBe(640) // clamped (§5.7) - raw W_rd (895.6) would overflow
+        expect(result.arrangement).toBe('column-only')
+        expect(result.workoutDashboard?.width).toBe(640) // matches the (clamped) dashboard
+        expect(result.map).toBeNull()
+        expect(result.elevation).toBeNull() // dropped, NOT relocated below the column - the main view keeps the screen
     })
 
-    // A narrow-but-tall screen: blockPossible stays true (aspect ceiling isn't the limiter), but
-    // even the minimum-width T's ear fails - the "block-below" cell of the 2x2, reached from the
-    // opposite direction to t-below.
-    it('600x800 narrow-but-tall, N=7: block-below - T narrows to its minimum but still cannot side-fit', () => {
-        const result = computeRideOverlayLayout({ screenWidth: 600, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true })
-        expect(result.inputs.blockPossible).toBe(true)
-        expect(result.arrangement).toBe('block-below')
-        expect(result.workoutDashboard?.width).toBeCloseTo(600, 5) // W_rd_eff, clamped to screenWidth
-        expect(result.map?.top).toBe(result.elevation.top)
+    it('860x480, N=7: column-only as well, just under the t-side floor', () => {
+        const result = computeRideOverlayLayout({ screenWidth: 860, screenHeight: 480, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        expect(result.arrangement).toBe('column-only')
+        expect(result.workoutDashboard?.width).toBeCloseTo(860, 5)
+        expect(result.elevation).toBeNull()
+    })
+
+    it('column-only needs no fit test - it is what is left, so it never falls through to fallback', () => {
+        const tiny = computeRideOverlayLayout({ screenWidth: 500, screenHeight: 430, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        expect(tiny.arrangement).toBe('column-only')
+        expect(tiny.workoutDashboard).not.toBeNull()
     })
 
     it('844x390 (phone landscape), any N: fallback, because screenLayout is compact', () => {
@@ -125,8 +122,36 @@ describe('computeRideOverlayLayout - the 4 arrangements + fallback (design doc �
         expect(result.workoutDashboard).toBeNull()
         expect(result.map).toBeNull()
         expect(result.cornerSlotIsToggle).toBe(true)
-        expect(result.elevation.width).toBeCloseTo(844 * 0.20, 5)
-        expect(result.elevation.height).toBeCloseTo(390 * 0.12, 5)
+        expect(result.elevation?.width).toBeCloseTo(844 * 0.20, 5)
+        expect(result.elevation?.height).toBeCloseTo(390 * 0.12, 5)
+    })
+})
+
+describe('computeRideOverlayLayout - widget sizing (session 4.1)', () => {
+    // Before the retune every ear occupant rendered at exactly SIDE_WIDGET_MIN_*, which made the
+    // elevation preview visibly smaller than on today's route-only screen (96 px tall vs 160).
+    it('renders ear occupants at today`s route-only proportions when the ear allows it', () => {
+        const result = computeRideOverlayLayout({ screenWidth: 1400, screenHeight: 900, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        expect(result.elevation?.width).toBeCloseTo(210, 5) // 0.15 * 1400
+        expect(result.elevation?.height).toBeCloseTo(180, 5) // 0.20 * 900
+    })
+
+    it('never renders an ear occupant below its floor, or wider than the ear it sits in', () => {
+        const result = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        expect(result.elevation?.width).toBe(SIDE_WIDGET_MIN_WIDTH) // 0.15*1280 = 192 would be below the floor
+        expect(result.elevation?.width as number).toBeLessThanOrEqual(result.inputs.earWidth as number)
+    })
+
+    it('keeps WorkoutDashboard`s height budget at ~1.5x RideDashboard`s, not 3x (HLD §6.2)', () => {
+        const result = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        expect(result.workoutDashboard?.height).toBe(120) // 0.15 * 800, against RideDashboard's 0.10 * 800 = 80
+    })
+
+    it('clamps WorkoutDashboard`s height on very short and very tall screens', () => {
+        const short = computeRideOverlayLayout({ screenWidth: 1024, screenHeight: 430, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const tall = computeRideOverlayLayout({ screenWidth: 1400, screenHeight: 1200, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        expect(short.workoutDashboard?.height).toBe(100) // floor - the widget's own intrinsic height
+        expect(tall.workoutDashboard?.height).toBe(160) // ceiling - its content does not grow with the screen
     })
 })
 
@@ -152,11 +177,11 @@ describe('computeRideOverlayLayout - invariants (design doc §4)', () => {
         expect(b.arrangement).toBe('fallback')
     })
 
-    // Confirmed explicitly by the design doc's own §7.1 text ("Because both v1 occupants share the
-    // same SIDE_WIDGET_MIN_WIDTH, an empty left ear ... never changes the width verdict"): the right
-    // ear (2 km elevation preview) is always occupied and uses the identical ear-width formula the
-    // left ear (corner map) would use, so in v1 the arrangement decision cannot differ by
-    // `mapVisible` - only whether the `map` rect itself is populated does.
+    // The design doc's §5.3 claimed an empty left ear would let a side arrangement fit at widths
+    // where it otherwise couldn't. It cannot, and §7.1 says so itself: both v1 occupants share the
+    // same floor, and the ears are symmetric, so the right ear alone decides. Session 4.1 dropped
+    // `mapVisible` from the fit test entirely (behaviour-identical) - it now only decides whether
+    // the `map` rect is populated.
     it('mapVisible does not change the arrangement decision in v1 - only whether `map` is populated', () => {
         const withMap = computeRideOverlayLayout({ screenWidth: 1194, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true })
         const withoutMap = computeRideOverlayLayout({ screenWidth: 1194, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: false })
@@ -169,65 +194,75 @@ describe('computeRideOverlayLayout - invariants (design doc §4)', () => {
 })
 
 describe('computeRideOverlayLayout - hysteresis (design doc §8.2)', () => {
-    // N=7, screenHeight=800 (blockPossible=true throughout) => W_rd_eff = 895.6. The unrelaxed
-    // block-side boundary is exactly at screenWidth = 895.6 + 2*(160+8) = 1231.6 (ear === 160).
-    const BOUNDARY_SCREEN_WIDTH = 1231.6
+    // N=7 => W_rd_eff = 895.6, so the unrelaxed block-side boundary is at
+    // 895.6 + 2*(200+8) = 1311.6 (ear === 200 exactly).
+    const BOUNDARY_SCREEN_WIDTH = 1311.6
 
     it('a small width change that crosses the normal boundary does NOT flip out of the active arrangement', () => {
         const result = computeRideOverlayLayout({
-            screenWidth: BOUNDARY_SCREEN_WIDTH - 12, // ear = 154, below the normal 160 minimum
-            screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true,
+            screenWidth: BOUNDARY_SCREEN_WIDTH - 12, // ear = 194, below the normal 200 floor
+            screenHeight: 900, screenLayout: 'normal', itemCount: 7, mapVisible: true,
             previousArrangement: 'block-side',
         })
-        expect(result.inputs.earWidth).toBeCloseTo(154, 5)
-        expect(result.arrangement).toBe('block-side') // relaxed minimum is 160 - 24 = 136; 154 still clears it
+        expect(result.inputs.earWidth).toBeCloseTo(194, 5)
+        expect(result.arrangement).toBe('block-side') // relaxed floor is 200 - 24 = 176; 194 still clears it
     })
 
     it('a large width change that exceeds the hysteresis cushion DOES flip', () => {
-        // Delta chosen well past the exact 48 px critical width (earWidthOf moves 1:1 with half of
-        // screenWidth, so clearing the 24 px ear cushion needs >= 48 px of screenWidth) - not the
-        // design doc's own worked number, chosen here to demonstrate the mechanism unambiguously.
-        // The 130 figure is the ear the *failed* block-side candidate would have had; the returned
-        // `inputs.earWidth` instead reflects the winning t-side candidate (WORKOUT_DASH_MIN_WIDTH-based).
+        // earWidthOf moves at half the rate of screenWidth, so clearing the 24 px ear cushion needs
+        // >= 48 px of screenWidth; 60 is comfortably past it.
         const result = computeRideOverlayLayout({
-            screenWidth: BOUNDARY_SCREEN_WIDTH - 60, // block-side's ear would be 130, below even the relaxed 136 minimum
-            screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true,
+            screenWidth: BOUNDARY_SCREEN_WIDTH - 60, // block-side's ear would be 170, below even the relaxed 176
+            screenHeight: 900, screenLayout: 'normal', itemCount: 7, mapVisible: true,
             previousArrangement: 'block-side',
         })
         expect(result.arrangement).toBe('t-side')
-        expect(result.inputs.workoutDashboardWidth).toBe(320) // WORKOUT_DASH_MIN_WIDTH
     })
 
-    it('with no previous arrangement (first render), the normal (unrelaxed) minimum applies', () => {
+    it('with no previous arrangement (first render), the normal (unrelaxed) floor applies', () => {
         const result = computeRideOverlayLayout({
-            screenWidth: BOUNDARY_SCREEN_WIDTH - 12, // ear = 154 - would stay under hysteresis, but there is no "previous" to relax for
-            screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true,
+            screenWidth: BOUNDARY_SCREEN_WIDTH - 12, // would stay under hysteresis, but there is no "previous" to relax for
+            screenHeight: 900, screenLayout: 'normal', itemCount: 7, mapVisible: true,
             previousArrangement: null,
         })
         expect(result.arrangement).toBe('t-side')
     })
 
-    // Design doc §8.2's own worked example: at 1112x834, 7->8 tiles takes the ear from 100.2 to
-    // 176.5 (clears 160, flips to block-side); 8->7 takes it back to 100.2, which is below even the
-    // relaxed 136 minimum, so it flips straight back - hysteresis alone does not prevent
-    // gear-tile-flap oscillation, the settle window (tested below, at the hook level) is what does.
-    it('the 1112px 7<->8 flip: hysteresis protects the marginal case but not this large a swing', () => {
-        const to8 = computeRideOverlayLayout({
-            screenWidth: 1112, screenHeight: 834, screenLayout: 'normal', itemCount: 8, mapVisible: true, previousArrangement: 't-side',
+    it('relaxes the t-side/below boundary too, not just block-side/t-side', () => {
+        // t-side needs screenWidth >= 2*(floor+8) + WORKOUT_DASH_MIN_WIDTH: 896 unrelaxed, 848 relaxed.
+        const cold = computeRideOverlayLayout({ screenWidth: 870, screenHeight: 600, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const warm = computeRideOverlayLayout({
+            screenWidth: 870, screenHeight: 600, screenLayout: 'normal', itemCount: 7, mapVisible: true, previousArrangement: 't-side',
         })
-        expect(to8.arrangement).toBe('block-side')
+        expect(cold.arrangement).toBe('column-only')
+        expect(warm.arrangement).toBe('t-side')
+        expect(warm.workoutDashboard?.width).toBe(WORKOUT_DASH_MIN_WIDTH + 22) // 870 - 2*(176+8)
+    })
 
-        const backTo7 = computeRideOverlayLayout({
-            screenWidth: 1112, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true, previousArrangement: 'block-side',
-        })
-        expect(backTo7.arrangement).toBe('t-side')
+    // Session 4.1's headline OQ5 finding: on most screens the Gear tile can no longer change the
+    // arrangement at all, because in a T the geometry is derived from screenWidth, not from W_rd.
+    it('the 1112px 7<->8 tile flip no longer changes anything (it flipped t-side<->block-side before)', () => {
+        const at7 = computeRideOverlayLayout({ screenWidth: 1112, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const at8 = computeRideOverlayLayout({ screenWidth: 1112, screenHeight: 834, screenLayout: 'normal', itemCount: 8, mapVisible: true })
+        expect(at7.arrangement).toBe('t-side')
+        expect(at8.arrangement).toBe('t-side')
+        expect(at8.workoutDashboard?.width).toBe(at7.workoutDashboard?.width)
+    })
+
+    // It is not gone everywhere though - the settle window still earns its keep in the band where
+    // the 8-tile dashboard clears the block-side boundary and the 7-tile one doesn't (1159..1311.6).
+    it('a tile-count flip can still change the arrangement inside the 1159-1311.6 band', () => {
+        const at7 = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const at8 = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 8, mapVisible: true })
+        expect(at7.arrangement).toBe('t-side')
+        expect(at8.arrangement).toBe('block-side')
     })
 })
 
 describe('useRideOverlayLayout - the hook', () => {
     beforeEach(() => {
         jest.useFakeTimers()
-        setDimensions(1112, 834)
+        setDimensions(1280, 800)
     })
 
     afterEach(() => {
@@ -294,7 +329,7 @@ describe('useRideOverlayLayout - the hook', () => {
         const { result, rerender } = renderHook(() => useRideOverlayLayout({ itemCount: 7, workoutAttached: true, mapVisible: true }), { initialProps: {} })
         expect(result.current.arrangement).toBe('t-side')
 
-        act(() => { setDimensions(1280, 800) })
+        act(() => { setDimensions(1400, 900) })
         rerender({})
         expect(result.current.arrangement).toBe('block-side')
     })
@@ -303,31 +338,32 @@ describe('useRideOverlayLayout - the hook', () => {
         const { result, rerender } = renderHook(() => useRideOverlayLayout({ itemCount: 7, workoutAttached: true, mapVisible: true }), { initialProps: {} })
         expect(result.current.arrangement).toBe('t-side')
 
-        // Settle a few px past the exact 1231.6 block-side boundary first (a small margin avoids
+        // Settle a few px past the exact 1311.6 block-side boundary first (a small margin avoids
         // floating-point noise right at the boundary - 124.8 * 7 does not land on an exact double).
-        const SETTLED_WIDTH = 1231.6 + 4
-        act(() => { setDimensions(SETTLED_WIDTH, 800) })
+        const SETTLED_WIDTH = 1311.6 + 4
+        act(() => { setDimensions(SETTLED_WIDTH, 900) })
         rerender({})
         expect(result.current.arrangement).toBe('block-side')
 
         // A 12px shrink crosses the *normal* boundary but must be absorbed by the 24px cushion,
         // since block-side is now the active (previous) arrangement.
-        act(() => { setDimensions(SETTLED_WIDTH - 12, 800) })
+        act(() => { setDimensions(SETTLED_WIDTH - 12, 900) })
         rerender({})
         expect(result.current.arrangement).toBe('block-side')
 
         // A larger shrink exceeds the cushion and genuinely flips.
-        act(() => { setDimensions(SETTLED_WIDTH - 60, 800) })
+        act(() => { setDimensions(SETTLED_WIDTH - 60, 900) })
         rerender({})
         expect(result.current.arrangement).toBe('t-side')
     })
 })
 
-// Sanity check the arrangement type union stays in sync with what the pure function actually returns.
+// Sanity check the arrangement type union stays in sync with what the pure function actually
+// returns. Four values since session 4.1 replaced 'block-below'/'t-below' with 'column-only'.
 describe('RideOverlayArrangement', () => {
-    it('covers exactly the 5 cells the design doc defines', () => {
-        const all: RideOverlayArrangement[] = ['block-side', 't-side', 'block-below', 't-below', 'fallback']
-        expect(all).toHaveLength(5)
+    it('covers exactly the 4 arrangements the tuned algorithm produces', () => {
+        const all: RideOverlayArrangement[] = ['block-side', 't-side', 'column-only', 'fallback']
+        expect(all).toHaveLength(4)
     })
 })
 

--- a/src/hooks/render/useRideOverlayLayout.ts
+++ b/src/hooks/render/useRideOverlayLayout.ts
@@ -13,28 +13,62 @@ import { useScreenLayout, ScreenLayout } from './useScreenLayout'
 // construction rather than by proving numeric equivalence with it.
 
 // -----------------------------------------------------------------------------------------------
-// §7 - threshold constants. These are v1 hypotheses ("starting hypothesis", design doc §7), meant
-// to be tuned by session 4.1 against real renders - kept as named exports, not inline literals, so
-// they can be adjusted from outside this file without touching the algorithm.
+// §7 - threshold constants.
+//
+// TUNED BY SESSION 4.1 (2026-08-11) against real renders - see `RideOverlayPrototype.stories.tsx`
+// and HLD §8's resolution table. The values below are the resolved ones; each carries the
+// hypothesis it replaced and why. Still exported as named constants rather than inlined.
 // -----------------------------------------------------------------------------------------------
 
-/** Below this an ear (2 km elevation preview, or corner map) stops conveying anything. ≈ today's 0.15·1080.
- *  The single most consequential constant - design doc §7.2: decides block-vs-T across the 1024-1230 px band. */
-export const SIDE_WIDGET_MIN_WIDTH = 160
-/** Same argument, vertically. ≈ today's 0.20·480. */
+/** Floor width for an ear occupant (2 km elevation preview, or corner map).
+ *
+ *  **Tuned 160 → 200 (session 4.1).** `SideWidgetWidthRuler` renders the real elevation preview at
+ *  140/160/184/200/220: at 160 the five x-axis tick labels collide into unreadable mush, at 184 the
+ *  first two still touch, and 200 is the first width where the preview reads as a distance-to-climb
+ *  graph rather than a coloured smear. (Only residual defect at 200: the leading tick carries the
+ *  unit - "9.8km" - and touches its neighbour. That is a label-formatting artifact of
+ *  `ElevationGraphAxes`, noted as an independent finding, not a reason to demand 220.) */
+export const SIDE_WIDGET_MIN_WIDTH = 200
+/** Same argument, vertically. ≈ today's 0.20·480. Unchanged - it is rarely the binding test. */
 export const SIDE_WIDGET_MIN_HEIGHT = 96
+/** Preferred ear-occupant width, as a fraction of screenWidth - today's `screenWidth * 0.15` on both
+ *  ride pages. Added by session 4.1: the ear is often much wider than the floor, and the previous
+ *  code rendered every widget at exactly `SIDE_WIDGET_MIN_*`, which visibly shrank the elevation
+ *  preview compared with today's route-only screen. The widget now renders at today's proportions
+ *  where they fit, and only falls back toward the floor when the ear is tight. */
+export const SIDE_WIDGET_WIDTH_RATIO = 0.15
+/** Preferred ear-occupant height, as a fraction of screenHeight - today's `ELEVATION_PREVIEW_HEIGHT`
+ *  (`screenHeight * 0.20`) on both ride pages. Same reasoning as `SIDE_WIDGET_WIDTH_RATIO`. */
+export const SIDE_WIDGET_HEIGHT_RATIO = 0.2
 /** Gutter between the column and an ear, and between an ear and the screen edge. Matches the existing 8 dp rhythm. */
 export const SIDE_GUTTER = 8
-/** Gap between stacked occupants on the same ear, and between the column and below-arrangement widgets. */
+/** Gap between stacked occupants on the same ear, and between `RideDashboard` and the ear below it. */
 export const SLOT_GAP = 8
-/** The narrow-T `WorkoutDashboard` width (step 2 of the cascade, §5.1/§5.5). */
-export const WORKOUT_DASH_MIN_WIDTH = 320
-/** `WorkoutDashboard` height, as a fraction of screenHeight. */
-export const WORKOUT_DASH_HEIGHT_RATIO = 0.30
-/** Floor for `WorkoutDashboard`'s height (description + graph + next steps). */
-export const WORKOUT_DASH_MIN_HEIGHT = 120
-/** Width:height ceiling for the `live` WorkoutGraph - above ~5:1 it is a letterbox. Only affects `t-below`'s reachability (§5.6). */
-export const WORKOUT_DASH_MAX_ASPECT = 5
+/** Floor width for `WorkoutDashboard` - below this the T stops being worth having and the corner
+ *  widgets are dropped instead ('column-only').
+ *
+ *  **Tuned 320 → 480 (session 4.1).** The 320 hypothesis was derived from `WorkoutStepsList`'s
+ *  compact width plus a graph Y axis, which predates session 3.1's rework into a three-column bar
+ *  (text row, then graph | steps | controls). `WorkoutDashboardWidthRuler` renders that real widget
+ *  at 320/400/480/560/640: at 320 the text bar truncates mid-sentence and the steps column collapses
+ *  to "2…", at 400 everything fits but the countdown crowds the progress marker, and 480 is the
+ *  first width where both rows read cleanly. */
+export const WORKOUT_DASH_MIN_WIDTH = 480
+/** `WorkoutDashboard` height, as a fraction of screenHeight.
+ *
+ *  **Tuned 0.30 → 0.15 (session 4.1)**, resolving the open question HLD §6.2 carried forward. 0.30
+ *  was ~3x `RIDE_DASH_HEIGHT_RATIO` and allocated ~240 px on a 1280×800 tablet to a widget that
+ *  renders at ~95 px - visible in the pre-retune `-below` renders as a ~145 px void between the
+ *  column and the widgets. 0.15 is exactly §6.2's "roughly ≤1.5x `RideDashboard`'s own height" rule
+ *  expressed as a ratio, so the rule now lives in the constant rather than in prose. */
+export const WORKOUT_DASH_HEIGHT_RATIO = 0.15
+/** Floor for `WorkoutDashboard`'s height (text bar + graph/steps row). Tuned 120 → 100: the widget's
+ *  own intrinsic height is ~78 (compact graph) to ~95 (normal), so 100 is a true floor rather than
+ *  an over-allocation. */
+export const WORKOUT_DASH_MIN_HEIGHT = 100
+/** Ceiling for `WorkoutDashboard`'s height. Added by session 4.1 alongside the ratio change: the
+ *  widget's content is fixed-height, so on a tall screen the ratio must stop growing the box. */
+export const WORKOUT_DASH_MAX_HEIGHT = 160
 /** `RideDashboard`'s height, as a fraction of screenHeight - the existing `DASHBOARD_HEIGHT` on both pages, reused not invented. */
 export const RIDE_DASH_HEIGHT_RATIO = 0.10
 /** The full-route elevation strip + Menu button bottom bar, as a fraction of screenHeight - existing `ELEVATION_FULL_HEIGHT`. */
@@ -103,7 +137,27 @@ export const FALLBACK_ELEVATION_HEIGHT_RATIO = 0.12
 // §5.8 - output shape
 // -----------------------------------------------------------------------------------------------
 
-export type RideOverlayArrangement = 'block-side' | 't-side' | 'block-below' | 't-below' | 'fallback'
+/**
+ * HLD §5.3 names four arrangements. Session 4.1's prototype replaced both `-below` ones with a
+ * single `'column-only'`, in two steps:
+ *
+ *  - `block-below` and `t-below` rendered 10 px apart and were indistinguishable. `-below` is only
+ *    reached when no side arrangement fits, i.e.
+ *    `screenWidth < 2·(SIDE_WIDGET_MIN_WIDTH + SIDE_GUTTER) + WORKOUT_DASH_MIN_WIDTH`, and in that
+ *    whole regime `WorkoutDashboard` takes `W_rd_eff` either way. `WORKOUT_DASH_MAX_ASPECT` - the
+ *    only thing that made them differ - is gone with them (see the constant block above).
+ *  - Dropping the corner widgets *below* the column was then rejected outright on review
+ *    (repo owner, 2026-08-11): on the narrow screens this arrangement occurs on, a full-width row of
+ *    map + elevation directly under a full-width dashboard column leaves the Video/GPX main view -
+ *    which is the point of a route ride - as a sliver. The corner widgets are auxiliary, so on a
+ *    screen with no room for them beside the column they are **dropped, not relocated**. HLD §5.3's
+ *    "drop below the block/column, split left/right of the screen" is superseded.
+ *
+ * `'column-only'` therefore renders the two dashboards over an unobstructed main view. It needs no
+ * fit test - it is what is left when nothing else fits - so `'fallback'` is now reached only via
+ * compact, which §6.1 already called its dominant path.
+ */
+export type RideOverlayArrangement = 'block-side' | 't-side' | 'column-only' | 'fallback'
 
 export interface Rect {
     top: number
@@ -126,8 +180,6 @@ export interface RideOverlayLayoutInputs {
     rideDashboardWidth: number
     /** W_rd_eff - `min(W_rd, screenWidth)`, what the algorithm actually reasons about. */
     rideDashboardWidthEffective: number
-    /** Whether a block (equal-width) column was geometrically possible at all (aspect ceiling, §5.2). Undefined in 'fallback'. */
-    blockPossible?: boolean
     /** The ear/half-screen width actually tested for the winning candidate. Undefined in 'fallback'. */
     earWidth?: number
     /** W_wd - the `WorkoutDashboard` width used by the winning candidate. Undefined in 'fallback'. */
@@ -140,7 +192,8 @@ export interface RideOverlayLayout {
     rideDashboard: { width: number }
     workoutDashboard: Rect | null
     map: Rect | null
-    elevation: Rect
+    /** Null in `'column-only'`, where both corner widgets are dropped rather than relocated. */
+    elevation: Rect | null
     /** True iff `arrangement === 'fallback'` (§6). */
     cornerSlotIsToggle: boolean
     inputs: RideOverlayLayoutInputs
@@ -154,51 +207,24 @@ const earWidthOf = (screenWidth: number, columnWidth: number): number => (screen
 
 const availableHeight = (top: number, screenHeight: number): number => screenHeight - top - BOTTOM_BAR_RATIO * screenHeight - SLOT_GAP
 
-/** Both v1 ear occupants (corner map, elevation preview) share `SIDE_WIDGET_MIN_WIDTH`/`_HEIGHT`
- *  (design doc §7.1: "Because both v1 occupants share the same SIDE_WIDGET_MIN_WIDTH, an empty left
- *  ear ... never changes the width verdict"), so a single width/height pair fit-checks either ear.
- *  `relaxed` implements §8's hysteresis: the minimum is relaxed by `ARRANGEMENT_HYSTERESIS_PX` when
- *  the candidate under test is the one currently in effect. */
-const earFits = (earWidth: number, availableHeightPx: number, relaxed: boolean): boolean => {
-    const effectiveMinWidth = SIDE_WIDGET_MIN_WIDTH - (relaxed ? ARRANGEMENT_HYSTERESIS_PX : 0)
-    return earWidth >= effectiveMinWidth && availableHeightPx >= SIDE_WIDGET_MIN_HEIGHT
-}
+const clamp = (value: number, min: number, max: number): number => Math.min(Math.max(value, min), max)
 
-const fitsSide = (
-    columnWidth: number,
-    decisionTop: number,
+/** §8's hysteresis: the ear floor is relaxed by `ARRANGEMENT_HYSTERESIS_PX` when the candidate under
+ *  test is the one currently in effect, so a marginal screen doesn't flip back and forth. Both
+ *  boundaries the cascade tests (block↔T and T↔below) are monotonic in this floor, so relaxing it is
+ *  all the hysteresis the algorithm needs. */
+const earFloorFor = (
     candidate: RideOverlayArrangement,
     previous: RideOverlayArrangement | null | undefined,
-    screenWidth: number,
-    screenHeight: number,
-    mapVisible: boolean,
-): boolean => {
-    const ear = earWidthOf(screenWidth, columnWidth)
-    const avail = availableHeight(decisionTop, screenHeight)
-    const relaxed = candidate === previous
-    const leftOk = !mapVisible || earFits(ear, avail, relaxed) // an empty ear imposes no requirement (§5.3)
-    const rightOk = earFits(ear, avail, relaxed) // the elevation preview is always present (§1.3)
-    return leftOk && rightOk
-}
-
-const fitsBelow = (
-    decisionTop: number,
-    candidate: RideOverlayArrangement,
-    previous: RideOverlayArrangement | null | undefined,
-    screenWidth: number,
-    screenHeight: number,
-    mapVisible: boolean,
-): boolean => {
-    const half = screenWidth / 2 - SIDE_GUTTER
-    const avail = availableHeight(decisionTop, screenHeight)
-    const relaxed = candidate === previous
-    const leftOk = !mapVisible || earFits(half, avail, relaxed)
-    const rightOk = earFits(half, avail, relaxed)
-    return leftOk && rightOk
-}
+): number => SIDE_WIDGET_MIN_WIDTH - (candidate === previous ? ARRANGEMENT_HYSTERESIS_PX : 0)
 
 // -----------------------------------------------------------------------------------------------
 // Rect builders
+//
+// Session 4.1: the widgets render at today's route-only proportions (`SIDE_WIDGET_*_RATIO`) wherever
+// those fit, and shrink toward the floor only when the ear is tight. The previous version rendered
+// every widget at exactly `SIDE_WIDGET_MIN_*`, which made the elevation preview visibly smaller than
+// on today's route-only screen (96 px tall against today's 160 on a 1280×800 tablet).
 // -----------------------------------------------------------------------------------------------
 
 const buildWorkoutDashboardRect = (screenWidth: number, width: number, top: number, height: number): Rect => ({
@@ -208,28 +234,28 @@ const buildWorkoutDashboardRect = (screenWidth: number, width: number, top: numb
     height,
 })
 
+const sideWidgetSize = (
+    screenWidth: number,
+    screenHeight: number,
+    earWidth: number,
+    top: number,
+): { width: number; height: number } => ({
+    width: clamp(SIDE_WIDGET_WIDTH_RATIO * screenWidth, SIDE_WIDGET_MIN_WIDTH, earWidth),
+    height: clamp(SIDE_WIDGET_HEIGHT_RATIO * screenHeight, SIDE_WIDGET_MIN_HEIGHT, availableHeight(top, screenHeight)),
+})
+
 const buildSideRects = (
     screenWidth: number,
+    screenHeight: number,
     columnWidth: number,
     top: number,
     mapVisible: boolean,
 ): { map: Rect | null; elevation: Rect } => {
     const ear = earWidthOf(screenWidth, columnWidth)
+    const { width, height } = sideWidgetSize(screenWidth, screenHeight, ear, top)
     return {
-        map: mapVisible ? { top, left: 0, width: ear, height: SIDE_WIDGET_MIN_HEIGHT } : null,
-        elevation: { top, right: 0, width: ear, height: SIDE_WIDGET_MIN_HEIGHT },
-    }
-}
-
-const buildBelowRects = (
-    screenWidth: number,
-    top: number,
-    mapVisible: boolean,
-): { map: Rect | null; elevation: Rect } => {
-    const half = screenWidth / 2 - SIDE_GUTTER
-    return {
-        map: mapVisible ? { top, left: 0, width: half, height: SIDE_WIDGET_MIN_HEIGHT } : null,
-        elevation: { top, right: 0, width: half, height: SIDE_WIDGET_MIN_HEIGHT },
+        map: mapVisible ? { top, left: 0, width, height } : null,
+        elevation: { top, right: 0, width, height },
     }
 }
 
@@ -319,9 +345,7 @@ export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): 
     const rideDashboardWidthEffective = Math.min(rideDashboardWidth, screenWidth) // §5.7 clamp
     const hRdEstimate = RIDE_DASH_HEIGHT_RATIO * screenHeight
     const hRd = measuredRideDashboardHeight ?? hRdEstimate // rect positioning only (invariant 2)
-    const hWd = Math.max(WORKOUT_DASH_MIN_HEIGHT, WORKOUT_DASH_HEIGHT_RATIO * screenHeight)
-    const wWdMax = WORKOUT_DASH_MAX_ASPECT * hWd
-    const blockPossible = rideDashboardWidthEffective <= wWdMax
+    const hWd = clamp(WORKOUT_DASH_HEIGHT_RATIO * screenHeight, WORKOUT_DASH_MIN_HEIGHT, WORKOUT_DASH_MAX_HEIGHT)
 
     const baseInputs = {
         screenWidth,
@@ -331,12 +355,37 @@ export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): 
         mapVisible,
         rideDashboardWidth,
         rideDashboardWidthEffective,
-        blockPossible,
     }
 
-    // 1. block, side-fit
-    if (blockPossible && fitsSide(rideDashboardWidthEffective, 0, 'block-side', previousArrangement, screenWidth, screenHeight, mapVisible)) {
-        const { map, elevation } = buildSideRects(screenWidth, rideDashboardWidthEffective, 0, mapVisible)
+    // -------------------------------------------------------------------------------------------
+    // Session 4.1 reshaped steps 1-2. The design doc's cascade tried a full-width block first and,
+    // when it didn't fit, narrowed `WorkoutDashboard` all the way to `WORKOUT_DASH_MIN_WIDTH` to buy
+    // ear width. Rendered (the `TSide` story at 1194×834, before tuning) that read badly: the widget
+    // the rider deliberately attached ended up the NARROWEST thing in its own row, truncated to
+    // "…VO2 ma…" and "2…", while the two auxiliary widgets took 429 px each.
+    //
+    // Replaced by one continuous allocation, evaluated once:
+    //
+    //     W_wd = min(W_rd_eff, screenWidth - 2·(earFloor + SIDE_GUTTER))
+    //
+    // i.e. the ears get their floor first, `WorkoutDashboard` takes everything that is left up to
+    // `RideDashboard`'s width, and any surplus beyond that goes back to the ears. `block` vs `T` is
+    // then a DESCRIPTION of the result (did the dashboard reach `RideDashboard`'s width?) rather
+    // than a separate candidate to test - which is also what makes the two share a single code path.
+    //
+    // Two consequences worth knowing when reading the tests:
+    //  - the T is now shallow, not narrow: 1194×834 gives W_wd = 778 rather than 320;
+    //  - because W_wd is capped by screenWidth-derived terms in the T, the Gear tile (N 7↔8, which
+    //    moves W_rd by 152 px) usually cannot change the layout at all - see §8's note in HLD §8.
+    // -------------------------------------------------------------------------------------------
+
+    // 1/2. side arrangements
+    const blockEarFloor = earFloorFor('block-side', previousArrangement)
+    const blockEar = earWidthOf(screenWidth, rideDashboardWidthEffective)
+    const blockFits = blockEar >= blockEarFloor && availableHeight(0, screenHeight) >= SIDE_WIDGET_MIN_HEIGHT
+
+    if (blockFits) {
+        const { map, elevation } = buildSideRects(screenWidth, screenHeight, rideDashboardWidthEffective, 0, mapVisible)
         return {
             arrangement: 'block-side',
             rideDashboard: { width: rideDashboardWidth },
@@ -344,30 +393,16 @@ export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): 
             map,
             elevation,
             cornerSlotIsToggle: false,
-            inputs: { ...baseInputs, earWidth: earWidthOf(screenWidth, rideDashboardWidthEffective), workoutDashboardWidth: rideDashboardWidthEffective },
+            inputs: { ...baseInputs, earWidth: blockEar, workoutDashboardWidth: rideDashboardWidthEffective },
         }
     }
 
-    // 2. T, side-fit - narrow WorkoutDashboard to buy ear width.
-    //
-    // Judgement call: the design doc's §5.5 pseudocode writes
-    // `W_wd_t = blockPossible ? WORKOUT_DASH_MIN_WIDTH : min(W_wd_max, W_rd_eff)`, but that
-    // contradicts its own §7.1 worked matrix and §5.6/§7.2 prose. The 932×430 row (blockPossible
-    // false there - W_wd_max=645 < W_rd_eff=895.6) is documented as landing in `t-side` with
-    // `ear = 298`, which only reproduces under `W_wd_t = WORKOUT_DASH_MIN_WIDTH = 320`
-    // (earWidthOf(932, 320) = 298) - the conditional branch would give `ear = 135.5` (not a fit) and
-    // wrongly fall through. Likewise §5.6's own worked 640×420 `t-below` example computes
-    // "ear at min width = 152" for a blockPossible=false screen, i.e. against 320, not against
-    // `min(W_wd_max, W_rd_eff)` = 630. §7.2 independently derives the `t-side` → `-below` boundary
-    // ("the narrowed ear fails at screenWidth < 656") by solving earWidthOf(w, 320) = 160, which
-    // only holds if W_wd_t is unconditionally WORKOUT_DASH_MIN_WIDTH. All three cross-checks agree
-    // with each other and disagree with the literal ternary, so this implementation uses
-    // `W_wd_t = WORKOUT_DASH_MIN_WIDTH` unconditionally.
-    const wWdT = WORKOUT_DASH_MIN_WIDTH
+    const tEarFloor = earFloorFor('t-side', previousArrangement)
+    const wWdT = Math.min(rideDashboardWidthEffective, screenWidth - 2 * (tEarFloor + SIDE_GUTTER))
     const tSideDecisionTop = hRdEstimate + SLOT_GAP // decision uses the estimate (invariant 2)
-    if (wWdT < rideDashboardWidthEffective && fitsSide(wWdT, tSideDecisionTop, 't-side', previousArrangement, screenWidth, screenHeight, mapVisible)) {
+    if (wWdT >= WORKOUT_DASH_MIN_WIDTH && availableHeight(tSideDecisionTop, screenHeight) >= SIDE_WIDGET_MIN_HEIGHT) {
         const tSideRectTop = hRd + SLOT_GAP // rect uses the measured height when available
-        const { map, elevation } = buildSideRects(screenWidth, wWdT, tSideRectTop, mapVisible)
+        const { map, elevation } = buildSideRects(screenWidth, screenHeight, wWdT, tSideRectTop, mapVisible)
         return {
             arrangement: 't-side',
             rideDashboard: { width: rideDashboardWidth },
@@ -379,26 +414,18 @@ export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): 
         }
     }
 
-    // 3/4. below - no reason to stay narrow unless the aspect ceiling forces it.
-    const wWdBelow = blockPossible ? rideDashboardWidthEffective : wWdMax
-    const belowLabel: RideOverlayArrangement = blockPossible ? 'block-below' : 't-below'
-    const belowDecisionTop = hRdEstimate + hWd + SLOT_GAP // decision uses the estimate (invariant 2)
-    if (fitsBelow(belowDecisionTop, belowLabel, previousArrangement, screenWidth, screenHeight, mapVisible)) {
-        const belowRectTop = hRd + hWd + SLOT_GAP
-        const { map, elevation } = buildBelowRects(screenWidth, belowRectTop, mapVisible)
-        return {
-            arrangement: belowLabel,
-            rideDashboard: { width: rideDashboardWidth },
-            workoutDashboard: buildWorkoutDashboardRect(screenWidth, wWdBelow, hRd, hWd),
-            map,
-            elevation,
-            cornerSlotIsToggle: false,
-            inputs: { ...baseInputs, earWidth: screenWidth / 2 - SIDE_GUTTER, workoutDashboardWidth: wWdBelow },
-        }
+    // 3. column-only - the two dashboards, and nothing else on top of the main view. No fit test:
+    // this is what is left when neither side arrangement fits, and the corner widgets are dropped
+    // rather than relocated (see `RideOverlayArrangement`'s doc comment).
+    return {
+        arrangement: 'column-only',
+        rideDashboard: { width: rideDashboardWidth },
+        workoutDashboard: buildWorkoutDashboardRect(screenWidth, rideDashboardWidthEffective, hRd, hWd),
+        map: null,
+        elevation: null,
+        cornerSlotIsToggle: false,
+        inputs: { ...baseInputs, workoutDashboardWidth: rideDashboardWidthEffective },
     }
-
-    // 5. fallback
-    return buildFallback(screenWidth, screenHeight, screenLayout, itemCount, mapVisible, rideDashboardWidth, measuredRideDashboardHeight)
 }
 
 // -----------------------------------------------------------------------------------------------

--- a/src/pages/RidePage/RideOverlayPrototype.stories.tsx
+++ b/src/pages/RidePage/RideOverlayPrototype.stories.tsx
@@ -1,0 +1,945 @@
+import React from 'react';
+import { View, Text, StyleSheet, Pressable, Image } from 'react-native';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import type { ActivityDashboardItem } from 'incyclist-services';
+import { FreeMap } from '../../components/FreeMap';
+import { RideDashboardView } from '../../components/RideDashboard/RideDashboardView';
+import { WorkoutDashboard } from '../../components/WorkoutDashboard';
+import { ElevationGraphView } from '../../components/ElevationGraph/ElevationGraphView';
+import { computeGraphPoints } from '../../components/ElevationGraph/utils';
+import { WorkoutGraphView } from '../../components/WorkoutGraph/WorkoutGraphView';
+import { Icon } from '../../components/Icon';
+import {
+    computeRideOverlayLayout,
+    RideOverlayLayout,
+    SIDE_WIDGET_MIN_WIDTH,
+    BOTTOM_BAR_RATIO,
+} from '../../hooks/render/useRideOverlayLayout';
+import { MOCK_DASHBOARD_MID_INTERVAL } from '../../components/WorkoutDashboard/WorkoutDashboard.mock';
+import { colors, textSizes } from '../../theme';
+import teideRoute from '../../../__tests__/testdata/ES_Teide.json';
+
+/**
+ * Session 4.1 — the Wave 4 visual checkpoint for the combined route+workout ride screen
+ * (`workout-mobile-hld-phase2.md` §5.3/§5.4/§6.3, `ride-overlay-layout-design.md` §5–§8).
+ * Mirrors Phase 1's 4.1/4.2 prototype sessions: a PROTOTYPE assembled inside the story file,
+ * not a page. No service, no gestures, no `RideMenu`, no navigation — the real page assembly
+ * is session 5.1, the real Stop-Workout control is 5.3.
+ *
+ * It exists to answer HLD §8's open questions 1–4 and 6 against actual renders — all six are now
+ * resolved there, and the constants in `useRideOverlayLayout.ts` were retuned as a result, so these
+ * stories are also the regression reference for what "right" looks like:
+ *
+ * | OQ | What this file shows |
+ * |---|---|
+ * | 1 — thresholds | every arrangement at the exact screen size that triggers it, with the decision inputs printed on screen (`ride-overlay-layout-design.md` §5.8's `inputs`), plus `SideWidgetWidthRuler` for eyeballing `SIDE_WIDGET_MIN_WIDTH` directly |
+ * | 2 — Map/Elevation side | `sideAssignment` arg swaps the two ears |
+ * | 3 — Stop-Workout | `stopMechanism` renders the dedicated button and the long-press affordance side by side, in every arrangement including the fallback (§6.5: the fallback is the binding constraint) |
+ * | 4 — WorkoutDashboard graph | `graphMode` switches `strip` ↔ `live` at the block width and at the T width — `live` is what ruled itself out here |
+ * | 6 — gear-shift room | `showGearGhost` draws a hypothetical shift control in the slot §8.6 settled on (under a corner widget, not beside `RideDashboard` — where it collides), and `workoutAttached: false` gives the route-only variant HLD §6.4 requires it to be judged against |
+ *
+ * ## Why the layout is computed, not hooked
+ *
+ * Stories render into fixed dp frames, but `useRideOverlayLayout()` reads the real browser
+ * window via `useWindowDimensions()`. So the prototype calls the hook's exported pure core,
+ * `computeRideOverlayLayout()`, with the frame's own size — same "computed, not measured"
+ * approach `RideDashboardView` uses for its shoutout width, and the same pure-view rule Phase
+ * 1's prototypes followed. The arrangement decision is bit-identical to what the hook produces
+ * at that window size (`ride-overlay-layout-design.md` §4, invariant 1).
+ *
+ * Known story-only caveat, inherited from Phase 1's 4.2 prototype: `RideDashboardView` reads
+ * `useWindowDimensions()` for its COMPACT column math, so the fallback stories' dashboard only
+ * sizes correctly when the browser viewport matches the frame. Non-compact stories are
+ * unaffected (their column widths are fixed dp).
+ */
+
+// ---------------------------------------------------------------------------
+// Mock data
+// ---------------------------------------------------------------------------
+
+/** A route ride's 7 always-on tiles (`services` `buildDashboardInfo`: 6 base + Slope). */
+const ROUTE_TILES_7: ActivityDashboardItem[] = [
+    { title: 'Time', data: [{ value: '0:24:18' }, { value: '-1:05:42' }] },
+    { title: 'Distance', data: [{ value: '11.4', unit: 'km' }, { value: '-28.6' }] },
+    { title: 'Speed', data: [{ value: '28.6', unit: 'km/h' }, { value: '55.0', label: 'max' }] },
+    { title: 'Power', data: [{ value: '243', unit: 'W' }, { value: '218', label: 'avg' }] },
+    { title: 'Slope', data: [{ value: '4.2', unit: '%' }, { value: '318', label: 'gain', unit: 'm' }] },
+    { title: 'Heartrate', data: [{ value: '156', unit: 'bpm' }, { value: '148', label: 'avg' }] },
+    { title: 'Cadence', data: [{ value: '88', unit: 'rpm' }, { value: '86', label: 'avg' }] },
+];
+
+/** The 8th tile appears mid-ride, the first time virtual shifting reports a gear string
+ *  (`ride-overlay-layout-design.md` §1.2) — the concrete driver of HLD Open Question 5. */
+const ROUTE_TILES_8: ActivityDashboardItem[] = [
+    ...ROUTE_TILES_7,
+    { title: 'Gear', data: [{ value: '10' }] },
+];
+
+const ROUTE_DATA = teideRoute as never;
+
+/** Slot height for the two width-ruler stories - the ear-occupant floor, so the ruler judges width
+ *  at the height these widgets are actually guaranteed. */
+const RULER_SLOT_HEIGHT = 96;
+
+/**
+ * Rendered heights of `RideDashboardView`, measured in the browser (2026-08-11) rather than assumed.
+ * The `icon-top` stack (icon ABOVE value above the secondary row) is 40% taller than `icon-left`'s —
+ * which matters because the Gear tile forces `icon-top`, so the dashboard gets both narrower AND
+ * taller the moment virtual shifting reports a gear.
+ *
+ * The real pages already measure this with `onLayout` and feed it to the hook as
+ * `measuredRideDashboardHeight` (design doc §4, invariant 2: measured heights refine positions,
+ * never the arrangement). The prototype substitutes the observed value for the same reason. Using
+ * the algorithm's own `RIDE_DASH_HEIGHT_RATIO` estimate instead puts `WorkoutDashboard` 13 px INTO
+ * the dashboard on an 8-tile frame — see HLD §8.7 finding 5.
+ */
+const OBSERVED_RIDE_DASH_HEIGHT = { 'icon-left': 66, 'icon-top': 93, compact: 41 } as const;
+
+// ---------------------------------------------------------------------------
+// Prototype view
+// ---------------------------------------------------------------------------
+
+type BackdropKind = 'map' | 'streetview' | 'video';
+type StopMechanism = 'none' | 'button' | 'longpress';
+type SideAssignment = 'map-left' | 'map-right';
+
+interface RideOverlayPrototypeProps {
+    /** Fixed device-frame size (dp) — fed to `computeRideOverlayLayout` in place of the window. */
+    frameWidth: number;
+    frameHeight: number;
+    /** 7 = no virtual shifting, 8 = Gear tile present. Toggling these two is HLD OQ5's live check. */
+    itemCount: number;
+    /** GPX main view (`map`/`streetview`) or a Video ride. Drives `mapVisible` — a full-screen map
+     *  makes the corner orientation map redundant (`ride-overlay-layout-design.md` §1.3.1). */
+    backdrop: BackdropKind;
+    /** false → the route-only screen exactly as it renders today (HLD §9.1's "identical to today"). */
+    workoutAttached: boolean;
+    stopMechanism: StopMechanism;
+    /** HLD OQ2. */
+    sideAssignment: SideAssignment;
+    /** HLD OQ4 — the graph inside `WorkoutDashboard`. */
+    graphMode: 'strip' | 'live';
+    /** The fallback corner slot's state (`ride-overlay-layout-design.md` §6.2(b)). */
+    cornerSlot: 'elevation' | 'workout';
+    /** HLD OQ6 — a hypothetical (NOT built) gear-shift trigger, to check the arrangement leaves room. */
+    showGearGhost: boolean;
+    /** §5.8's `inputs`, rendered on screen: Phase 1 found layout issues precisely because the
+     *  numbers were visible. */
+    showDebug: boolean;
+}
+
+const RideOverlayPrototypeView = (props: RideOverlayPrototypeProps) => {
+    const {
+        frameWidth,
+        frameHeight,
+        itemCount,
+        backdrop,
+        workoutAttached,
+        stopMechanism,
+        sideAssignment,
+        graphMode,
+        cornerSlot,
+        showGearGhost,
+        showDebug,
+    } = props;
+
+    const compact = frameHeight < 420; // useScreenLayout()'s own rule
+    const mapVisible = !compact && backdrop !== 'map';
+
+    const items = itemCount > 7 ? ROUTE_TILES_8 : ROUTE_TILES_7;
+    // `RideDashboard.tsx:15` overrides the requested layout to 'icon-top' above 7 tiles; the
+    // prototype uses the pure View (which has no such override) so it has to apply it itself -
+    // otherwise the 8-tile frame renders 1006 px wide while the layout algorithm reasons about 743.
+    const dashboardLayout = itemCount > 7 ? 'icon-top' : 'icon-left';
+    const dashboardHeight = compact ? OBSERVED_RIDE_DASH_HEIGHT.compact : OBSERVED_RIDE_DASH_HEIGHT[dashboardLayout];
+    const bottomBarHeight = BOTTOM_BAR_RATIO * frameHeight;
+
+    const layout = computeRideOverlayLayout({
+        screenWidth: frameWidth,
+        screenHeight: frameHeight,
+        screenLayout: compact ? 'compact' : 'normal',
+        itemCount,
+        mapVisible,
+        measuredRideDashboardHeight: dashboardHeight,
+    });
+
+    return (
+        <View style={[styles.frame, { width: frameWidth, height: frameHeight }]}>
+            <Backdrop kind={backdrop} />
+
+            {/* --- RideDashboard: top, centered, unchanged from today ------------------- */}
+            <View style={[styles.dashboardContainer, compact ? styles.dashboardCompact : styles.dashboardTablet]}>
+                <RideDashboardView items={items} layout={dashboardLayout} compact={compact} />
+            </View>
+
+            {workoutAttached ? (
+                <WorkoutOverlay
+                    layout={layout}
+                    frameWidth={frameWidth}
+                    frameHeight={frameHeight}
+                    compact={compact}
+                    graphMode={graphMode}
+                    cornerSlot={cornerSlot}
+                    sideAssignment={sideAssignment}
+                    stopMechanism={stopMechanism}
+                    showGearGhost={showGearGhost}
+                    dashboardHeight={dashboardHeight}
+                />
+            ) : (
+                <RouteOnlyOverlay
+                    frameWidth={frameWidth}
+                    frameHeight={frameHeight}
+                    compact={compact}
+                    mapVisible={mapVisible}
+                    showGearGhost={showGearGhost}
+                />
+            )}
+
+            {/* --- Bottom bar: Menu + full-route elevation strip. Untouched by this phase. */}
+            <View style={[styles.bottomBar, { height: bottomBarHeight }]}>
+                <View style={styles.menuButton}>
+                    <Text style={styles.menuButtonText}>Menu</Text>
+                </View>
+                <ElevationGraphView
+                    width={frameWidth - 90}
+                    height={bottomBarHeight}
+                    showLine
+                    showColors
+                    showXAxis={false}
+                    showYAxis={false}
+                    {...computeGraphPoints(ROUTE_DATA, frameWidth - 90, bottomBarHeight, {})}
+                />
+            </View>
+
+            {showDebug && <DebugPanel layout={layout} bottom={bottomBarHeight + 4} />}
+        </View>
+    );
+};
+
+// ---------------------------------------------------------------------------
+// Overlay pieces
+// ---------------------------------------------------------------------------
+
+interface WorkoutOverlayProps {
+    layout: RideOverlayLayout;
+    frameWidth: number;
+    frameHeight: number;
+    compact: boolean;
+    graphMode: 'strip' | 'live';
+    cornerSlot: 'elevation' | 'workout';
+    sideAssignment: SideAssignment;
+    stopMechanism: StopMechanism;
+    showGearGhost: boolean;
+    /** Observed, not estimated - see `OBSERVED_RIDE_DASH_HEIGHT`. */
+    dashboardHeight: number;
+}
+
+const WorkoutOverlay = (props: WorkoutOverlayProps) => {
+    const { layout, frameWidth, frameHeight, compact, graphMode, cornerSlot, sideAssignment, stopMechanism, showGearGhost, dashboardHeight } = props;
+    const { arrangement, workoutDashboard, map, elevation } = layout;
+
+    // OQ2 — the two ears are geometrically identical, so swapping is purely which occupant goes
+    // where. `map-right` mirrors both rects rather than re-running the algorithm.
+    const mapRect = map && (sideAssignment === 'map-left' ? map : mirror(map));
+    const elevationRect = elevation && (arrangement === 'fallback' || sideAssignment === 'map-left' ? elevation : mirror(elevation));
+
+    return (
+        <>
+            {/* --- WorkoutDashboard ------------------------------------------------------ */}
+            {workoutDashboard && (
+                <View
+                    testID="proto-workout-dashboard"
+                    style={[
+                        styles.absolute,
+                        {
+                            top: workoutDashboard.top,
+                            left: workoutDashboard.left,
+                            width: workoutDashboard.width,
+                            maxHeight: workoutDashboard.height,
+                        },
+                    ]}
+                >
+                    <WorkoutDashboard
+                        {...MOCK_DASHBOARD_MID_INTERVAL}
+                        graphMode={graphMode}
+                        compact={compact}
+                        controls={stopMechanism === 'button' ? <StopWorkoutButton compact={compact} /> : undefined}
+                    />
+                </View>
+            )}
+
+            {/* --- Corner map ------------------------------------------------------------ */}
+            {mapRect && (
+                <View testID="proto-corner-map" style={[styles.cornerWidget, rectStyle(mapRect)]}>
+                    <FreeMap points={(ROUTE_DATA as { points: never[] }).points} draggable={false} followPosition />
+                </View>
+            )}
+
+            {/* --- 2 km elevation preview, or the fallback's 2-way toggle slot. Absent entirely in
+                    'column-only', where both corner widgets are dropped so the Video/GPX main view
+                    keeps the screen (repo-owner review, 2026-08-11). -------------------------- */}
+            {elevationRect && (
+            <View testID="proto-elevation" style={[styles.cornerWidget, rectStyle(elevationRect)]}>
+                {layout.cornerSlotIsToggle && cornerSlot === 'workout' ? (
+                    <WorkoutGraphView
+                        width={elevationRect.width}
+                        height={elevationRect.height}
+                        mode="live"
+                        plan={MOCK_DASHBOARD_MID_INTERVAL.graph}
+                        actuals={MOCK_DASHBOARD_MID_INTERVAL.actuals}
+                        showAxes={false}
+                        showFtpLine
+                    />
+                ) : (
+                    <ElevationGraphView
+                        width={elevationRect.width}
+                        height={elevationRect.height}
+                        showLine
+                        showColors
+                        showXAxis={!compact}
+                        showYAxis={!compact}
+                        {...computeGraphPoints(ROUTE_DATA, elevationRect.width, elevationRect.height, {
+                            range: 2000,
+                            position: 10000,
+                        })}
+                    />
+                )}
+            </View>
+            )}
+
+            {/* --- §5.4's unconditional single-line current-step description (fallback only) */}
+            {arrangement === 'fallback' && (
+                <View style={[styles.absolute, styles.fallbackShoutout, { top: dashboardHeight }]}>
+                    <Text style={styles.fallbackShoutoutText} numberOfLines={1}>
+                        {MOCK_DASHBOARD_MID_INTERVAL.line.text}
+                    </Text>
+                </View>
+            )}
+
+            {/* --- Stop-Workout, mechanism B: no persistent control, a long-press hint ---- */}
+            {stopMechanism === 'longpress' && <LongPressAffordance frameHeight={frameHeight} compact={compact} />}
+
+            {/* --- Stop-Workout, mechanism A, in the fallback: there is no WorkoutDashboard
+                    to host the button (§6.5), so it needs its own slot mirroring the corner one. */}
+            {stopMechanism === 'button' && arrangement === 'fallback' && (
+                <View style={[styles.absolute, styles.fallbackStopSlot, { top: dashboardHeight + 26 }]}>
+                    <StopWorkoutButton compact={compact} />
+                </View>
+            )}
+
+            {/* --- OQ6: hypothetical gear-shift trigger, NOT part of this phase. Drawn as a third
+                    stacked ear occupant, under the corner widget — the only place with room, since
+                    both top corners are already spoken for and `RideDashboard` is the widest thing
+                    on screen. The fallback's corner slot works the same way, with less room below. */}
+            {showGearGhost && elevationRect && <GearShiftGhost top={elevationRect.top + elevationRect.height + 8} compact={compact} />}
+
+            <ArrangementBadge arrangement={arrangement} width={frameWidth} />
+        </>
+    );
+};
+
+/** The screen exactly as it renders today for a route-only ride — the HLD §6.4 / OQ6 comparison
+ *  case, and the "route-only rendering is untouched" reference (HLD §9.1). Reproduces
+ *  `GPX/View.tsx`'s own `cornerTopOffset` math verbatim rather than using the new algorithm,
+ *  which route-only rides deliberately bypass (`ride-overlay-layout-design.md` §2). */
+const RouteOnlyOverlay = ({
+    frameWidth,
+    frameHeight,
+    compact,
+    mapVisible,
+    showGearGhost,
+}: {
+    frameWidth: number;
+    frameHeight: number;
+    compact: boolean;
+    mapVisible: boolean;
+    showGearGhost: boolean;
+}) => {
+    const elevationPreviewHeight = frameHeight * 0.2;
+    const elevationFullHeight = frameHeight * 0.12;
+    const dashboardHeight = frameHeight * 0.1;
+    const reservedRight = frameWidth * (compact ? 0.2 : 0.15);
+    // Today's over-conservative check (`ride-overlay-layout-design.md` §1.4): both widths are
+    // reserved on the right even though the map sits left.
+    const dashboardRightEdge = frameWidth / 2 + 895.6 / 2;
+    const cornerTopOffset = dashboardRightEdge > frameWidth - reservedRight ? dashboardHeight + 2 : 0;
+    const previewHeight = compact ? elevationFullHeight : elevationPreviewHeight;
+
+    return (
+        <>
+            {mapVisible && (
+                <View
+                    style={[
+                        styles.cornerWidget,
+                        styles.cornerLeft,
+                        { top: cornerTopOffset, width: frameWidth * 0.15, height: elevationPreviewHeight },
+                    ]}
+                >
+                    <FreeMap points={(ROUTE_DATA as { points: never[] }).points} draggable={false} followPosition />
+                </View>
+            )}
+            <View
+                style={[
+                    styles.cornerWidget,
+                    styles.cornerRight,
+                    {
+                        top: compact ? dashboardHeight : cornerTopOffset,
+                        width: reservedRight,
+                        height: previewHeight,
+                    },
+                ]}
+            >
+                <ElevationGraphView
+                    width={reservedRight}
+                    height={previewHeight}
+                    showLine
+                    showColors
+                    showXAxis={!compact}
+                    showYAxis={!compact}
+                    {...computeGraphPoints(ROUTE_DATA, reservedRight, previewHeight, { range: 2000, position: 10000 })}
+                />
+            </View>
+            {showGearGhost && (
+                <GearShiftGhost
+                    top={(compact ? dashboardHeight : cornerTopOffset) + previewHeight + 8}
+                    compact={compact}
+                />
+            )}
+            <ArrangementBadge arrangement="route-only (today's layout)" width={frameWidth} />
+        </>
+    );
+};
+
+// ---------------------------------------------------------------------------
+// Small prototype-only widgets
+// ---------------------------------------------------------------------------
+
+/** Mechanism A. Deliberately small and single-purpose — sized against `WorkoutDashboard`'s
+ *  reserved third column (session 3.1), not the app's standard `Button` (32/16 dp padding,
+ *  far too big for that slot). Hit target is kept ≥44 dp in the tappable axis. */
+const StopWorkoutButton = ({ compact }: { compact: boolean }) => (
+    <Pressable style={[styles.stopButton, compact && styles.stopButtonCompact]} onPress={noop}>
+        <View style={styles.stopGlyph} />
+        <Text style={[styles.stopLabel, compact && styles.stopLabelCompact]}>Stop{'\n'}Workout</Text>
+    </Pressable>
+);
+
+/** Mechanism B. A long-press has no resting visual, so the only thing to judge is the
+ *  discoverability affordance it needs — shown here in its most generous form (a persistent
+ *  hint strip), plus the confirmation toast the gesture would have to raise. */
+const LongPressAffordance = ({ frameHeight, compact }: { frameHeight: number; compact: boolean }) => (
+    <>
+        <View style={[styles.absolute, styles.longPressHint, { bottom: BOTTOM_BAR_RATIO * frameHeight + 8 }]}>
+            <Text style={[styles.longPressHintText, compact && styles.longPressHintTextCompact]}>
+                Long-press anywhere to stop the workout
+            </Text>
+        </View>
+        <View style={[styles.absolute, styles.longPressToast, { top: frameHeight * 0.45 }]}>
+            <Text style={styles.longPressToastText}>Hold to stop workout… 1.2s</Text>
+        </View>
+    </>
+);
+
+/** HLD OQ6 — NOT built this phase. A plausible two-button shifter drawn where it would most
+ *  likely live: immediately beside `RideDashboard`, which is the widest thing on screen. */
+const GearShiftGhost = ({ top, compact }: { top: number; compact: boolean }) => (
+    <View style={[styles.absolute, styles.gearGhost, { top }]}>
+        <View style={[styles.gearGhostButton, compact && styles.gearGhostButtonCompact]}>
+            <Icon name="chevron-up" size={compact ? 16 : 22} color={colors.text} />
+        </View>
+        <View style={styles.gearGhostLabel}>
+            <Icon name="gear" size={compact ? 14 : 18} color={colors.text} />
+            <Text style={styles.gearGhostText}>10</Text>
+        </View>
+        <View style={[styles.gearGhostButton, compact && styles.gearGhostButtonCompact]}>
+            <Icon name="chevron-down" size={compact ? 16 : 22} color={colors.text} />
+        </View>
+    </View>
+);
+
+/**
+ * The full-screen main view the overlay floats on. Video and StreetView use the same
+ * `/screenshot.jpg` placeholder photo `VideoRidePage`'s own story uses (repo-owner request,
+ * 2026-08-11) — a flat colour makes every widget look legible, and the real question here is whether
+ * the translucent widget backgrounds (`rgba(0,0,0,0.45)`) hold up over actual ride imagery.
+ */
+const Backdrop = ({ kind }: { kind: BackdropKind }) => {
+    if (kind === 'map') {
+        return (
+            <View style={styles.backdrop}>
+                <FreeMap points={(ROUTE_DATA as { points: never[] }).points} draggable={false} followPosition />
+            </View>
+        );
+    }
+    return (
+        <View style={styles.backdrop}>
+            <Image source={{ uri: '/screenshot.jpg' }} style={StyleSheet.absoluteFill} resizeMode="cover" />
+            <Text style={styles.backdropText}>{kind === 'video' ? 'Video' : 'StreetView'}</Text>
+        </View>
+    );
+};
+
+const ArrangementBadge = ({ arrangement, width }: { arrangement: string; width: number }) => (
+    <View style={[styles.absolute, styles.badge, { maxWidth: width }]}>
+        <Text style={styles.badgeText}>{arrangement}</Text>
+    </View>
+);
+
+/** `ride-overlay-layout-design.md` §5.8 — the decision inputs, on screen, while tuning. */
+const DebugPanel = ({ layout, bottom }: { layout: RideOverlayLayout; bottom: number }) => {
+    const i = layout.inputs;
+    const round = (v?: number) => (v === undefined ? '—' : Math.round(v * 10) / 10);
+    return (
+        <View style={[styles.absolute, styles.debug, { bottom }]}>
+            <Text style={styles.debugText}>
+                {i.screenWidth}×{i.screenHeight} ({i.screenLayout}) · N={i.itemCount} · map={String(i.mapVisible)}
+            </Text>
+            <Text style={styles.debugText}>
+                W_rd={round(i.rideDashboardWidth)} → eff {round(i.rideDashboardWidthEffective)}
+            </Text>
+            <Text style={styles.debugText}>
+                ear={round(i.earWidth)} (min {SIDE_WIDGET_MIN_WIDTH}) · W_wd={round(i.workoutDashboardWidth)}
+            </Text>
+        </View>
+    );
+};
+
+const noop = () => undefined;
+
+const mirror = <T extends { left?: number; right?: number }>(rect: T): T => ({
+    ...rect,
+    left: rect.right,
+    right: rect.left,
+});
+
+const rectStyle = (rect: { top: number; left?: number; right?: number; width: number; height: number }) => ({
+    top: rect.top,
+    left: rect.left,
+    right: rect.right,
+    width: rect.width,
+    height: rect.height,
+});
+
+// ---------------------------------------------------------------------------
+// Stories
+//
+// Frames are chosen by which ARRANGEMENT they trigger, not by device tier — the whole point of
+// §5.2's computed fit-check. `ride-overlay-layout-design.md` §7.1's worked matrix is the source
+// for each size; the debug panel on each story shows the numbers that produced the verdict.
+// ---------------------------------------------------------------------------
+
+const meta: Meta<typeof RideOverlayPrototypeView> = {
+    title: 'Pages/RidePage/RideOverlayPrototype',
+    component: RideOverlayPrototypeView,
+    args: {
+        itemCount: 7,
+        backdrop: 'video',
+        workoutAttached: true,
+        stopMechanism: 'none',
+        sideAssignment: 'map-left',
+        graphMode: 'strip',
+        cornerSlot: 'elevation',
+        showGearGhost: false,
+        showDebug: true,
+    },
+    argTypes: {
+        backdrop: { control: 'inline-radio', options: ['map', 'streetview', 'video'] },
+        stopMechanism: { control: 'inline-radio', options: ['none', 'button', 'longpress'] },
+        sideAssignment: { control: 'inline-radio', options: ['map-left', 'map-right'] },
+        graphMode: { control: 'inline-radio', options: ['strip', 'live'] },
+        cornerSlot: { control: 'inline-radio', options: ['elevation', 'workout'] },
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof RideOverlayPrototypeView>;
+
+const frame = (width: number, height: number) => ({ frameWidth: width, frameHeight: height });
+
+/** `block-side` needs `screenWidth ≥ W_rd_eff + 2·(200 + 8)` = 1311.6 at 7 tiles, so a large
+ *  landscape tablet: 1400×900, ears 244. The roomiest arrangement. */
+export const BlockSide: Story = { args: { ...frame(1400, 900) } };
+
+/** 1194×834 (iPad Air) — the common tablet case. The ears take their 200 px floor and
+ *  `WorkoutDashboard` takes the remaining 778: a SHALLOW T, not the narrow 320 one the untuned
+ *  cascade produced (that render is what drove the retune — see the file header). */
+export const TSide: Story = { args: { ...frame(1194, 834) } };
+
+/** A small landscape tablet: 860×480. Below the `t-side` floor (`2·(200+8) + 480` = 896), so the
+ *  corner map and elevation preview are **dropped** — relocating them under the column (the design
+ *  doc's original `-below`) left the Video/GPX main view as a sliver, and the main view is the point
+ *  of a route ride (repo-owner review, 2026-08-11). Note the `RideDashboard` overflow — a
+ *  pre-existing bug (`ride-overlay-layout-design.md` §5.7), left visible rather than hidden. */
+export const ColumnOnly: Story = { args: { ...frame(860, 480) } };
+
+/** The same arrangement on the narrowest landscape frame that is still non-compact. */
+export const ColumnOnlyNarrow: Story = { args: { ...frame(640, 430) } };
+
+/** §6.1 — a landscape phone (844×390 → compact). No side region exists at all: `RideDashboard`
+ *  is `alignSelf:'stretch'`, so the arrangement is the §5.4 fallback by construction. */
+export const Fallback: Story = { args: { ...frame(844, 390) } };
+
+/** The same phone with §5.4's corner slot toggled to the workout graph. */
+export const FallbackWorkoutSlot: Story = { args: { ...frame(844, 390), cornerSlot: 'workout' } };
+
+/**
+ * HLD Open Question 5, live. The Gear tile appears mid-ride and makes `RideDashboard` 152 px
+ * NARROWER (it forces `icon-top`). 1280×800 sits inside the only band where that still changes
+ * the arrangement — 1159 ≤ screenWidth < 1311.6 — so this pair is the worst case the settle
+ * window has to absorb. Compare with `Oq5GearOn`. On 1112×834 (the design doc's own example)
+ * the retuned algorithm produces the identical layout at 7 and 8 tiles.
+ */
+export const Oq5GearOff: Story = { args: { ...frame(1280, 800), itemCount: 7 } };
+
+/** The other half of the OQ5 pair — same screen, Gear tile present: `t-side` → `block-side`. */
+export const Oq5GearOn: Story = { args: { ...frame(1280, 800), itemCount: 8 } };
+
+/** OQ2 — the same frame with the ears swapped. */
+export const BlockSideMapRight: Story = { args: { ...frame(1400, 900), sideAssignment: 'map-right' } };
+
+/** OQ4 — the `live` graph mode inside `WorkoutDashboard` at the generous block width. */
+export const BlockSideLiveGraph: Story = { args: { ...frame(1400, 900), graphMode: 'live' } };
+
+/** OQ4's hard case — `live` mode at the narrow-T width (320 px). */
+export const TSideLiveGraph: Story = { args: { ...frame(1194, 834), graphMode: 'live' } };
+
+/** OQ3, mechanism A, roomiest arrangement — the button in `WorkoutDashboard`'s reserved column. */
+export const StopButtonBlockSide: Story = { args: { ...frame(1400, 900), stopMechanism: 'button' } };
+
+/** OQ3, mechanism A, tightest non-fallback arrangement — the T, where the reserved column has to
+ *  share the width with the graph and the steps list. */
+export const StopButtonTSide: Story = { args: { ...frame(1194, 834), stopMechanism: 'button' } };
+
+/** OQ3, mechanism A, at the narrowest width `WorkoutDashboard` is ever asked to render
+ *  (`WORKOUT_DASH_MIN_WIDTH` = 480, reached just above the `below` boundary). */
+export const StopButtonMinWidth: Story = { args: { ...frame(900, 800), stopMechanism: 'button' } };
+
+/** OQ3, mechanism A, §6.5's binding constraint — the fallback has no `WorkoutDashboard` at all,
+ *  so the button needs a slot of its own. */
+export const StopButtonFallback: Story = { args: { ...frame(844, 390), stopMechanism: 'button' } };
+
+/** OQ3, mechanism B — long-press, with the discoverability hint it would need. */
+export const StopLongPressBlockSide: Story = { args: { ...frame(1400, 900), stopMechanism: 'longpress' } };
+
+/** OQ3, mechanism B on the phone — the same hint competing with the fallback's own additions. */
+export const StopLongPressFallback: Story = { args: { ...frame(844, 390), stopMechanism: 'longpress' } };
+
+/** OQ6 — a hypothetical gear-shift trigger on the combined screen, drawn in the slot session 4.1
+ *  recommends: a third stacked occupant in an ear, under the corner widget. */
+export const GearGhostTSide: Story = { args: { ...frame(1194, 834), showGearGhost: true } };
+
+/** OQ6, the case HLD §6.4 actually requires: the same trigger on a ROUTE-ONLY ride, which is
+ *  where a shifter is relevant with or without a workout. */
+export const GearGhostRouteOnly: Story = {
+    args: { ...frame(1194, 834), showGearGhost: true, workoutAttached: false },
+};
+
+/** OQ6 on a phone route-only ride — the tightest case for a shift control. */
+export const GearGhostRouteOnlyPhone: Story = {
+    args: { ...frame(844, 390), showGearGhost: true, workoutAttached: false, backdrop: 'map' },
+};
+
+/** The route-only reference render (HLD §9.1: "must render identically to today"). */
+export const RouteOnly: Story = { args: { ...frame(1400, 900), workoutAttached: false } };
+
+/** A GPX ride whose main view IS a map — the corner map is redundant, so the left ear is empty
+ *  (`ride-overlay-layout-design.md` §1.3.1/§5.3). */
+export const BlockSideNoCornerMap: Story = { args: { ...frame(1400, 900), backdrop: 'map' } };
+
+/** A StreetView GPX ride (session 0.3's corner map) — both ears occupied. */
+export const TSideStreetViewGpx: Story = { args: { ...frame(1194, 834), backdrop: 'streetview' } };
+
+/**
+ * OQ1's direct instrument. `SIDE_WIDGET_MIN_WIDTH` = 160 is the single most consequential
+ * constant (§7.2: it decides block-vs-T across the 1024–1230 px band, where most Incyclist
+ * tablet users are). This renders the two real ear occupants at candidate widths so the claim
+ * "below this it stops conveying anything" can be checked rather than assumed.
+ */
+export const SideWidgetWidthRuler = {
+    render: () => (
+        <View style={styles.ruler}>
+            {[140, 160, 184, 200, 220].map(width => (
+                <View key={width} style={styles.rulerCol}>
+                    <Text style={styles.rulerLabel}>{width} px</Text>
+                    <View style={[styles.cornerWidget, styles.rulerSlot, { width }]}>
+                        <ElevationGraphView
+                            width={width}
+                            height={RULER_SLOT_HEIGHT}
+                            showLine
+                            showColors
+                            showXAxis
+                            showYAxis
+                            {...computeGraphPoints(ROUTE_DATA, width, RULER_SLOT_HEIGHT, { range: 2000, position: 10000 })}
+                        />
+                    </View>
+                    <View style={[styles.cornerWidget, styles.rulerSlot, { width }]}>
+                        <FreeMap points={(ROUTE_DATA as { points: never[] }).points} draggable={false} followPosition />
+                    </View>
+                </View>
+            ))}
+        </View>
+    ),
+};
+
+/**
+ * The other half of OQ1. `WORKOUT_DASH_MIN_WIDTH` = 320 was derived (§7's table) from
+ * `WorkoutStepsList`'s compact width plus room for a graph Y axis — but that predates session
+ * 3.1's rework into a three-column bar (text row + graph | steps | controls). This renders the
+ * real widget at candidate widths so the floor can be set from what stays readable, not from
+ * the superseded composition.
+ */
+export const WorkoutDashboardWidthRuler = {
+    render: () => (
+        <View style={styles.rulerColumn}>
+            {[320, 400, 480, 560, 640].map(width => (
+                <View key={width} style={styles.rulerRow}>
+                    <Text style={styles.rulerLabel}>{width}</Text>
+                    <View style={{ width }}>
+                        <WorkoutDashboard {...MOCK_DASHBOARD_MID_INTERVAL} />
+                    </View>
+                </View>
+            ))}
+        </View>
+    ),
+};
+
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+    frame: {
+        alignSelf: 'flex-start',
+        overflow: 'hidden',
+        borderWidth: 1,
+        borderColor: 'rgba(255,255,255,0.25)',
+        backgroundColor: colors.background,
+    },
+    absolute: {
+        position: 'absolute',
+    },
+    backdrop: {
+        ...StyleSheet.absoluteFillObject,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    backdropText: {
+        color: 'rgba(255,255,255,0.5)',
+        fontSize: 20,
+        fontWeight: '700',
+    },
+    dashboardContainer: {
+        position: 'absolute',
+        top: 0,
+        zIndex: 10,
+    },
+    dashboardCompact: {
+        left: 0,
+        right: 0,
+    },
+    dashboardTablet: {
+        left: 0,
+        right: 0,
+        alignItems: 'center',
+    },
+    cornerLeft: {
+        left: 0,
+    },
+    cornerRight: {
+        right: 0,
+    },
+    cornerWidget: {
+        position: 'absolute',
+        backgroundColor: 'rgba(0,0,0,0.45)',
+        borderRadius: 4,
+        overflow: 'hidden',
+        zIndex: 10,
+    },
+    bottomBar: {
+        position: 'absolute',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        flexDirection: 'row',
+        alignItems: 'center',
+        zIndex: 5,
+    },
+    menuButton: {
+        width: 82,
+        paddingHorizontal: 8,
+        paddingVertical: 10,
+        marginHorizontal: 4,
+        borderRadius: 8,
+        backgroundColor: colors.buttonPrimary,
+        alignItems: 'center',
+    },
+    menuButtonText: {
+        color: colors.text,
+        fontWeight: '700',
+    },
+    fallbackShoutout: {
+        left: 0,
+        right: 0,
+        alignItems: 'center',
+        zIndex: 11,
+    },
+    fallbackShoutoutText: {
+        color: colors.text,
+        backgroundColor: 'rgba(0,0,0,0.45)',
+        fontWeight: '700',
+        fontSize: textSizes.subtitle,
+        paddingHorizontal: 8,
+        paddingVertical: 2,
+    },
+    fallbackStopSlot: {
+        left: 8,
+        zIndex: 11,
+    },
+    stopButton: {
+        minWidth: 56,
+        minHeight: 44,
+        paddingHorizontal: 8,
+        paddingVertical: 4,
+        borderRadius: 6,
+        borderWidth: 1,
+        borderColor: 'rgba(255,255,255,0.45)',
+        backgroundColor: 'rgba(0,0,0,0.55)',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 2,
+    },
+    stopButtonCompact: {
+        minWidth: 48,
+    },
+    stopGlyph: {
+        width: 12,
+        height: 12,
+        borderRadius: 2,
+        backgroundColor: colors.text,
+    },
+    stopLabel: {
+        color: colors.text,
+        fontSize: 10,
+        lineHeight: 11,
+        textAlign: 'center',
+    },
+    stopLabelCompact: {
+        fontSize: 9,
+        lineHeight: 10,
+    },
+    longPressHint: {
+        left: 0,
+        right: 0,
+        alignItems: 'center',
+        zIndex: 11,
+    },
+    longPressHintText: {
+        color: colors.text,
+        backgroundColor: 'rgba(0,0,0,0.55)',
+        borderRadius: 4,
+        fontSize: 12,
+        paddingHorizontal: 8,
+        paddingVertical: 3,
+    },
+    longPressHintTextCompact: {
+        fontSize: 10,
+    },
+    longPressToast: {
+        left: 0,
+        right: 0,
+        alignItems: 'center',
+        zIndex: 12,
+    },
+    longPressToastText: {
+        color: colors.text,
+        backgroundColor: 'rgba(0,0,0,0.75)',
+        borderRadius: 6,
+        fontSize: 16,
+        fontWeight: '700',
+        paddingHorizontal: 14,
+        paddingVertical: 8,
+    },
+    gearGhost: {
+        right: 8,
+        alignItems: 'center',
+        gap: 4,
+        zIndex: 12,
+    },
+    gearGhostButton: {
+        width: 46,
+        height: 46,
+        borderRadius: 23,
+        borderWidth: 1,
+        borderStyle: 'dashed',
+        borderColor: 'rgba(255,255,255,0.6)',
+        backgroundColor: 'rgba(0,0,0,0.45)',
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    gearGhostButtonCompact: {
+        width: 34,
+        height: 34,
+        borderRadius: 17,
+    },
+    gearGhostLabel: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 3,
+    },
+    gearGhostText: {
+        color: colors.text,
+        fontWeight: '700',
+    },
+    badge: {
+        top: 0,
+        left: 0,
+        backgroundColor: 'rgba(255,180,0,0.85)',
+        paddingHorizontal: 6,
+        paddingVertical: 2,
+        zIndex: 20,
+    },
+    badgeText: {
+        color: '#000',
+        fontWeight: '700',
+        fontSize: 12,
+    },
+    debug: {
+        left: 0,
+        backgroundColor: 'rgba(0,0,0,0.7)',
+        paddingHorizontal: 6,
+        paddingVertical: 3,
+        zIndex: 20,
+    },
+    debugText: {
+        color: '#8fe',
+        fontSize: 11,
+        lineHeight: 14,
+    },
+    ruler: {
+        flexDirection: 'row',
+        alignItems: 'flex-start',
+        gap: 16,
+        padding: 16,
+        backgroundColor: colors.background,
+    },
+    rulerCol: {
+        gap: 8,
+    },
+    rulerLabel: {
+        color: colors.text,
+        fontWeight: '700',
+    },
+    rulerSlot: {
+        position: 'relative',
+        height: RULER_SLOT_HEIGHT,
+    },
+    rulerColumn: {
+        gap: 12,
+        padding: 16,
+        backgroundColor: colors.background,
+    },
+    rulerRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+    },
+});

--- a/src/pages/RidePage/RideOverlayPrototype.stories.tsx
+++ b/src/pages/RidePage/RideOverlayPrototype.stories.tsx
@@ -82,6 +82,18 @@ const ROUTE_DATA = teideRoute as never;
 const RULER_SLOT_HEIGHT = 96;
 
 /**
+ * `NearbyRiders`/`PrevRides` are **variable-length lists, capped at 10 but usually shorter** on
+ * desktop today, and both can be on screen at once (repo owner, 2026-08-11 - e.g. a "ride again"
+ * that turns into a group ride). So the reserved slot is not a fixed box, and it is not a
+ * worst-case-10 box either: its height is `header + n · row` for whatever `n` currently is, clamped
+ * to what the ear can afford. These are stand-in metrics for the ghost - Phase 3 owns the real ones.
+ */
+const PHASE3_MAX_ENTRIES = 10;
+const PHASE3_TYPICAL_ENTRIES = 4;
+const PHASE3_ROW_HEIGHT = 24;
+const PHASE3_HEADER_HEIGHT = 22;
+
+/**
  * Rendered heights of `RideDashboardView`, measured in the browser (2026-08-11) rather than assumed.
  * The `icon-top` stack (icon ABOVE value above the secondary row) is 40% taller than `icon-left`'s —
  * which matters because the Gear tile forces `icon-top`, so the dashboard gets both narrower AND
@@ -123,6 +135,12 @@ interface RideOverlayPrototypeProps {
     cornerSlot: 'elevation' | 'workout';
     /** HLD OQ6 — a hypothetical (NOT built) gear-shift trigger, to check the arrangement leaves room. */
     showGearGhost: boolean;
+    /** HLD §5.5 — the reserved Phase 3 `NearbyRiders`/`PrevRides` slots, drawn as ghosts to check the
+     *  ear budget actually holds once occupied. Neither is designed or built in this phase. */
+    showPhase3Ghosts: boolean;
+    /** Entries per reserved list. Both are capped at 10 but are usually shorter, so the default is
+     *  the typical case, not the worst one. */
+    phase3Entries: number;
     /** §5.8's `inputs`, rendered on screen: Phase 1 found layout issues precisely because the
      *  numbers were visible. */
     showDebug: boolean;
@@ -140,6 +158,8 @@ const RideOverlayPrototypeView = (props: RideOverlayPrototypeProps) => {
         graphMode,
         cornerSlot,
         showGearGhost,
+        showPhase3Ghosts,
+        phase3Entries,
         showDebug,
     } = props;
 
@@ -183,6 +203,8 @@ const RideOverlayPrototypeView = (props: RideOverlayPrototypeProps) => {
                     sideAssignment={sideAssignment}
                     stopMechanism={stopMechanism}
                     showGearGhost={showGearGhost}
+                    showPhase3Ghosts={showPhase3Ghosts}
+                    phase3Entries={phase3Entries}
                     dashboardHeight={dashboardHeight}
                 />
             ) : (
@@ -192,6 +214,8 @@ const RideOverlayPrototypeView = (props: RideOverlayPrototypeProps) => {
                     compact={compact}
                     mapVisible={mapVisible}
                     showGearGhost={showGearGhost}
+                    showPhase3Ghosts={showPhase3Ghosts}
+                    phase3Entries={phase3Entries}
                 />
             )}
 
@@ -230,12 +254,15 @@ interface WorkoutOverlayProps {
     sideAssignment: SideAssignment;
     stopMechanism: StopMechanism;
     showGearGhost: boolean;
+    showPhase3Ghosts: boolean;
+    /** How many entries each reserved list currently holds (capped at `PHASE3_MAX_ENTRIES`). */
+    phase3Entries: number;
     /** Observed, not estimated - see `OBSERVED_RIDE_DASH_HEIGHT`. */
     dashboardHeight: number;
 }
 
 const WorkoutOverlay = (props: WorkoutOverlayProps) => {
-    const { layout, frameWidth, frameHeight, compact, graphMode, cornerSlot, sideAssignment, stopMechanism, showGearGhost, dashboardHeight } = props;
+    const { layout, frameWidth, frameHeight, compact, graphMode, cornerSlot, sideAssignment, stopMechanism, showGearGhost, showPhase3Ghosts, phase3Entries, dashboardHeight } = props;
     const { arrangement, workoutDashboard, map, elevation } = layout;
 
     // OQ2 — the two ears are geometrically identical, so swapping is purely which occupant goes
@@ -327,11 +354,36 @@ const WorkoutOverlay = (props: WorkoutOverlayProps) => {
                 </View>
             )}
 
-            {/* --- OQ6: hypothetical gear-shift trigger, NOT part of this phase. Drawn as a third
-                    stacked ear occupant, under the corner widget — the only place with room, since
-                    both top corners are already spoken for and `RideDashboard` is the widest thing
-                    on screen. The fallback's corner slot works the same way, with less room below. */}
-            {showGearGhost && elevationRect && <GearShiftGhost top={elevationRect.top + elevationRect.height + 8} compact={compact} />}
+            {/* --- §5.5's reserved Phase 3 occupants, NOT designed or built here. Informational
+                    occupants stack DOWNWARD from under each ear's corner widget: NearbyRiders under
+                    the Map (left), PrevRides under the Elevation (right). */}
+            {showPhase3Ghosts && mapRect && (
+                <SlotGhost
+                    label="NearbyRiders"
+                    side={sideAssignment === 'map-left' ? 'left' : 'right'}
+                    top={mapRect.top + mapRect.height + 8}
+                    width={mapRect.width}
+                    availableHeight={earFreeBand(frameHeight, mapRect.top + mapRect.height)}
+                    entries={phase3Entries}
+                />
+            )}
+            {showPhase3Ghosts && elevationRect && arrangement !== 'fallback' && (
+                <SlotGhost
+                    label="PrevRides"
+                    side={sideAssignment === 'map-left' ? 'right' : 'left'}
+                    top={elevationRect.top + elevationRect.height + 8}
+                    width={elevationRect.width}
+                    availableHeight={earFreeBand(frameHeight, elevationRect.top + elevationRect.height)}
+                    entries={phase3Entries}
+                />
+            )}
+
+            {/* --- OQ6: hypothetical gear-shift trigger, NOT part of this phase. BOTTOM-anchored in
+                    the right ear, not stacked under the corner widget: it is the only interactive
+                    occupant, so it must not shift position when an informational one appears above
+                    it. Bottom-right also keeps it diagonally opposite the Menu button (bottom-left),
+                    so the two controls can't be mis-tapped for each other. */}
+            {showGearGhost && <GearShiftGhost bottom={BOTTOM_BAR_RATIO * frameHeight + 8} compact={compact} />}
 
             <ArrangementBadge arrangement={arrangement} width={frameWidth} />
         </>
@@ -348,12 +400,16 @@ const RouteOnlyOverlay = ({
     compact,
     mapVisible,
     showGearGhost,
+    showPhase3Ghosts,
+    phase3Entries,
 }: {
     frameWidth: number;
     frameHeight: number;
     compact: boolean;
     mapVisible: boolean;
     showGearGhost: boolean;
+    showPhase3Ghosts: boolean;
+    phase3Entries: number;
 }) => {
     const elevationPreviewHeight = frameHeight * 0.2;
     const elevationFullHeight = frameHeight * 0.12;
@@ -399,12 +455,29 @@ const RouteOnlyOverlay = ({
                     {...computeGraphPoints(ROUTE_DATA, reservedRight, previewHeight, { range: 2000, position: 10000 })}
                 />
             </View>
-            {showGearGhost && (
-                <GearShiftGhost
-                    top={(compact ? dashboardHeight : cornerTopOffset) + previewHeight + 8}
-                    compact={compact}
+            {/* The same Phase 3 slots on a route-only ride — they are not workout-specific, so the
+                budget has to hold here too, where the widgets sit higher (no WorkoutDashboard). */}
+            {showPhase3Ghosts && mapVisible && (
+                <SlotGhost
+                    label="NearbyRiders"
+                    side="left"
+                    top={cornerTopOffset + elevationPreviewHeight + 8}
+                    width={frameWidth * 0.15}
+                    availableHeight={earFreeBand(frameHeight, cornerTopOffset + elevationPreviewHeight)}
+                    entries={phase3Entries}
                 />
             )}
+            {showPhase3Ghosts && (
+                <SlotGhost
+                    label="PrevRides"
+                    side="right"
+                    top={(compact ? dashboardHeight : cornerTopOffset) + previewHeight + 8}
+                    width={reservedRight}
+                    availableHeight={earFreeBand(frameHeight, (compact ? dashboardHeight : cornerTopOffset) + previewHeight)}
+                    entries={phase3Entries}
+                />
+            )}
+            {showGearGhost && <GearShiftGhost bottom={elevationFullHeight + 8} compact={compact} />}
             <ArrangementBadge arrangement="route-only (today's layout)" width={frameWidth} />
         </>
     );
@@ -440,10 +513,11 @@ const LongPressAffordance = ({ frameHeight, compact }: { frameHeight: number; co
     </>
 );
 
-/** HLD OQ6 — NOT built this phase. A plausible two-button shifter drawn where it would most
- *  likely live: immediately beside `RideDashboard`, which is the widest thing on screen. */
-const GearShiftGhost = ({ top, compact }: { top: number; compact: boolean }) => (
-    <View style={[styles.absolute, styles.gearGhost, { top }]}>
+/** HLD OQ6 — NOT built this phase. A plausible two-button shifter, drawn bottom-anchored in the
+ *  right ear (see §8.6): the ear's free vertical band is the only place with room, and an
+ *  interactive control has to keep a fixed position as informational occupants come and go above it. */
+const GearShiftGhost = ({ bottom, compact }: { bottom: number; compact: boolean }) => (
+    <View style={[styles.absolute, styles.gearGhost, { bottom }]}>
         <View style={[styles.gearGhostButton, compact && styles.gearGhostButtonCompact]}>
             <Icon name="chevron-up" size={compact ? 16 : 22} color={colors.text} />
         </View>
@@ -463,6 +537,42 @@ const GearShiftGhost = ({ top, compact }: { top: number; compact: boolean }) => 
  * 2026-08-11) — a flat colour makes every widget look legible, and the real question here is whether
  * the translucent widget backgrounds (`rgba(0,0,0,0.45)`) hold up over actual ride imagery.
  */
+/** A reserved-but-unbuilt overlay slot, drawn at the size the ear budget gives it. Deliberately an
+ *  empty labelled box: this session answers *where they go*, not what they contain (§5.5 — content
+ *  and triggers are Phase 3 and explicitly out of scope). */
+const SlotGhost = ({
+    label,
+    side,
+    top,
+    width,
+    availableHeight,
+    entries,
+}: {
+    label: string;
+    side: 'left' | 'right';
+    top: number;
+    width: number;
+    /** The ear's free vertical band below the corner widget, down to the bottom bar. */
+    availableHeight: number;
+    /** How many entries the list currently HAS - not its cap. The slot sizes to this, clamped. */
+    entries: number;
+}) => {
+    const fits = Math.max(0, Math.floor((availableHeight - PHASE3_HEADER_HEIGHT) / PHASE3_ROW_HEIGHT));
+    const visible = Math.min(entries, fits);
+    const height = PHASE3_HEADER_HEIGHT + visible * PHASE3_ROW_HEIGHT;
+
+    return (
+        <View style={[styles.slotGhost, side === 'left' ? styles.cornerLeft : styles.cornerRight, { top, width, height }]}>
+            <Text style={[styles.slotGhostText, visible < entries && styles.slotGhostTextShort]}>
+                {label} {visible}/{entries}
+            </Text>
+            {Array.from({ length: visible }, (_, i) => (
+                <View key={i} style={styles.slotGhostRow} />
+            ))}
+        </View>
+    );
+};
+
 const Backdrop = ({ kind }: { kind: BackdropKind }) => {
     if (kind === 'map') {
         return (
@@ -504,6 +614,16 @@ const DebugPanel = ({ layout, bottom }: { layout: RideOverlayLayout; bottom: num
     );
 };
 
+/** The free vertical band in an ear: from the bottom of its corner widget down to the bottom bar,
+ *  less a slot gap at each end.
+ *
+ *  Deliberately does NOT subtract a standing reserve for §8.6's gear-shift control. An earlier draft
+ *  did, and it cost ~220 px of screen-height requirement - enough to take a 430 px-tall landscape
+ *  frame from 8 list rows down to 1. The shifter is bottom-anchored and only exists on rides with
+ *  virtual shifting, so it should claim its space when it is actually there, not permanently. */
+const earFreeBand = (frameHeight: number, cornerWidgetBottom: number): number =>
+    frameHeight - BOTTOM_BAR_RATIO * frameHeight - cornerWidgetBottom - 16;
+
 const noop = () => undefined;
 
 const mirror = <T extends { left?: number; right?: number }>(rect: T): T => ({
@@ -540,6 +660,8 @@ const meta: Meta<typeof RideOverlayPrototypeView> = {
         graphMode: 'strip',
         cornerSlot: 'elevation',
         showGearGhost: false,
+        showPhase3Ghosts: false,
+        phase3Entries: PHASE3_TYPICAL_ENTRIES,
         showDebug: true,
     },
     argTypes: {
@@ -626,8 +748,70 @@ export const StopLongPressBlockSide: Story = { args: { ...frame(1400, 900), stop
 export const StopLongPressFallback: Story = { args: { ...frame(844, 390), stopMechanism: 'longpress' } };
 
 /** OQ6 — a hypothetical gear-shift trigger on the combined screen, drawn in the slot session 4.1
- *  recommends: a third stacked occupant in an ear, under the corner widget. */
+ *  recommends: bottom-anchored in the right ear. */
 export const GearGhostTSide: Story = { args: { ...frame(1194, 834), showGearGhost: true } };
+
+/**
+ * §5.5's reserved Phase 3 slots, occupied — the check the arrangement budget was designed for but
+ * that nothing had actually rendered. `NearbyRiders` stacks under the corner Map (left ear),
+ * `PrevRides` under the Elevation preview (right ear), and the gear-shift trigger sits
+ * bottom-anchored below both so an informational occupant appearing never moves a control.
+ */
+export const Phase3SlotsTSide: Story = {
+    args: { ...frame(1194, 834), showPhase3Ghosts: true, showGearGhost: true, backdrop: 'streetview' },
+};
+
+/** The same, with the ears at their most generous. */
+export const Phase3SlotsBlockSide: Story = {
+    args: { ...frame(1400, 900), showPhase3Ghosts: true, showGearGhost: true, backdrop: 'streetview' },
+};
+
+/** The tightest ear the side arrangements produce — a large phone in landscape, still non-compact.
+ *  If the Phase 3 budget breaks anywhere, it breaks here. */
+export const Phase3SlotsTight: Story = {
+    args: { ...frame(932, 430), showPhase3Ghosts: true, showGearGhost: true, backdrop: 'streetview' },
+};
+
+/** Both lists at their 10-entry cap — the worst case, not the common one. Shown so the clamp is
+ *  visible: where the ear runs out, the header reports `visible/total` rather than overflowing. */
+export const Phase3SlotsFullLists: Story = {
+    args: {
+        ...frame(1194, 834),
+        showPhase3Ghosts: true,
+        showGearGhost: true,
+        phase3Entries: PHASE3_MAX_ENTRIES,
+        backdrop: 'streetview',
+    },
+};
+
+/** The 10-entry cap on the tightest ear — where the clamp actually bites. */
+export const Phase3SlotsFullListsTight: Story = {
+    args: {
+        ...frame(932, 430),
+        showPhase3Ghosts: true,
+        showGearGhost: true,
+        phase3Entries: PHASE3_MAX_ENTRIES,
+        backdrop: 'streetview',
+    },
+};
+
+/** Phase 3 slots on a ROUTE-ONLY ride — neither widget is workout-specific, so the budget has to
+ *  hold on today's layout too, where the corner widgets sit higher. */
+export const Phase3SlotsRouteOnly: Story = {
+    args: { ...frame(1194, 834), showPhase3Ghosts: true, showGearGhost: true, workoutAttached: false, backdrop: 'streetview' },
+};
+
+/** `column-only` has no ears at all, so there is nowhere for them — the arg is on and nothing
+ *  renders. That is the finding, not a bug. */
+export const Phase3SlotsColumnOnly: Story = {
+    args: { ...frame(860, 480), showPhase3Ghosts: true, showGearGhost: true },
+};
+
+/** The phone fallback has exactly one corner slot and it is already a 2-way toggle, so PrevRides is
+ *  suppressed here too — extending the existing cycle is the only mechanism that could fit. */
+export const Phase3SlotsFallback: Story = {
+    args: { ...frame(844, 390), showPhase3Ghosts: true, showGearGhost: true },
+};
 
 /** OQ6, the case HLD §6.4 actually requires: the same trigger on a ROUTE-ONLY ride, which is
  *  where a shifter is relevant with or without a workout. */
@@ -857,6 +1041,33 @@ const styles = StyleSheet.create({
         fontWeight: '700',
         paddingHorizontal: 14,
         paddingVertical: 8,
+    },
+    slotGhost: {
+        position: 'absolute',
+        paddingBottom: 4,
+        borderWidth: 1,
+        borderStyle: 'dashed',
+        borderColor: 'rgba(255,255,255,0.55)',
+        backgroundColor: 'rgba(0,0,0,0.45)',
+        borderRadius: 4,
+        zIndex: 10,
+    },
+    slotGhostText: {
+        textAlign: 'center',
+        paddingVertical: 3,
+        color: colors.text,
+        fontWeight: '700',
+    },
+    slotGhostTextShort: {
+        color: '#ffcf70',
+    },
+    slotGhostRow: {
+        alignSelf: 'stretch',
+        height: PHASE3_ROW_HEIGHT - 6,
+        marginHorizontal: 6,
+        marginBottom: 2,
+        borderRadius: 2,
+        backgroundColor: 'rgba(255,255,255,0.14)',
     },
     gearGhost: {
         right: 8,


### PR DESCRIPTION
Phase 2, Wave 4 — the visual checkpoint HLD §5.3/§8 deferred the pixel-level decisions to. Mirrors Phase 1's 4.1/4.2 prototype sessions.

## What changed

**New:** `src/pages/RidePage/RideOverlayPrototype.stories.tsx` — composes the real `WorkoutDashboard`, `RideDashboard`, `ElevationGraph` and corner map into every arrangement at the screen size that triggers it (not device presets — the arrangement is a computed fit check), over the same `/screenshot.jpg` placeholder the `VideoRidePage` story uses, with the algorithm's decision inputs printed on screen. Includes a route-only variant, the 7↔8 tile (virtual shifting) pair, both Stop-Workout mechanisms, both graph modes, both corner assignments, a gear-shift ghost, and two width-ruler stories.

**Changed:** `useRideOverlayLayout.ts` + its tests — rendering the algorithm changed the design, not just the numbers.

- The cascade no longer narrows `WorkoutDashboard` to a floor to buy ear width. Ears take their minimum, the workout dashboard takes the rest up to `RideDashboard`'s width, surplus goes back to the ears. Block vs T is now a description of the result, not a separate candidate. At 1194×834 the workout bar is **778 wide instead of a truncated 320**.
- `block-below`/`t-below` → **`column-only`**. They rendered 10 px apart, and relocating the corner widgets under the column left the Video/GPX main view as a sliver — so where they don't fit beside the column they are **dropped, not relocated**.
- Constants tuned against the two ruler stories: `SIDE_WIDGET_MIN_WIDTH` 160→**200**, `WORKOUT_DASH_MIN_WIDTH` 320→**480**, `WORKOUT_DASH_HEIGHT_RATIO` 0.30→**0.15** (HLD §6.2's "≤1.5× `RideDashboard`" rule, now living in the constant), `MIN_HEIGHT` 120→**100**, new `MAX_HEIGHT` 160, `WORKOUT_DASH_MAX_ASPECT` **removed**, new `SIDE_WIDGET_WIDTH/HEIGHT_RATIO` so ear occupants render at today's proportions rather than at their bare floor.

## Open questions resolved

| OQ | Resolution |
|---|---|
| 1 — thresholds | Retuned + cascade reshaped (HLD §8.1) |
| 2 — Map/Elevation side | Map left, Elevation right — the fallback has only one corner slot and it is elevation at `right: 0` (HLD §8.2) |
| 3 — Stop-Workout | **Dedicated button.** Long-press needs a persistent hint that costs more space than the button on the fallback, and needs a hold-to-confirm against accidental activation — i.e. more friction than a tap (HLD §8.3) |
| 4 — WorkoutDashboard graph | **`strip`**, not `live`: at 56 px `live` spends the box on axes/legend and leaves the workout shape a sliver (HLD §8.4) |
| 5 — runtime width changes | Already resolved by 1.2; largely defused — the Gear tile can no longer change the layout on most screens (HLD §8.5) |
| 6 — gear-shift room | Room exists, but **under** a corner widget, not beside `RideDashboard` (where it collides on route-only rides too) (HLD §8.6) |

Six independent findings are recorded in HLD §8.7. The one that needed a call — whether the `rgba(0,0,0,0.45)` overlay scrim is too light over bright ride imagery — was decided by the repo owner as **keep 0.45, change nothing**: the text reads and the ride imagery still shows through, which is what a translucent overlay is for. Closed, not carried into 5.1.

## Test plan

- `npm test` — 658 passed, 100 suites (34 in the retuned hook suite)
- `npx tsc --noEmit` clean, `eslint` clean on changed files
- Every arrangement screenshotted headlessly at its triggering frame; frames are landscape-only, matching the app's orientation lock
