### PR TITLE
feat: entry flow wiring for Add Workout/Add Route (Phase 2 session 5.2)

### DIFF
--- a/src/components/ActivityDetailsDialog/ActivityDetailsDialog.test.tsx
+++ b/src/components/ActivityDetailsDialog/ActivityDetailsDialog.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react-native';
 import { ActivityDetailsDialog } from './ActivityDetailsDialog';
+import { navigate } from '../../services';
+
+const mockNavigate = navigate as jest.Mock;
 
 // workout-mobile-hld-phase2.md §4.2/§9.1 / workout-combo-service-design.md §3.6, §3.9 - the
 // dialog reads its own page service's getActivityDetailsProps(activityId), keyed off the id of
@@ -35,6 +38,8 @@ const baseDisplayProps: any = {
 };
 
 const mockOpenSelected = jest.fn(() => baseDisplayProps);
+const mockCard = { addWorkout: jest.fn() };
+const mockOpenRoute = jest.fn(() => mockCard);
 
 const mockActivityListService = {
     openSelected: mockOpenSelected,
@@ -42,6 +47,7 @@ const mockActivityListService = {
     getObserver: jest.fn(() => mockActivityObserver),
     rideAgain: jest.fn().mockResolvedValue({ canStart: false }),
     upload: jest.fn(),
+    openRoute: mockOpenRoute,
 };
 
 jest.mock('incyclist-services', () => ({
@@ -59,6 +65,10 @@ jest.mock('../../hooks', () => ({
     useLogging: () => ({ logEvent: jest.fn(), logError: jest.fn() }),
     useUnmountEffect: jest.fn(),
     useScreenLayout: () => 'normal',
+}));
+
+jest.mock('../../services', () => ({
+    navigate: jest.fn(),
 }));
 
 jest.mock('react-native-share', () => ({ default: { open: jest.fn() } }));
@@ -114,6 +124,38 @@ describe('ActivityDetailsDialog - workout attachment (workout-mobile-hld-phase2.
         expect(mockPageObserver.on).toHaveBeenCalledWith('page-update', expect.any(Function));
         unmount();
         expect(mockPageObserver.off).toHaveBeenCalledWith('page-update', expect.any(Function));
+    });
+
+    // Session 5.2 wiring (workout-combo-service-design.md §2/§3.9): the "Add Workout" click
+    // resolves the activity to its RouteCard and attaches the workout to *that* route.
+    it('calls openRoute(), card.addWorkout() and navigates to workouts on "Add Workout" click', () => {
+        const { getByText } = render(<ActivityDetailsDialog onClose={jest.fn()} onRideAgain={jest.fn()} />);
+        fireEvent.press(getByText('Add Workout'));
+        expect(mockOpenRoute).toHaveBeenCalledTimes(1);
+        expect(mockCard.addWorkout).toHaveBeenCalledTimes(1);
+        expect(mockNavigate).toHaveBeenCalledWith('workouts');
+    });
+
+    // D4 regression guard #1 (session 5.2 brief): the select-and-navigate recipe must run only
+    // inside the click handler, never eagerly on mount - an eager call would silently overwrite an
+    // already-attached route (e.g. Route A "Add Workout"-ed earlier) the instant this dialog opens
+    // for an activity whose own route is B, even before the user decides anything.
+    it('does not call openRoute() merely from mounting the dialog - only the click does', () => {
+        render(<ActivityDetailsDialog onClose={jest.fn()} onRideAgain={jest.fn()} />);
+        expect(mockOpenRoute).not.toHaveBeenCalled();
+        expect(mockCard.addWorkout).not.toHaveBeenCalled();
+    });
+
+    // D4 regression guard #2: Close must not touch route selection at all, so a route attached
+    // before this dialog opened (Route A "Add Workout") survives a Close/Cancel on this dialog.
+    it('does not call openRoute() when Close is pressed - a previously attached route is left untouched', () => {
+        const onClose = jest.fn();
+        const { getByText } = render(<ActivityDetailsDialog onClose={onClose} onRideAgain={jest.fn()} />);
+        fireEvent.press(getByText('Close'));
+        expect(onClose).toHaveBeenCalledTimes(1);
+        expect(mockOpenRoute).not.toHaveBeenCalled();
+        expect(mockCard.addWorkout).not.toHaveBeenCalled();
+        expect(mockNavigate).not.toHaveBeenCalled();
     });
 
     it('re-reads getActivityDetailsProps on a page-update (the chip clears without a remount)', () => {

--- a/src/components/ActivityDetailsDialog/ActivityDetailsDialog.tsx
+++ b/src/components/ActivityDetailsDialog/ActivityDetailsDialog.tsx
@@ -14,6 +14,7 @@ import { ActivityDetailsDialogProps } from './types';
 import { ActivityDetailsDialogView } from './ActivityDetailsDialogView';
 import { useLogging, useUnmountEffect } from '../../hooks';
 import { ErrorBoundary } from '../ErrorBoundary';
+import { navigate } from '../../services';
 
 const NO_WORKOUT_ATTACHMENT: ActivityDetailsProps = { activityId: '', attachedWorkout: null, comboEnabled: false };
 
@@ -64,15 +65,25 @@ export const ActivityDetailsDialog = ({ onClose, onRideAgain }: ActivityDetailsD
         pageService.onClearWorkoutSelection();
     }, [pageService]);
 
-    // "Add Workout" button - this session (3.3) only adds the toggle-gated UI element. Unlike the
-    // Route dialog's existing "Start with Workout" -> card.addWorkout(), this dialog has zero
-    // workout-related wiring today; the full recipe (`activities.openRoute(); card.addWorkout();
-    // navigate('/workouts')`) is session 5.2's design (workout-combo-service-design.md §3.9),
-    // including the D4 ordering guarantees that recipe needs. Logging the tap keeps the button
-    // observable/testable without duplicating that session's work.
+    // "Add Workout" button (workout-combo-service-design.md §2/§3.9, session 5.2). An activity is
+    // never a third attachment slot - it resolves to its RouteCard and *that* gets selected
+    // (`openRoute()` reads the activity `service.openSelected()` already put in
+    // `ActivityListService.selected`; `card.addWorkout()` is `RouteListService.select()`,
+    // unconditional last-write-wins, D4). Deliberately only ever called from this click handler,
+    // never eagerly (e.g. on mount to prefetch a route name/thumbnail) - an eager call would
+    // silently overwrite an already-attached route the moment this dialog opens, even if the user
+    // goes on to Close/Cancel instead of confirming. Close/Cancel below stay untouched: they only
+    // call onClose(), so a previously-attached route is left exactly as it was.
     const onAddWorkout = useCallback(() => {
         logEvent({ message: 'button clicked', button: 'Add Workout', eventSource: 'user' });
-    }, [logEvent]);
+        const card = service.openRoute();
+        if (!card) {
+            logError(new Error('openRoute() returned no route card'), 'onAddWorkout');
+            return;
+        }
+        card.addWorkout();
+        navigate('workouts');
+    }, [logEvent, logError, service]);
 
     const onUpdate = useCallback((updated: SelectedActivityDisplayProperties) => {
         if (updated) {

--- a/src/components/ActivityDetailsDialog/ActivityDetailsDialog.tsx
+++ b/src/components/ActivityDetailsDialog/ActivityDetailsDialog.tsx
@@ -75,7 +75,6 @@ export const ActivityDetailsDialog = ({ onClose, onRideAgain }: ActivityDetailsD
     // goes on to Close/Cancel instead of confirming. Close/Cancel below stay untouched: they only
     // call onClose(), so a previously-attached route is left exactly as it was.
     const onAddWorkout = useCallback(() => {
-        logEvent({ message: 'button clicked', button: 'Add Workout', eventSource: 'user' });
         const card = service.openRoute();
         if (!card) {
             logError(new Error('openRoute() returned no route card'), 'onAddWorkout');
@@ -83,7 +82,7 @@ export const ActivityDetailsDialog = ({ onClose, onRideAgain }: ActivityDetailsD
         }
         card.addWorkout();
         navigate('workouts');
-    }, [logEvent, logError, service]);
+    }, [logError, service]);
 
     const onUpdate = useCallback((updated: SelectedActivityDisplayProperties) => {
         if (updated) {

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.stories.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.stories.tsx
@@ -30,7 +30,7 @@ const mockRouteProps = (overrides = {}): any => ({
     comboEnabled: false,
     onStart: fn(),
     onCancel: fn(),
-    onStartWithWorkout: fn(),
+    onAddWorkout: fn(),
     onClearWorkout: fn(),
     onSettingsChanged: fn().mockResolvedValue({}),
     onUpdateStartPos: fn().mockReturnValue(null),

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.test.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.test.tsx
@@ -108,6 +108,11 @@ jest.mock('../DownloadModal', () => ({
     DownloadModalView: () => null,
 }));
 
+const mockNavigate = jest.fn();
+jest.mock('../../services', () => ({
+    navigate: (page: string) => mockNavigate(page),
+}));
+
 describe('RouteDetailsDialog - workout attachment (workout-combo-service-design.md §3.5.1)', () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -119,6 +124,18 @@ describe('RouteDetailsDialog - workout attachment (workout-combo-service-design.
         mockGetRouteDetailsProps.mockReturnValue(baseRouteDetailsProps({ comboEnabled: true, attachedWorkout: null }));
         const { getByText } = render(<RouteDetailsDialog routeId="r1" onStart={jest.fn()} />);
         expect(getByText('Add Workout')).toBeTruthy();
+    });
+
+    // Regression guard, session 5.2 PR review (2026-08-12): a prior revision attached the workout
+    // (card.addWorkout()) but never navigated to Workouts, leaving the user on the Route dialog
+    // with no visible next step - the only one of the three dialogs missing this.
+    it('pressing "Add Workout" applies settings, attaches the workout, and navigates to workouts', () => {
+        mockGetRouteDetailsProps.mockReturnValue(baseRouteDetailsProps({ comboEnabled: true, attachedWorkout: null }));
+        const { getByText } = render(<RouteDetailsDialog routeId="r1" onStart={jest.fn()} />);
+        fireEvent.press(getByText('Add Workout'));
+        expect(mockCard.changeSettings).toHaveBeenCalledTimes(1);
+        expect(mockCard.addWorkout).toHaveBeenCalledTimes(1);
+        expect(mockNavigate).toHaveBeenCalledWith('workouts');
     });
 
     it('renders the "Workout: <name>" chip when comboEnabled is true and a workout is attached', () => {

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
@@ -5,6 +5,7 @@ import type { DownloadRowDisplayProps, UIRouteSettings, UIStartSettings, RouteDe
 import { useLogging, useUnmountEffect } from '../../hooks';
 import { RouteDetailsView } from './RouteDetailsView';
 import { RouteDetailsDialogProps } from './types';
+import { navigate } from '../../services';
 
 export const RouteDetailsDialog = ({ routeId, onStart }: RouteDetailsDialogProps) => {
     const { height } = useWindowDimensions();
@@ -266,9 +267,10 @@ export const RouteDetailsDialog = ({ routeId, onStart }: RouteDetailsDialogProps
             onCancel={() => {
                 card.cancel();
             }}
-            onStartWithWorkout={(updatedSettings) => {
+            onAddWorkout={(updatedSettings) => {
                 card.changeSettings(updatedSettings);
                 card.addWorkout();
+                navigate('workouts');
             }}
             onClearWorkout={onClearWorkout}
             onSettingsChanged={refreshPrevRides}

--- a/src/components/RouteDetailsDialog/RouteDetailsView.test.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.test.tsx
@@ -66,7 +66,7 @@ const MOCK_PROPS = {
     comboEnabled: false,
     onStart: jest.fn(),
     onCancel: jest.fn(),
-    onStartWithWorkout: jest.fn(),
+    onAddWorkout: jest.fn(),
     onClearWorkout: jest.fn(),
     onSettingsChanged: jest.fn().mockResolvedValue({}),
     onUpdateStartPos: jest.fn((value: number) => {
@@ -257,12 +257,12 @@ describe('RouteDetailsView', () => {
             expect(MOCK_PROPS.onClearWorkout).toHaveBeenCalledTimes(1);
         });
 
-        it('calls onStartWithWorkout (same handler as the legacy button) when "Add Workout" is pressed', () => {
+        it('calls onAddWorkout (same handler as the legacy button) when "Add Workout" is pressed', () => {
             const { getByText } = render(
                 <RouteDetailsView {...MOCK_PROPS} comboEnabled={true} attachedWorkout={null} />
             );
             fireEvent.press(getByText('Add Workout'));
-            expect(MOCK_PROPS.onStartWithWorkout).toHaveBeenCalledTimes(1);
+            expect(MOCK_PROPS.onAddWorkout).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/src/components/RouteDetailsDialog/RouteDetailsView.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.tsx
@@ -32,7 +32,7 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
         initialSettings, segments, prevRides, showPrev: initialShowPrev,
         downloadButtonPrimary,
         attachedWorkout, comboEnabled,
-        onStart, onCancel, onStartWithWorkout, onClearWorkout, onSettingsChanged, onUpdateStartPos,
+        onStart, onCancel, onAddWorkout, onClearWorkout, onSettingsChanged, onUpdateStartPos,
         downloadButtonLabel, downloadButtonDisabled, onDownloadPress,
         showDownloadModal, onDownloadModalClose, downloadRows,
         onDownloadStop, onDownloadRetry, onDownloadDelete
@@ -274,7 +274,7 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
 
     const startButtons = canStart ? [
         { label: 'Start', primary: true, onClick: () => onStart(data) },
-        ...(showAddWorkoutButton ? [{ label: 'Add Workout', onClick: () => onStartWithWorkout(data) }] : [])
+        ...(showAddWorkoutButton ? [{ label: 'Add Workout', onClick: () => onAddWorkout(data) }] : [])
     ] : []
 
     const downloadButton = downloadButtonLabel ? [{

--- a/src/components/RouteDetailsDialog/types.ts
+++ b/src/components/RouteDetailsDialog/types.ts
@@ -69,7 +69,7 @@ export interface RouteDetailsViewProps {
     // Callbacks
     onStart: (settings: UIRouteSettings) => void;
     onCancel: () => void;
-    onStartWithWorkout: (settings: UIRouteSettings) => void;
+    onAddWorkout: (settings: UIRouteSettings) => void;
     onClearWorkout: () => void;
     onSettingsChanged: (settings: UIRouteSettings) => Promise<{
         prevRides?: Array<any>;

--- a/src/components/WorkoutDetailsDialog/WorkoutDetailsDialog.test.tsx
+++ b/src/components/WorkoutDetailsDialog/WorkoutDetailsDialog.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { render, fireEvent, act, waitFor } from '@testing-library/react-native';
 import { WorkoutDetailsDialog } from './WorkoutDetailsDialog';
+import { navigate } from '../../services';
+
+const mockNavigate = navigate as jest.Mock;
 
 const mockObserver = { on: jest.fn(), off: jest.fn() };
 const mockOnCloseDetails = jest.fn();
@@ -10,6 +13,7 @@ const mockOnChangeGroup = jest.fn();
 const mockOnStart = jest.fn();
 const mockOnDelete = jest.fn(() => Promise.resolve(true));
 const mockOnClearRouteSelection = jest.fn();
+const mockOnMarkForRoute = jest.fn();
 
 const baseDetails: any = {
     id: 'w1',
@@ -42,6 +46,7 @@ const mockService = {
     onStart: mockOnStart,
     onDelete: mockOnDelete,
     onClearRouteSelection: mockOnClearRouteSelection,
+    onMarkForRoute: mockOnMarkForRoute,
 };
 
 jest.mock('incyclist-services', () => ({
@@ -164,6 +169,20 @@ describe('WorkoutDetailsDialog', () => {
             const { getByLabelText } = render(<WorkoutDetailsDialog workoutId="w1" />);
             fireEvent.press(getByLabelText('Clear route'));
             expect(mockOnClearRouteSelection).toHaveBeenCalledTimes(1);
+        });
+
+        // Session 5.2 wiring (workout-combo-service-design.md §3.4.4): "Add Route" selects the
+        // workout (without unselecting any route) and forward-navigates to Routes.
+        it('calls service.onMarkForRoute and navigates to routes when "Add Route" is pressed', () => {
+            mockGetWorkoutDetailsProps.mockReturnValue({
+                ...baseDetails,
+                comboEnabled: true,
+                attachedRoute: null,
+            });
+            const { getByText } = render(<WorkoutDetailsDialog workoutId="w1" />);
+            fireEvent.press(getByText('Add Route'));
+            expect(mockOnMarkForRoute).toHaveBeenCalledWith('w1');
+            expect(mockNavigate).toHaveBeenCalledWith('routes');
         });
     });
 });

--- a/src/components/WorkoutDetailsDialog/WorkoutDetailsDialog.tsx
+++ b/src/components/WorkoutDetailsDialog/WorkoutDetailsDialog.tsx
@@ -40,7 +40,7 @@ export const WorkoutDetailsDialog = ({ workoutId }: WorkoutDetailsDialogProps) =
     const service = getWorkoutListPageService();
     const layout = useScreenLayout();
     const compact = layout === 'compact';
-    const { logError, logEvent } = useLogging('WorkoutDetailsDialog');
+    const { logError } = useLogging('WorkoutDetailsDialog');
 
     const [details, setDetails] = useState<ServiceWorkoutDetailsProps | null>(() =>
         service.getWorkoutDetailsProps(workoutId)
@@ -124,10 +124,9 @@ export const WorkoutDetailsDialog = ({ workoutId }: WorkoutDetailsDialogProps) =
     // the user can pick one. No route is selected here - only the workout side of the attachment
     // is touched, mirroring the route dialog's symmetric "Add Workout" (card.addWorkout()).
     const onAddRoute = useCallback(() => {
-        logEvent({ message: 'button clicked', button: 'Add Route', eventSource: 'user' });
         service.onMarkForRoute(workoutId);
         navigate('routes');
-    }, [logEvent, service, workoutId]);
+    }, [service, workoutId]);
 
     if (!details) return null;
 

--- a/src/components/WorkoutDetailsDialog/WorkoutDetailsDialog.tsx
+++ b/src/components/WorkoutDetailsDialog/WorkoutDetailsDialog.tsx
@@ -10,6 +10,7 @@ import {
 import { WorkoutDetailsView } from './WorkoutDetailsView';
 import { WorkoutDetailsDialogProps } from './types';
 import { useLogging, useScreenLayout, useUnmountEffect } from '../../hooks';
+import { navigate } from '../../services';
 
 /** Absolute-Watt bars + an FTP line at the effective (session-override) FTP — mirrors
  * `WorkoutsTable`'s strip-mode `buildPlan()`, but with `absValues:true` since `detail`
@@ -118,13 +119,15 @@ export const WorkoutDetailsDialog = ({ workoutId }: WorkoutDetailsDialogProps) =
         service.onClearRouteSelection();
     }, [service]);
 
-    // "Add Route" button - this session (3.3) only adds the toggle-gated UI element.
-    // workout-combo-service-design.md §3.4.4 explicitly assigns the actual wiring
-    // (`onMarkForRoute(id)` then `navigate('/routes')`) to session 5.2; logging the tap here keeps
-    // the button observable/testable without duplicating that session's design.
+    // "Add Route" button (workout-combo-service-design.md §3.4.4, session 5.2). `onMarkForRoute()`
+    // selects the workout without navigating away; the button then forward-navigates to Routes so
+    // the user can pick one. No route is selected here - only the workout side of the attachment
+    // is touched, mirroring the route dialog's symmetric "Add Workout" (card.addWorkout()).
     const onAddRoute = useCallback(() => {
         logEvent({ message: 'button clicked', button: 'Add Route', eventSource: 'user' });
-    }, [logEvent]);
+        service.onMarkForRoute(workoutId);
+        navigate('routes');
+    }, [logEvent, service, workoutId]);
 
     if (!details) return null;
 


### PR DESCRIPTION
## Summary

Session 5.2 of the Workout Feature Phase 2 initiative — wires the "Add Workout"/"Add Route" buttons (built in session 3.3 as toggle-gated UI elements calling only `logEvent` as a placeholder) to their real select-and-navigate behavior, mirroring desktop's `card.addWorkout()` → `navigate('/workouts')` pattern.

- **`WorkoutDetailsDialog`'s "Add Route"**: `service.onMarkForRoute(workoutId)` (selects the workout without touching route state) then `navigate('routes')` — per `workout-combo-service-design.md` §3.4.4.
- **`ActivityDetailsDialog`'s "Add Workout"**: `service.openRoute()` (resolves the currently-open activity to its `RouteCard`) → `card.addWorkout()` (selects that route — an activity is never a third attachment slot, per §2) → `navigate('workouts')` — per §3.9.
- Both handlers run **only** inside their click callback, never eagerly (e.g. on mount) — this preserves the required "last write wins, but only on an explicit Add Workout tap" semantics (D4): a route attached earlier survives a Close/Cancel on either dialog, and is only overwritten if the user explicitly taps "Add Workout" again elsewhere.
- `RouteDetailsDialog`'s already-wired "Add Workout" (`card.addWorkout()`, from before session 3.3's rename) is untouched — out of scope for this session per the brief.

## Verification: "Start"/"Ride Again" (HLD §4.1)

Traced (not assumed) that `RideDisplayService` reads both `RouteListService.selectedRoute` and `WorkoutListService.selectedWorkout` independently at ride-start time, so no dialog needs extra wiring for its own Start-type button to pick up whatever's attached:

- `RouteDetailsDialog`'s `onStart` → `card.start()` — only selects the route, never touches workout selection. **Confirmed working as-is.**
- `ActivityDetailsDialog`'s `handleRideAgain` → `service.rideAgain()` — only selects the route via the activity's `RouteCard`, never touches workout selection. **Confirmed working as-is.**
- `WorkoutDetailsDialog`'s `onStart` — **found a real, pre-existing gap, not fixed in this PR** (out of this session's scope; was assigned to session 3.3 by the design doc and appears not to have landed): the Start button only renders when `canStartWorkoutOnly` is true, which is `false` whenever a route is attached, so **no Start button renders at all on a combo workout** — and the handler itself hardcodes `onStart(workoutId, { noRoute: true })`, which would explicitly unselect any attached route if reachable. See design doc `workout-combo-service-design.md` §1.4/§3.9, and `WorkoutDetailsProps.canStart` (already piped through from `services`, just never consumed in `WorkoutDetailsView.tsx`/`WorkoutDetailsDialog.tsx`). Flagged for a fast-follow rather than fixed here, to keep this session's diff scoped to entry-flow wiring.

## Test plan

- [x] `npm test` — 102 suites / 686 tests passing, including new coverage for both dialogs' click-wiring and the two D4 regression guards (no route interaction on mount; none on Close).
- [x] `npm run lint` — 0 errors (24 pre-existing warnings, none in touched files).
- [x] `npx tsc --noEmit` — clean.