### PR TITLE
fix: WorkoutDetailsDialog Start button dead for a route+workout combo

### DIFF
--- a/src/components/WorkoutDetailsDialog/WorkoutDetailsDialog.test.tsx
+++ b/src/components/WorkoutDetailsDialog/WorkoutDetailsDialog.test.tsx
@@ -93,10 +93,28 @@ describe('WorkoutDetailsDialog', () => {
         expect(mockOnCloseDetails).toHaveBeenCalledTimes(1);
     });
 
-    it('calls service.onStart with noRoute:true on Start', () => {
+    it('calls service.onStart with noRoute:true on Start (workout-only, no route attached)', () => {
         const { getByText } = render(<WorkoutDetailsDialog workoutId="w1" />);
         fireEvent.press(getByText('Start'));
         expect(mockOnStart).toHaveBeenCalledWith('w1', { noRoute: true });
+    });
+
+    // Regression guard, 2026-08-12 (first Wave 6 real-device pass): a route was attached via
+    // "Add Workout" on RouteDetailsDialog, then the same workout opened here - Start must appear
+    // and must NOT force noRoute:true, or the attached route is silently dropped on start.
+    // canStart mirrors desktop's WorkoutDetails `canStart` (route currently selected).
+    it('shows Start and calls service.onStart with noRoute:false when a route is attached (canStart true)', () => {
+        mockGetWorkoutDetailsProps.mockReturnValue({
+            ...baseDetails,
+            canStart: true,
+            canStartWorkoutOnly: false,
+            attachedRoute: { id: 'r1', title: 'Alblasserwaard (SD)' },
+            comboEnabled: true,
+        });
+        const { getByText } = render(<WorkoutDetailsDialog workoutId="w1" />);
+        expect(getByText('Start')).toBeTruthy();
+        fireEvent.press(getByText('Start'));
+        expect(mockOnStart).toHaveBeenCalledWith('w1', { noRoute: false });
     });
 
     it('shows the delete confirmation and only deletes on Yes, not on No', () => {

--- a/src/components/WorkoutDetailsDialog/WorkoutDetailsDialog.tsx
+++ b/src/components/WorkoutDetailsDialog/WorkoutDetailsDialog.tsx
@@ -85,9 +85,14 @@ export const WorkoutDetailsDialog = ({ workoutId }: WorkoutDetailsDialogProps) =
         service.onChangeGroup(workoutId, group);
     }, [service, workoutId]);
 
+    // canStart (route attached, combo start) and canStartWorkoutOnly (!canStart, no route) are
+    // mutually exclusive - mirrors desktop's WorkoutDetails onStartClicked()/onStartWorkoutClicked()
+    // split (web-ui/src/components/modules/workout/selection/WorkoutDetails/component.jsx), just
+    // collapsed into mobile's single "Start" button rather than two labelled buttons. noRoute is
+    // only forced when there is no route to start with.
     const onStart = useCallback(() => {
-        service.onStart(workoutId, { noRoute: true });
-    }, [service, workoutId]);
+        service.onStart(workoutId, { noRoute: !details?.canStart });
+    }, [service, workoutId, details?.canStart]);
 
     const onDeleteRequest = useCallback(() => {
         setShowDeleteConfirm(true);
@@ -150,6 +155,7 @@ export const WorkoutDetailsDialog = ({ workoutId }: WorkoutDetailsDialogProps) =
             isScheduled={details.isScheduled}
             scheduledLabel={scheduledLabel}
             canDelete={details.canDelete}
+            canStart={details.canStart}
             canStartWorkoutOnly={details.canStartWorkoutOnly}
             showDeleteConfirm={showDeleteConfirm}
             deleting={deleting}

--- a/src/components/WorkoutDetailsDialog/WorkoutDetailsView.test.tsx
+++ b/src/components/WorkoutDetailsDialog/WorkoutDetailsView.test.tsx
@@ -17,6 +17,7 @@ const baseProps = {
     isScheduled: false,
     scheduledLabel: undefined,
     canDelete: true,
+    canStart: false,
     canStartWorkoutOnly: true,
     showDeleteConfirm: false,
     deleting: false,
@@ -45,9 +46,20 @@ describe('WorkoutDetailsView', () => {
         expect(queryByText('Delete')).toBeNull();
     });
 
-    it('hides the Start button when canStartWorkoutOnly is false', () => {
-        const { queryByText } = render(<WorkoutDetailsView {...baseProps} canStartWorkoutOnly={false} />);
+    it('hides the Start button when neither canStart nor canStartWorkoutOnly is true', () => {
+        const { queryByText } = render(
+            <WorkoutDetailsView {...baseProps} canStart={false} canStartWorkoutOnly={false} />
+        );
         expect(queryByText('Start')).toBeNull();
+    });
+
+    // Regression guard, 2026-08-12 (first Wave 6 real-device pass): Start was only ever gated on
+    // canStartWorkoutOnly, so it silently disappeared the moment a route got attached.
+    it('shows the Start button when canStart is true (route attached, combo)', () => {
+        const { getByText } = render(
+            <WorkoutDetailsView {...baseProps} canStart={true} canStartWorkoutOnly={false} />
+        );
+        expect(getByText('Start')).toBeTruthy();
     });
 
     it('hides the group picker for a scheduled workout', () => {

--- a/src/components/WorkoutDetailsDialog/WorkoutDetailsView.tsx
+++ b/src/components/WorkoutDetailsDialog/WorkoutDetailsView.tsx
@@ -73,7 +73,7 @@ export const WorkoutDetailsView = (props: WorkoutDetailsViewProps) => {
     const {
         title, description, duration, plan, compact,
         ftp, useErgMode, groups, group, isScheduled, scheduledLabel,
-        canDelete, canStartWorkoutOnly,
+        canDelete, canStart, canStartWorkoutOnly,
         showDeleteConfirm, deleting,
         attachedRoute, comboEnabled,
         onClose, onSetFtp, onSetErgMode, onChangeGroup, onStart,
@@ -102,7 +102,9 @@ export const WorkoutDetailsView = (props: WorkoutDetailsViewProps) => {
         { label: 'Close', onClick: onClose },
         ...(canDelete ? [{ label: 'Delete', onClick: onDeleteRequest }] : []),
         ...(showAddRoute ? [{ label: 'Add Route', onClick: onAddRoute }] : []),
-        ...(canStartWorkoutOnly ? [{ label: 'Start', onClick: onStart, primary: true }] : []),
+        // canStart (route attached, combo) and canStartWorkoutOnly (!canStart) are mutually
+        // exclusive - either one means Start is available, onStart itself decides noRoute.
+        ...(canStart || canStartWorkoutOnly ? [{ label: 'Start', onClick: onStart, primary: true }] : []),
     ];
 
     // Web/desktop also shows total duration — folded into the title bar (rather than a

--- a/src/components/WorkoutDetailsDialog/types.ts
+++ b/src/components/WorkoutDetailsDialog/types.ts
@@ -30,6 +30,9 @@ export interface WorkoutDetailsViewProps {
     scheduledLabel?: string;
 
     canDelete: boolean;
+    /** True when a route is currently attached - a combo Start is available (mirrors desktop's
+     *  WorkoutDetails `canStart`, mutually exclusive with canStartWorkoutOnly below). */
+    canStart: boolean;
     canStartWorkoutOnly: boolean;
 
     showDeleteConfirm: boolean;


### PR DESCRIPTION
## Summary
- Found live during the first Wave 6 real-device validation pass: open a Route → "Add Workout" → open the same Workout (route now attached) → no Start button.
- Root cause: the Start button was gated only on `canStartWorkoutOnly` (true exactly when *no* route is attached), and `onStart` always hardcoded `{ noRoute: true }` regardless of attachment state. This is the `WorkoutDetailsDialog` gap flagged (but explicitly left unfixed, out of scope) during session 5.2's PR review (#372).
- Fix mirrors desktop's existing `WorkoutDetails` split (`canStart` = route currently attached/combo start available; `canStartWorkoutOnly` = `!canStart`, no-route start — mutually exclusive, see `web-ui/src/components/modules/workout/selection/WorkoutDetails/component.jsx`'s `onStartClicked()`/`onStartWorkoutClicked()`), collapsed into mobile's single "Start" button: show it when `canStart || canStartWorkoutOnly`, and pass `noRoute: !canStart` to the real start call instead of always `true`.

## Test plan
- [x] `npm test` — 103 suites / 698 tests passing
- [x] `npm run lint` — 0 errors (24 pre-existing warnings, none in touched files)
- [x] `npx tsc --noEmit` — clean
- [x] New tests: `WorkoutDetailsDialog` — combo Start calls `onStart('w1', { noRoute: false })`; `WorkoutDetailsView` — Start renders when `canStart` is true even with `canStartWorkoutOnly` false