### PR TITLE
fix: prevent concurrent InAppBrowser.openAuth() calls on rapid Connect taps

### DIFF
--- a/src/components/OAuthAppSettings/OAuthAppSettings.raceCondition.test.tsx
+++ b/src/components/OAuthAppSettings/OAuthAppSettings.raceCondition.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { TouchableOpacity } from 'react-native';
+import InAppBrowser from 'react-native-inappbrowser-reborn';
+import { OAuthAppSettings } from './OAuthAppSettings';
+
+// Mimics react-native-inappbrowser-reborn's real Android/polyfill behavior:
+// a second concurrent openAuth() call while one is already in flight throws,
+// since the library keeps a single module-level redirect handler.
+let handlerActive = false;
+(InAppBrowser.openAuth as jest.Mock).mockImplementation(() => {
+    if (handlerActive) {
+        throw new Error(
+            'InAppBrowser.openAuth is in a bad state. _redirectHandler is defined when it should not be.'
+        );
+    }
+    handlerActive = true;
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            handlerActive = false;
+            resolve({ type: 'cancel' });
+        }, 20);
+    });
+});
+
+jest.mock('incyclist-services', () => ({
+    useAppsService: () => ({
+        openAppSettings: jest.fn().mockReturnValue({ isConnected: false, operations: [] }),
+        connect: jest.fn().mockResolvedValue(true),
+        disconnect: jest.fn(),
+        enableOperation: jest.fn().mockReturnValue([]),
+    }),
+}));
+
+// Bypasses the isConnecting-based hiding in AppSettingsView so the test
+// isolates whether onConnect itself has a reentrancy guard, independent of
+// render-timing races between a native touch event and a React commit.
+jest.mock('../AppSettingsView', () => ({
+    AppSettingsView: ({ connectButton }: any) => connectButton(),
+}));
+
+afterEach(() => {
+    handlerActive = false;
+    jest.clearAllMocks();
+});
+
+describe('OAuthAppSettings reentrancy guard', () => {
+    it('only calls InAppBrowser.openAuth once when the connect button is pressed rapidly multiple times', async () => {
+        const { UNSAFE_getByType } = render(<OAuthAppSettings appKey="strava" />);
+        const button = UNSAFE_getByType(TouchableOpacity);
+
+        // Simulate rapid repeated taps landing before the isConnecting
+        // state update commits and hides/disables the button.
+        fireEvent.press(button);
+        fireEvent.press(button);
+        fireEvent.press(button);
+
+        await waitFor(() => expect(InAppBrowser.isAvailable).toHaveBeenCalled());
+
+        expect(InAppBrowser.openAuth).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/components/OAuthAppSettings/OAuthAppSettings.tsx
+++ b/src/components/OAuthAppSettings/OAuthAppSettings.tsx
@@ -24,6 +24,7 @@ const OAuthAppSettings = ({ appKey, onBack }: OAuthAppSettingsProps) => {
 
     const refInitialized = useRef<boolean>(false);
     const refStateParam = useRef<string>('');
+    const refConnecting = useRef<boolean>(false);
 
     useEffect(() => {
         if (refInitialized.current || !service) return;
@@ -37,12 +38,13 @@ const OAuthAppSettings = ({ appKey, onBack }: OAuthAppSettingsProps) => {
     }, [service, appKey]);
 
     const onConnect = useCallback(async () => {
-        if (!service) return;
+        if (!service || refConnecting.current) return;
+        refConnecting.current = true;
 
         const stateParam = Math.random().toString(36).substring(2);
         refStateParam.current = stateParam;
 
-        logEvent({ message: 'oauth connect start', appKey, eventSource: 'user' });
+        logEvent({ message: 'button clicked', button:`connect  ${appKey}`, eventSource: 'user' });
         setIsConnecting(true);
 
         const url = `${OAUTH_BASE}/${appKey}?sid=${encodeURIComponent(REDIRECT_URI)}&state=${stateParam}`;
@@ -111,16 +113,20 @@ const OAuthAppSettings = ({ appKey, onBack }: OAuthAppSettingsProps) => {
         } catch (err) {
             logError(err as Error, 'onConnect');
         } finally {
+            refConnecting.current = false;
             setIsConnecting(false);
         }
     }, [service, appKey, logEvent, logError]);
 
     const onDisconnect = useCallback(() => {
+
+        logEvent({ message: 'button clicked', button:`disconnect  ${appKey}`, eventSource: 'user' });
+
         if (!service) return;
         service.disconnect(appKey);
         setIsConnected(false);
         setOperations([]);
-    }, [service, appKey]);
+    }, [logEvent, appKey, service]);
 
     const onOperationsChanged = useCallback(
         (operation: AppsOperation, enabled: boolean) => {
@@ -133,16 +139,16 @@ const OAuthAppSettings = ({ appKey, onBack }: OAuthAppSettingsProps) => {
 
     const stravaConnectButton = useCallback(
         () => (
-            <TouchableOpacity onPress={onConnect}>
+            <TouchableOpacity onPress={onConnect} disabled={isConnecting}>
                 <StravaConnectSvg />
             </TouchableOpacity>
         ),
-        [onConnect],
+        [onConnect, isConnecting],
     );
 
     const intervalsConnectButton = useCallback(
         () => (
-            <TouchableOpacity onPress={onConnect} style={styles.intervalsButton}>
+            <TouchableOpacity onPress={onConnect} disabled={isConnecting} style={styles.intervalsButton}>
                 {React.createElement(
                     require('react-native').Text,
                     { style: styles.intervalsButtonText },
@@ -150,7 +156,7 @@ const OAuthAppSettings = ({ appKey, onBack }: OAuthAppSettingsProps) => {
                 )}
             </TouchableOpacity>
         ),
-        [onConnect],
+        [onConnect, isConnecting],
     );
 
     const connectButton = appKey === 'strava' ? stravaConnectButton : intervalsConnectButton;


### PR DESCRIPTION
## Summary
- Fixes `FIXES_BACKLOG` item #44: rapid re-tapping "Connect" on the Strava/Intervals.icu OAuth screen could fire `onConnect` multiple times before the `isConnecting` state update committed and hid the button, racing several `InAppBrowser.openAuth()` calls.
- On Android, `react-native-inappbrowser-reborn`'s polyfill path only supports one concurrent auth session and throws an Invariant Violation on the second/third call — matches a production log from 2026-08-12 exactly (`version:0.0.42`, three `oauth connect start` events 1-2ms apart followed by two `InAppBrowser.openAuth is in a bad state` errors).
- Also includes an unrelated logging cleanup already in progress on `main` (unifying `oauth connect/disconnect start` into a single `button clicked` event) that was sitting uncommitted in the working tree.

## What changed
- `OAuthAppSettings.tsx`: added a synchronous `refConnecting` ref guard in `onConnect` — a second tap while one is already in flight is a no-op. A `useState`-only guard can't close this race since it only takes effect after a React re-render; the ref is checked/set before the first `await`.
- Added `disabled={isConnecting}` to both connect buttons as defense-in-depth.
- New test `OAuthAppSettings.raceCondition.test.tsx`: fires 3 rapid presses on the connect button, asserts `InAppBrowser.openAuth()` is called exactly once. Verified red→green manually (stashed the fix, confirmed the test fails with `Received: 3`, restored the fix, confirmed it passes).

## Test plan
- [x] `npm test` — 104/104 suites, 701/701 tests pass
- [x] `npx eslint src/components/OAuthAppSettings/` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Manual validation on an Android device: rapid-tap "Connect" for Strava/Intervals.icu several times, confirm no Invariant Violation log entry and exactly one browser session opens