### PR TITLE
fix: route-only ride screens use the combo overlay's corner-widget fit-check/sizing

### DIFF
--- a/src/hooks/render/useRideOverlayLayout.test.ts
+++ b/src/hooks/render/useRideOverlayLayout.test.ts
@@ -3,6 +3,8 @@ import {
     useRideOverlayLayout,
     computeRideOverlayLayout,
     getRideDashboardWidth,
+    fitsSideBySide,
+    buildSideRects,
     RideOverlayArrangement,
     SIDE_WIDGET_MIN_WIDTH,
     TILE_COUNT_SETTLE_MS,
@@ -42,6 +44,46 @@ describe('getRideDashboardWidth', () => {
 
     it('collapses to screenWidth exactly in compact mode (RideDashboard is alignSelf: stretch there)', () => {
         expect(getRideDashboardWidth({ itemCount: 7, layout: 'icon-left', compact: true, screenWidth: 844 })).toBe(844)
+    })
+})
+
+// Exported post-Wave-6 for VideoRidePageView/GPXTourPageView's route-only (no workout attached)
+// corner-widget placement — real-device finding: the old measured-width heuristic kept stacking
+// map/elevation below RideDashboard even when there was genuinely room beside it. These reuse the
+// exact same fit-check/sizing the combo overlay's block-side arrangement already uses.
+describe('fitsSideBySide / buildSideRects - exported for route-only reuse', () => {
+    // Worked numbers from the getRideDashboardWidth tests above, at screenWidth 1280: the 7-tile
+    // icon-left dashboard (895.6 wide) leaves only a 184.2 ear (below the 200 floor) - the exact
+    // non-monotonic-width case ride-overlay-layout-design.md §1.2 documents. The 8-tile icon-top
+    // dashboard that replaces it once the Gear tile appears (743.0 wide) leaves a 260.5 ear instead
+    // - wide enough. This is the real-device transition the bug report described.
+    it('7-tile icon-left dashboard at 1280 width: ear (184.2) is below the floor - does not fit', () => {
+        const w = getRideDashboardWidth({ itemCount: 7, layout: 'icon-left', compact: false, screenWidth: 1280 })
+        expect(fitsSideBySide(1280, 800, w)).toBe(false)
+    })
+
+    it('8-tile icon-top dashboard at 1280 width: ear (260.5) clears the floor - fits', () => {
+        const w = getRideDashboardWidth({ itemCount: 8, layout: 'icon-top', compact: false, screenWidth: 1280 })
+        expect(fitsSideBySide(1280, 800, w)).toBe(true)
+    })
+
+    it('buildSideRects positions the map at left:0 and elevation at right:0, both top:0', () => {
+        const w = getRideDashboardWidth({ itemCount: 8, layout: 'icon-top', compact: false, screenWidth: 1280 })
+        const { map, elevation } = buildSideRects(1280, 800, w, 0, true)
+        expect(map).toMatchObject({ top: 0, left: 0 })
+        expect(elevation).toMatchObject({ top: 0, right: 0 })
+        expect(map!.width).toBeGreaterThanOrEqual(SIDE_WIDGET_MIN_WIDTH)
+    })
+
+    it('buildSideRects omits the map rect when mapVisible is false', () => {
+        const w = getRideDashboardWidth({ itemCount: 8, layout: 'icon-top', compact: false, screenWidth: 1280 })
+        const { map } = buildSideRects(1280, 800, w, 0, false)
+        expect(map).toBeNull()
+    })
+
+    it('a very narrow screen: neither tile count leaves room beside the dashboard', () => {
+        const w = getRideDashboardWidth({ itemCount: 8, layout: 'icon-top', compact: false, screenWidth: 700 })
+        expect(fitsSideBySide(700, 500, w)).toBe(false)
     })
 })
 

--- a/src/hooks/render/useRideOverlayLayout.ts
+++ b/src/hooks/render/useRideOverlayLayout.ts
@@ -203,7 +203,10 @@ export interface RideOverlayLayout {
 // §5.3 - per-ear fit check
 // -----------------------------------------------------------------------------------------------
 
-const earWidthOf = (screenWidth: number, columnWidth: number): number => (screenWidth - columnWidth) / 2 - SIDE_GUTTER
+/** Exported for `Video/View.tsx`/`GPX/View.tsx`'s route-only (no workout attached) corner-widget
+ *  placement — the same "does the ear have room" question the combo algorithm's block-side
+ *  candidate asks, minus the WorkoutDashboard-fitting concern that doesn't apply there. */
+export const earWidthOf = (screenWidth: number, columnWidth: number): number => (screenWidth - columnWidth) / 2 - SIDE_GUTTER
 
 const availableHeight = (top: number, screenHeight: number): number => screenHeight - top - BOTTOM_BAR_RATIO * screenHeight - SLOT_GAP
 
@@ -244,7 +247,10 @@ const sideWidgetSize = (
     height: clamp(SIDE_WIDGET_HEIGHT_RATIO * screenHeight, SIDE_WIDGET_MIN_HEIGHT, availableHeight(top, screenHeight)),
 })
 
-const buildSideRects = (
+/** Exported for the same route-only reuse `earWidthOf` is — the exact rect sizing/positioning
+ *  quality session 4.1 tuned for the combo screen (`SIDE_WIDGET_WIDTH_RATIO`/`_HEIGHT_RATIO`,
+ *  shrinking toward the floor only when the ear is tight), with no WorkoutDashboard dependency. */
+export const buildSideRects = (
     screenWidth: number,
     screenHeight: number,
     columnWidth: number,
@@ -258,6 +264,12 @@ const buildSideRects = (
         elevation: { top, right: 0, width, height },
     }
 }
+
+/** Whether the side widgets fit beside a column of the given effective width, at `top: 0` (the
+ *  route-only case's only vertical candidate — there is no WorkoutDashboard band to sit below
+ *  first, unlike the combo screen's t-side candidate). */
+export const fitsSideBySide = (screenWidth: number, screenHeight: number, columnWidth: number): boolean =>
+    earWidthOf(screenWidth, columnWidth) >= SIDE_WIDGET_MIN_WIDTH && availableHeight(0, screenHeight) >= SIDE_WIDGET_MIN_HEIGHT
 
 // -----------------------------------------------------------------------------------------------
 // §5.5 - the cascade itself

--- a/src/pages/RidePage/GPX/View.tsx
+++ b/src/pages/RidePage/GPX/View.tsx
@@ -22,6 +22,13 @@ import { colors, textSizes } from '../../../theme';
 import { useScreenLayout } from '../../../hooks';
 import { StreetView } from '../../../components/StreetView';
 import { IPosition } from '../../../components/StreetView/types';
+import {
+    getRideDashboardWidth,
+    fitsSideBySide,
+    buildSideRects,
+    RIDE_DASHBOARD_ICON_TOP_TILE_THRESHOLD,
+    DEFAULT_ROUTE_RIDE_TILE_COUNT,
+} from '../../../hooks/render/useRideOverlayLayout';
 
 export interface GPXTourPageViewProps {
     displayProps: GPXRidePageDisplayProps;
@@ -95,38 +102,59 @@ export const GPXTourPageView = (props: GPXTourPageViewProps) => {
     const ELEVATION_PREVIEW_HEIGHT = screenHeight * 0.20;
     const DASHBOARD_HEIGHT = screenHeight * 0.10;
 
-    const [dashboardWidth, setDashboardWidth] = useState(0);
+    // Width is no longer measured (post-Wave-6 fix, see Video/View.tsx's identical comment).
     const [dashboardHeight, setDashboardHeight] = useState(DASHBOARD_HEIGHT);
     const updateDashboardDimensions = useCallback((e: any) => {
-        setDashboardWidth(e.nativeEvent.layout.width);
         setDashboardHeight(e.nativeEvent.layout.height);
     }, []);
 
-    // RideDashboard's own reported tile count — see Video/View.tsx's identical comment.
+    // RideDashboard's own reported tile count — tracked unconditionally now, see Video/View.tsx's
+    // identical comment.
     const [dashboardItemCount, setDashboardItemCount] = useState<number | undefined>(undefined);
     const onDashboardMetrics = useCallback((m: { itemCount: number }) => setDashboardItemCount(m.itemCount), []);
 
     // Same visibility condition the existing corner map below already uses (unchanged, §1.3.1).
     const mapVisible = !isCompact && mainViewIsNotAMap && !!hasGpx && !!routeData?.points?.length;
 
-    // Account for both elevation preview width
-    const reservedRight = screenWidth * (isCompact ? 0.20 : 0.15);
-    const dashboardRightEdge = (screenWidth / 2) + (dashboardWidth / 2);
-    const cornerTopOffset = dashboardRightEdge > (screenWidth - reservedRight) ? dashboardHeight + 2 : 0;
+    // Route-only corner-widget placement — see Video/View.tsx's identical comment for the full
+    // rationale (ports the combo overlay's analytic fit-check/sizing instead of the old
+    // measured-width heuristic).
+    const dashboardLayoutMode = (dashboardItemCount ?? DEFAULT_ROUTE_RIDE_TILE_COUNT) > RIDE_DASHBOARD_ICON_TOP_TILE_THRESHOLD
+        ? 'icon-top' : 'icon-left';
+    const rideDashboardWidthEffective = Math.min(
+        getRideDashboardWidth({
+            itemCount: dashboardItemCount ?? DEFAULT_ROUTE_RIDE_TILE_COUNT,
+            layout: dashboardLayoutMode,
+            compact: isCompact,
+            screenWidth,
+        }),
+        screenWidth,
+    );
+    const sideBySideFits = !isCompact && fitsSideBySide(screenWidth, screenHeight, rideDashboardWidthEffective);
+    const sideRects = sideBySideFits
+        ? buildSideRects(screenWidth, screenHeight, rideDashboardWidthEffective, 0, mapVisible)
+        : null;
 
-    // Dynamic style constants to satisfy no-inline-styles
-    const elevationPreviewDynamicStyle = {
-        height: isCompact ? ELEVATION_FULL_HEIGHT : ELEVATION_PREVIEW_HEIGHT,
-        top: isCompact ? dashboardHeight : cornerTopOffset,
-        width: reservedRight,
-    };
+    // Stacked-below fallback — compact, or the side widgets don't fit beside the dashboard.
+    // Unchanged from before the fix.
+    const reservedRight = screenWidth * (isCompact ? 0.20 : 0.15);
+    const cornerTopOffset = dashboardHeight + 2;
+    const elevationPreviewDynamicStyle = sideRects
+        ? { top: sideRects.elevation.top, right: sideRects.elevation.right, width: sideRects.elevation.width, height: sideRects.elevation.height }
+        : {
+            height: isCompact ? ELEVATION_FULL_HEIGHT : ELEVATION_PREVIEW_HEIGHT,
+            top: isCompact ? dashboardHeight : cornerTopOffset,
+            width: reservedRight,
+        };
     const dashboardDynamicStyle = { height: DASHBOARD_HEIGHT };
 
-    const mapOverlayDynamicStyle = {
-        width: screenWidth * 0.15,
-        height: ELEVATION_PREVIEW_HEIGHT,
-        top: cornerTopOffset,
-    };
+    const mapOverlayDynamicStyle = sideRects?.map
+        ? { top: sideRects.map.top, left: sideRects.map.left, width: sideRects.map.width, height: sideRects.map.height }
+        : {
+            width: screenWidth * 0.15,
+            height: ELEVATION_PREVIEW_HEIGHT,
+            top: cornerTopOffset,
+        };
 
     const bottomBarStyle = {
         position: 'absolute' as const,
@@ -221,7 +249,7 @@ export const GPXTourPageView = (props: GPXTourPageViewProps) => {
                         dashboardDynamicStyle,
                     ]}>
                         <View onLayout={updateDashboardDimensions}>
-                            <RideDashboard layout='icon-left' onMetrics={comboActive ? onDashboardMetrics : undefined} />
+                            <RideDashboard layout='icon-left' onMetrics={onDashboardMetrics} />
                         </View>
                     </View>
 

--- a/src/pages/RidePage/Video/View.tsx
+++ b/src/pages/RidePage/Video/View.tsx
@@ -17,6 +17,13 @@ import {
 import { LatLng } from '../../../components/FreeMap/types';
 import { colors } from '../../../theme';
 import { useScreenLayout  } from '../../../hooks';
+import {
+    getRideDashboardWidth,
+    fitsSideBySide,
+    buildSideRects,
+    RIDE_DASHBOARD_ICON_TOP_TILE_THRESHOLD,
+    DEFAULT_ROUTE_RIDE_TILE_COUNT,
+} from '../../../hooks/render/useRideOverlayLayout';
 
 interface VideoRidePageViewProps {
     displayProps: VideoRidePageDisplayProps;
@@ -88,16 +95,19 @@ export const VideoRidePageView = (props: VideoRidePageViewProps) => {
     const ELEVATION_PREVIEW_HEIGHT = screenHeight * 0.20;
     const DASHBOARD_HEIGHT = screenHeight * 0.10;
 
-    const [dashboardWidth, setDashboardWidth] = useState(0);
+    // Width is no longer measured (post-Wave-6 fix: the corner-widget placement below now uses
+    // RideDashboard's analytic width, same as the combo overlay does and for the same reason —
+    // ride-overlay-layout-design.md §1.1 found onLayout-measured values unreliable). Height still
+    // is; nothing analytic replaces it and the stacked-below fallback still needs it.
     const [dashboardHeight, setDashboardHeight] = useState(DASHBOARD_HEIGHT );
     const updateDashboardDimensions = useCallback((e: any) => {
-        setDashboardWidth(e.nativeEvent.layout.width);
         setDashboardHeight(e.nativeEvent.layout.height);
     }, []);
 
     // RideDashboard's own reported tile count (session 5.1 — ride-overlay-layout-design.md §3.2).
-    // Only consumed by the combo overlay below; falls back to the hook's own default (7) until
-    // the first report lands, and whenever combo is inactive.
+    // Tracked unconditionally now (post-Wave-6 fix): the route-only corner-widget placement below
+    // needs it just as much as the combo overlay does, to compute RideDashboard's real analytic
+    // width rather than guess at the default 7-tile one.
     const [dashboardItemCount, setDashboardItemCount] = useState<number | undefined>(undefined);
     const onDashboardMetrics = useCallback((m: { itemCount: number }) => setDashboardItemCount(m.itemCount), []);
 
@@ -105,25 +115,51 @@ export const VideoRidePageView = (props: VideoRidePageViewProps) => {
     // as the combo layout hook's `mapVisible` input (ride-overlay-layout-design.md §3.1).
     const mapVisible = !isCompact && !!route?.description?.hasGpx && !!routeData?.points?.length;
 
-    // Account for both elevation preview and map width
-    const reservedRight = screenWidth * 0.15 * 2;
-    const dashboardRightEdge = (screenWidth / 2) + (dashboardWidth / 2);
-    const cornerTopOffset = dashboardRightEdge > (screenWidth - reservedRight) ? dashboardHeight+2 : 0;    
+    // Route-only corner-widget placement (map + 2km elevation preview), fixed post-Wave-6: this
+    // used to be a crude heuristic based on the *measured* dashboard width (onLayout), which is
+    // exactly the value ride-overlay-layout-design.md §1.1 found unreliable and replaced with an
+    // analytic formula for the combo screen — ported here rather than reinvented, via the same
+    // `getRideDashboardWidth()`/`fitsSideBySide()`/`buildSideRects()` the combo overlay uses, so a
+    // route-only ride gets the identical fit-check and widget sizing quality. Real-device Wave 6
+    // finding: the old heuristic kept stacking the widgets below the dashboard even when there was
+    // genuinely room beside it.
+    const dashboardLayoutMode = (dashboardItemCount ?? DEFAULT_ROUTE_RIDE_TILE_COUNT) > RIDE_DASHBOARD_ICON_TOP_TILE_THRESHOLD
+        ? 'icon-top' : 'icon-left';
+    const rideDashboardWidthEffective = Math.min(
+        getRideDashboardWidth({
+            itemCount: dashboardItemCount ?? DEFAULT_ROUTE_RIDE_TILE_COUNT,
+            layout: dashboardLayoutMode,
+            compact: isCompact,
+            screenWidth,
+        }),
+        screenWidth,
+    );
+    const sideBySideFits = !isCompact && fitsSideBySide(screenWidth, screenHeight, rideDashboardWidthEffective);
+    const sideRects = sideBySideFits
+        ? buildSideRects(screenWidth, screenHeight, rideDashboardWidthEffective, 0, mapVisible)
+        : null;
 
-    // Dynamic style constants to satisfy no-inline-styles
-    const elevationPreviewDynamicStyle = {
-        height: isCompact ? ELEVATION_FULL_HEIGHT : ELEVATION_PREVIEW_HEIGHT,
-        top: isCompact ? dashboardHeight : cornerTopOffset,
-        width: isCompact ? screenWidth * 0.20 : screenWidth * 0.15,
-    };
+    // Stacked-below fallback — compact, or the side widgets don't fit beside the dashboard.
+    // Unchanged from before the fix (not reported as wrong; only the "should have fit beside but
+    // didn't" case was).
+    const cornerTopOffset = dashboardHeight + 2;
+    const elevationPreviewDynamicStyle = sideRects
+        ? { top: sideRects.elevation.top, right: sideRects.elevation.right, width: sideRects.elevation.width, height: sideRects.elevation.height }
+        : {
+            height: isCompact ? ELEVATION_FULL_HEIGHT : ELEVATION_PREVIEW_HEIGHT,
+            top: isCompact ? dashboardHeight : cornerTopOffset,
+            width: isCompact ? screenWidth * 0.20 : screenWidth * 0.15,
+        };
     const dashboardDynamicStyle = { height: DASHBOARD_HEIGHT };
 
-    const mapOverlayDynamicStyle = {
-        width: screenWidth * 0.15,
-        height: ELEVATION_PREVIEW_HEIGHT,
-        top: cornerTopOffset,
-    };
-    
+    const mapOverlayDynamicStyle = sideRects?.map
+        ? { top: sideRects.map.top, left: sideRects.map.left, width: sideRects.map.width, height: sideRects.map.height }
+        : {
+            width: screenWidth * 0.15,
+            height: ELEVATION_PREVIEW_HEIGHT,
+            top: cornerTopOffset,
+        };
+
     const bottomBarStyle = {
         position: 'absolute' as const,
         bottom: 0,
@@ -155,7 +191,7 @@ export const VideoRidePageView = (props: VideoRidePageViewProps) => {
                     dashboardDynamicStyle
                 ]}>
                     <View onLayout={updateDashboardDimensions}>
-                        <RideDashboard layout='icon-left' onMetrics={comboActive ? onDashboardMetrics : undefined} />
+                        <RideDashboard layout='icon-left' onMetrics={onDashboardMetrics} />
                     </View>
                 </View>
             </View>}


### PR DESCRIPTION
## Summary
Real-device Wave 6 finding: `VideoRidePageView`/`GPXTourPageView`'s map+elevation corner-widget placement (route-only, no workout attached) used a crude heuristic based on `RideDashboard`'s *measured* width (`onLayout`) — exactly what `ride-overlay-layout-design.md` §1.1 already found unreliable and replaced with an analytic formula for the combo overlay. Confirmed still broken even after #375 (the dashboard-wrap fix): the widgets kept stacking below `RideDashboard` even when there was genuinely room beside it.

## Fix
Ports the combo overlay's own fit-check (`fitsSideBySide`, newly exported from `useRideOverlayLayout.ts`) and rect sizing (`buildSideRects`, newly exported) instead of reinventing them — the same tuned `SIDE_WIDGET_MIN_WIDTH`/`_HEIGHT` floor and proportional sizing session 4.1 already validated for the combo screen, using `RideDashboard`'s analytic width (`getRideDashboardWidth`, already exported) fed by the tile count `RideDashboard` now reports via `onMetrics` **unconditionally** (previously only tracked when a workout was attached).

The stacked-below fallback (compact mode, or genuinely no room beside the dashboard) is unchanged — only the "should fit beside but didn't" case was reported wrong.

## Test plan
- [x] `npm test` — 103 suites / 705 tests passing (5 new tests, pinned to the exact numbers from the real-device report)
- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit` — clean
- [ ] **Real-device re-verification still needed.** `RideDashboard`'s real (service-backed) component renders nothing in Storybook (no live ride observer to attach to), which collapses its measured height to near-zero there — this makes the side-fit vs stacked-below cases visually indistinguishable in Storybook regardless of which one actually fires, so I could not get a clean visual proof there. Verified via unit tests instead, using the exact numbers from the report: a 7-tile icon-left dashboard at 1280px width doesn't fit beside (ear 184.2 < floor 200); an 8-tile icon-top dashboard (what the device transitions to once the workout ends and virtual shifting adds the Gear tile) does (ear 260.5).