### PR TITLE
fix: RideDashboard Time column wraps at 8 tiles (icon-top layout)

### DIFF
--- a/src/components/RideDashboard/RideDashboard.test.tsx
+++ b/src/components/RideDashboard/RideDashboard.test.tsx
@@ -55,6 +55,29 @@ describe('RideDashboardView — workout shoutout', () => {
     });
 });
 
+// Regression guard, real-device Wave 6 finding (2026-08-12): at >7 tiles RideDashboard.tsx forces
+// icon-top layout, whose fixed colWidthBase (90dp, no icon-width bonus unlike icon-left) is too
+// narrow for a remaining-time string like "-1:51:53" at the un-shrunk secondary font size — it
+// wrapped onto a second line, growing the whole dashboard row's height.
+describe('RideDashboardView — Time column secondary value, icon-top layout', () => {
+    const iconTopItems: ActivityDashboardItem[] = [
+        { title: 'Time', data: [{ value: '01:23' }, { value: '-1:51:53' }] },
+        { title: 'Power', data: [{ value: '154', unit: 'W' }, { value: '145', label: 'avg' }] },
+    ];
+
+    test('renders the remaining-time value with numberOfLines=1 (no wrap-driven height growth)', () => {
+        const { getByText } = render(<RideDashboardView items={iconTopItems} layout="icon-top" compact={false} />);
+        expect(getByText('-1:51:53').props.numberOfLines).toBe(1);
+    });
+
+    test('shrinks the Time column\'s secondary font size the same way its primary value already is', () => {
+        const { getByText } = render(<RideDashboardView items={iconTopItems} layout="icon-top" compact={false} />);
+        const timeSecondaryStyle = getByText('-1:51:53').props.style.find((s: any) => s?.fontSize);
+        const powerSecondaryStyle = getByText('145').props.style.find((s: any) => s?.fontSize);
+        expect(timeSecondaryStyle.fontSize).toBeLessThan(powerSecondaryStyle.fontSize);
+    });
+});
+
 // ---------------------------------------------------------------------------
 // RideDashboard (the smart wrapper) — onMetrics reporting
 // (ride-overlay-layout-design.md §3.2: the only way useRideOverlayLayout() learns the current

--- a/src/components/RideDashboard/RideDashboardView.tsx
+++ b/src/components/RideDashboard/RideDashboardView.tsx
@@ -67,6 +67,15 @@ export const RideDashboardView = ({ items, layout = 'icon-top', compact = false,
         const effectiveValueSize =  isTimeColumn
             ? valueSize * 0.75
             : valueSize;
+        // Same reasoning extended to the secondary (remaining-time) value — icon-top's colWidthBase
+        // is a fixed 90dp with no icon-width bonus (unlike icon-left's colWidthLeft), and a
+        // remaining-time string like "-1:51:53" doesn't fit at the un-shrunk size, wrapping the
+        // Text onto a second line and growing the whole tile's (and dashboard row's) height. Found
+        // on a real device, Wave 6 session: this only ever showed up at >7 tiles (icon-top layout),
+        // never in icon-left, where the wider column already had enough room by coincidence.
+        const effectiveSecValueSize = isTimeColumn
+            ? secValueSize * 0.75
+            : secValueSize;
 
         // Secondary row is never shown in compact mode, and is replaced wholesale by the
         // workout shoutout line (below) when one is supplied — not shown alongside it.
@@ -89,16 +98,19 @@ export const RideDashboardView = ({ items, layout = 'icon-top', compact = false,
                         </View>
                         {showSecondaryRow && (
                             <View style={styles.valueRow}>
-                                <Text style={[styles.secValue, { fontSize: secValueSize }]}>
+                                <Text
+                                    style={[styles.secValue, { fontSize: effectiveSecValueSize }]}
+                                    numberOfLines={1}
+                                >
                                     {secondary.value ?? '--'}
                                 </Text>
                                 {secondary.unit && (
-                                    <Text style={[styles.secUnit, { fontSize: secUnitSize }]}>
+                                    <Text style={[styles.secUnit, { fontSize: secUnitSize }]} numberOfLines={1}>
                                         {secondary.unit}
                                     </Text>
                                 )}
                                 {secondary.label && (
-                                    <Text style={[styles.secUnit, { fontSize: secUnitSize }]}>
+                                    <Text style={[styles.secUnit, { fontSize: secUnitSize }]} numberOfLines={1}>
                                         {secondary.label}
                                     </Text>
                                 )}


### PR DESCRIPTION
## Summary
Found live on a real device during the first Wave 6 integration pass, alongside a report that the video-only ride screen's corner-widget positioning looked worse than the combo screen. Root cause was here, not in the positioning code: `RideDashboard.tsx` switches to `icon-top` layout at >7 tiles (the Gear tile reappears once a workout ends and gear-shifting resumes); icon-top's fixed 90dp column has no room for a remaining-time string like `-1:51:53` at the un-shrunk secondary font size, so it wraps onto a second line, growing the dashboard row's height — which was the actual thing throwing off the corner-widget vertical offset (measured from the dashboard's real height).

## Fix
- Extends the existing Time-column font-shrink (already applied to the primary value, "Fix 2" in the file) to the secondary (remaining-time) value/unit too.
- Adds `numberOfLines={1}` as a defensive backstop against any future overflow, on any tile — not just the one string length that happened to trigger this.

## Test plan
- [x] `npm test` — 103 suites / 698 tests passing (2 new tests)
- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit` — clean
- [x] Visually confirmed in Storybook (`Components/RideDashboard` → `Icon Top`, which already had an 8-item fixture with a matching-length remaining-time value) — no wrap, uniform tile height, before/after screenshots taken