### PR TITLE
fix: Street View black screen — load lifecycle, retry and diagnostics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "axios": "^1.17.0",
         "events": "^3.3.0",
         "gd-eventlog": "^0.1.27",
-        "incyclist-services": "^1.7.105",
+        "incyclist-services": "^1.7.106",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
         "react": "^19.2.4",
@@ -11739,9 +11739,9 @@
       }
     },
     "node_modules/incyclist-services": {
-      "version": "1.7.105",
-      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.105.tgz",
-      "integrity": "sha512-wzC1WYUFxBq+6gfOWH4kFAAto0hltRCmhj0+8eBUwjXkXRUpXwGvKoS6rzl7OYTSR9l6JD+9HOODykIqnctCag==",
+      "version": "1.7.106",
+      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.106.tgz",
+      "integrity": "sha512-M9RpjMLZyttWQTQgFleTaJu9EEPcL7+j9qAU1xr3uphoQtTfcC3UPM9Ph8HijYVtAchRB3dFoIoGIO3K7OkF1A==",
       "dependencies": {
         "@garmin/fitsdk": "^21.200.0",
         "axios": "^1.15.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "axios": "^1.17.0",
         "events": "^3.3.0",
         "gd-eventlog": "^0.1.27",
-        "incyclist-services": "^1.7.104",
+        "incyclist-services": "^1.7.105",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
         "react": "^19.2.4",
@@ -11739,9 +11739,9 @@
       }
     },
     "node_modules/incyclist-services": {
-      "version": "1.7.104",
-      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.104.tgz",
-      "integrity": "sha512-BCnvCbKts+ophw97Qqg/MYk3I7lWIkcRTw8uNmLJDJ5JnX8VvvjYKSYi1dLhBWLa/lnTOqTkzFXbugvQOH9sXA==",
+      "version": "1.7.105",
+      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.105.tgz",
+      "integrity": "sha512-wzC1WYUFxBq+6gfOWH4kFAAto0hltRCmhj0+8eBUwjXkXRUpXwGvKoS6rzl7OYTSR9l6JD+9HOODykIqnctCag==",
       "dependencies": {
         "@garmin/fitsdk": "^21.200.0",
         "axios": "^1.15.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "axios": "^1.17.0",
     "events": "^3.3.0",
     "gd-eventlog": "^0.1.27",
-    "incyclist-services": "^1.7.104",
+    "incyclist-services": "^1.7.105",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "react": "^19.2.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "axios": "^1.17.0",
     "events": "^3.3.0",
     "gd-eventlog": "^0.1.27",
-    "incyclist-services": "^1.7.105",
+    "incyclist-services": "^1.7.106",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "react": "^19.2.4",

--- a/src/components/Dynamic/Dynamic.tsx
+++ b/src/components/Dynamic/Dynamic.tsx
@@ -103,9 +103,15 @@ export const Dynamic = (props: DynamicProps) => {
 
     const renderChild = (child: ReactElement<any>) => {
         if (!child) return null;
-        
-        const childStyle = { ...((child.props as any).style ?? {}), ...extraStyle };
-        
+
+        // Reuse the child's own style object when there is nothing to merge into it: a fresh
+        // object on every render changes the prop identity, which defeats any React.memo on
+        // the child and makes render tracing useless.
+        const ownStyle = (child.props as any).style;
+        const childStyle = hidden
+            ? { ...(ownStyle ?? {}), ...extraStyle }
+            : ownStyle;
+
         return React.cloneElement(child, {
             ...staticProps,
             ...dynamicProps,

--- a/src/components/Dynamic/Dynamic.tsx
+++ b/src/components/Dynamic/Dynamic.tsx
@@ -1,6 +1,9 @@
 import React, { useRef, useState, useEffect, ReactElement } from 'react';
+import { StyleSheet } from 'react-native';
 import { IObserver } from 'incyclist-services';
 import { useUnmountEffect } from '../../hooks';
+
+const HIDDEN_STYLE = { opacity: 0 };
 
 interface DynamingMapping {
     event: string;
@@ -99,17 +102,17 @@ export const Dynamic = (props: DynamicProps) => {
     });
 
     const staticProps = copyPropsExcluding(props, EXCLUDED_PROPS);
-    const extraStyle = hidden ? { opacity: 0 } : {};
 
     const renderChild = (child: ReactElement<any>) => {
         if (!child) return null;
 
-        // Reuse the child's own style object when there is nothing to merge into it: a fresh
-        // object on every render changes the prop identity, which defeats any React.memo on
-        // the child and makes render tracing useless.
+        // Pass the child's own style through untouched unless something has to be merged into
+        // it: a fresh object on every render changes the prop identity, which defeats any
+        // React.memo on the child and makes render tracing useless. flatten() (rather than an
+        // array) keeps the result a plain object, which not every child tolerates as an array.
         const ownStyle = (child.props as any).style;
         const childStyle = hidden
-            ? { ...(ownStyle ?? {}), ...extraStyle }
+            ? StyleSheet.flatten([ownStyle, HIDDEN_STYLE])
             : ownStyle;
 
         return React.cloneElement(child, {

--- a/src/components/StreetView/StreetView.test.tsx
+++ b/src/components/StreetView/StreetView.test.tsx
@@ -1,13 +1,124 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, act } from '@testing-library/react-native';
 import { StreetView } from './StreetView';
 
 jest.mock('../../specs/StreetViewNativeComponent', () => 'StreetView');
 
+const P1 = { lat: 40.758, lng: -73.9855, heading: 0 };
+const P2 = { lat: 40.759, lng: -73.986, heading: 90 };
+
+/** props the native component was rendered with, or null when it was not rendered at all */
+const nativeProps = (result: ReturnType<typeof render>): any =>
+    (result.toJSON() as any)?.props ?? null;
+
 it('renders without crashing', () => {
-    render(
-        <StreetView
-            position={{ lat: 40.758, lng: -73.9855, heading: 0 }}
-        />,
-    );
+    render(<StreetView position={P1} />);
+});
+
+it('does not render the native view before a position is known', () => {
+    // rendering without one would ask the Maps SDK for a panorama at (0,0)
+    const result = render(<StreetView />);
+
+    expect(result.toJSON()).toBeNull();
+});
+
+it('applies the initial position', () => {
+    const result = render(<StreetView position={P1} />);
+
+    expect(nativeProps(result).latitude).toBe(P1.lat);
+    expect(nativeProps(result).longitude).toBe(P1.lng);
+});
+
+it('raises the position timeout above the observed first-load time', () => {
+    const result = render(<StreetView position={P1} />);
+
+    expect(nativeProps(result).positionTimeout).toBe(12000);
+});
+
+it('lets an explicit position timeout win', () => {
+    const result = render(<StreetView position={P1} positionTimeout={3000} />);
+
+    expect(nativeProps(result).positionTimeout).toBe(3000);
+});
+
+it('queues position updates while the initial load is outstanding', () => {
+    const result = render(<StreetView position={P1} />);
+
+    result.rerender(<StreetView position={P2} />);
+
+    // superseding the in-flight request can stop the initial load from ever completing
+    expect(nativeProps(result).latitude).toBe(P1.lat);
+});
+
+it('applies the queued position once loaded', () => {
+    const result = render(<StreetView position={P1} />);
+    result.rerender(<StreetView position={P2} />);
+
+    act(() => { nativeProps(result).onLoaded(); });
+
+    expect(nativeProps(result).latitude).toBe(P2.lat);
+});
+
+it('applies position updates directly once loaded', () => {
+    const result = render(<StreetView position={P1} />);
+    act(() => { nativeProps(result).onLoaded(); });
+
+    result.rerender(<StreetView position={P2} />);
+
+    expect(nativeProps(result).latitude).toBe(P2.lat);
+});
+
+it('forwards the loaded event to the caller', () => {
+    const onLoaded = jest.fn();
+    const result = render(<StreetView position={P1} onLoaded={onLoaded} />);
+
+    act(() => { nativeProps(result).onLoaded(); });
+
+    expect(onLoaded).toHaveBeenCalled();
+});
+
+it('retries the position when the initial load never completes', () => {
+    jest.useFakeTimers();
+    try {
+        const result = render(<StreetView position={P1} />);
+
+        act(() => { jest.advanceTimersByTime(8000); });
+
+        const { latitude } = nativeProps(result);
+        expect(latitude).not.toBe(P1.lat);
+        expect(latitude).toBeCloseTo(P1.lat, 6);
+    }
+    finally {
+        jest.useRealTimers();
+    }
+});
+
+it('stops retrying once loaded', () => {
+    jest.useFakeTimers();
+    try {
+        const result = render(<StreetView position={P1} />);
+        act(() => { nativeProps(result).onLoaded(); });
+
+        act(() => { jest.advanceTimersByTime(60000); });
+
+        expect(nativeProps(result).latitude).toBe(P1.lat);
+    }
+    finally {
+        jest.useRealTimers();
+    }
+});
+
+it('stops retrying once the panorama reports no imagery', () => {
+    jest.useFakeTimers();
+    try {
+        const result = render(<StreetView position={P1} />);
+        act(() => { nativeProps(result).onNoPanorama(); });
+
+        act(() => { jest.advanceTimersByTime(60000); });
+
+        expect(nativeProps(result).latitude).toBe(P1.lat);
+    }
+    finally {
+        jest.useRealTimers();
+    }
 });

--- a/src/components/StreetView/StreetView.test.tsx
+++ b/src/components/StreetView/StreetView.test.tsx
@@ -93,6 +93,43 @@ it('retries the position when the initial load never completes', () => {
     }
 });
 
+it('keeps applying position updates when the load never completes', () => {
+    // On a device whose panorama never resolves, holding updates back forever would leave the
+    // view making no attempts at all once the retries are exhausted - worse than not gating.
+    jest.useFakeTimers();
+    try {
+        const result = render(<StreetView position={P1} />);
+        act(() => { jest.advanceTimersByTime(60000); });
+
+        // the ride is running now, so position updates keep arriving
+        for (let i = 1; i <= 6; i++) {
+            result.rerender(<StreetView position={{ ...P2, lat: P2.lat + i * 0.0001 }} />);
+            act(() => { jest.advanceTimersByTime(3000); });
+        }
+
+        // the view must have moved on from where it started, not stayed stuck on it
+        expect(nativeProps(result).latitude).not.toBeCloseTo(P1.lat, 3);
+    }
+    finally {
+        jest.useRealTimers();
+    }
+});
+
+it('still holds back an update that arrives while a load is genuinely in flight', () => {
+    jest.useFakeTimers();
+    try {
+        const result = render(<StreetView position={P1} />);
+        act(() => { jest.advanceTimersByTime(1000); });
+
+        result.rerender(<StreetView position={P2} />);
+
+        expect(nativeProps(result).latitude).toBe(P1.lat);
+    }
+    finally {
+        jest.useRealTimers();
+    }
+});
+
 it('stops retrying once loaded', () => {
     jest.useFakeTimers();
     try {

--- a/src/components/StreetView/StreetView.tsx
+++ b/src/components/StreetView/StreetView.tsx
@@ -1,9 +1,41 @@
-import React, { useCallback } from 'react';
-import { NativeSyntheticEvent, StyleSheet } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { LayoutChangeEvent, NativeSyntheticEvent, StyleSheet } from 'react-native';
 import StreetViewNativeComponent from '../../specs/StreetViewNativeComponent';
-import { StreetViewProps, StreetViewErrorReason } from './types';
+import { StreetViewProps, StreetViewErrorReason, IPosition } from './types';
 import { useLogging, useWhyDidYouRender } from '../../hooks';
 
+/**
+ * The native default (2000ms) sits right on top of the real first-load time - production logs
+ * show ~2.2s even on a fast device on a fast network - so it reports 'unavailable' as a false
+ * alarm on almost every ride. The timeout never cancels the pending request, it only reports,
+ * so a generous value costs nothing.
+ */
+const DEFAULT_POSITION_TIMEOUT = 12000;
+
+/** elapsed times (ms) at which an initial load that has not completed yet is reported */
+const WATCHDOG_MARKS = [2000, 5000, 10000, 20000, 30000];
+
+/** elapsed times (ms) at which the position is re-sent while the initial load is outstanding */
+const RETRY_DELAYS = [8000, 20000, 40000];
+
+/**
+ * Offset applied to a retried position: large enough that neither our own comparison nor the
+ * Maps SDK can treat the request as a no-op, small enough (~1cm) to be invisible to the rider.
+ */
+const RETRY_OFFSET = 1e-7;
+
+const samePosition = (a?: IPosition | null, b?: IPosition | null) =>
+    a?.lat === b?.lat && a?.lng === b?.lng && a?.heading === b?.heading;
+
+/**
+ * Wraps the native Street View component with the load lifecycle the native side does not
+ * own: it decides which position is handed down, reports loads that are taking too long and
+ * retries ones that never complete.
+ *
+ * Background: the panorama only becomes visible once the Maps SDK fires its change listener.
+ * If that never happens the component shows nothing at all, and nothing in the shipped native
+ * code retries or reports it - which is what a black ride screen looks like from the outside.
+ */
 export const StreetView = (props: StreetViewProps) => {
 
     const {logEvent} = useLogging('StreetView')
@@ -20,49 +52,174 @@ export const StreetView = (props: StreetViewProps) => {
         onPanoramaChanged,
     } = props;
 
+    // the position actually handed to the native component - deliberately not `props.position`
+    const [applied, setApplied] = useState<IPosition | undefined>(undefined);
+
+    const sentRef = useRef<IPosition | undefined>(undefined);
+    const sentAtRef = useRef<number | undefined>(undefined);
+    const pendingRef = useRef<IPosition | undefined>(undefined);
+    const loadedRef = useRef(false);
+    const retriesRef = useRef(0);
+    const timersRef = useRef<Array<ReturnType<typeof setTimeout>>>([]);
+    const sizeRef = useRef<{ width: number, height: number } | undefined>(undefined);
+
+    const clearTimers = useCallback(() => {
+        timersRef.current.forEach(clearTimeout);
+        timersRef.current = [];
+    }, []);
+
+    const armWatchdog = useCallback((sent: IPosition) => {
+        WATCHDOG_MARKS.forEach(elapsed => {
+            timersRef.current.push(setTimeout(() => {
+                logEvent({
+                    message: 'streetview still waiting',
+                    elapsed,
+                    retries: retriesRef.current,
+                    lat: sent.lat,
+                    lng: sent.lng,
+                    ...sizeRef.current,
+                });
+            }, elapsed));
+        });
+
+        RETRY_DELAYS.forEach((delay, i) => {
+            timersRef.current.push(setTimeout(() => {
+                const attempt = i + 1;
+                const retried = { ...sent, lat: sent.lat + RETRY_OFFSET * attempt };
+
+                retriesRef.current = attempt;
+                sentRef.current = retried;
+                sentAtRef.current = Date.now();
+                logEvent({ message: 'streetview retry', attempt, lat: retried.lat, lng: retried.lng });
+                setApplied(retried);
+            }, delay));
+        });
+    }, [logEvent]);
+
+    const applyPosition = useCallback((next: IPosition, reason: string) => {
+        clearTimers();
+        sentRef.current = next;
+        sentAtRef.current = Date.now();
+        setApplied(next);
+
+        // steady-state updates are already logged by the service - only log what the service
+        // cannot see, i.e. everything around an initial load that has not completed yet
+        if (!loadedRef.current || reason !== 'update') {
+            logEvent({
+                message: 'streetview position applied',
+                reason,
+                lat: next.lat,
+                lng: next.lng,
+                heading: next.heading,
+                ...sizeRef.current,
+            });
+        }
+
+        if (!loadedRef.current)
+            armWatchdog(next);
+    }, [clearTimers, armWatchdog, logEvent]);
+
+    useEffect(() => {
+        if (!position)
+            return;
+        if (samePosition(position, sentRef.current))
+            return;
+
+        // While the first panorama is still in flight, queue the update instead of sending it:
+        // every setPosition() supersedes the outstanding request, so a stream of updates on a
+        // slow connection can keep the initial load from ever completing.
+        if (!loadedRef.current && sentRef.current) {
+            pendingRef.current = position;
+            return;
+        }
+
+        applyPosition(position, sentRef.current ? 'update' : 'initial');
+    }, [position, applyPosition]);
+
+    useEffect(() => clearTimers, [clearTimers]);
+
     const handleLicenseConsumed = useCallback(() => {
         onLicenseConsumed?.();
         logEvent( {message:'streetview license consumed', cnt:1})
     }, [onLicenseConsumed,logEvent]);
 
     const handleLoaded = useCallback(() => {
-        logEvent({message:'streetview loaded'})
+        const elapsed = sentAtRef.current ? Date.now() - sentAtRef.current : undefined;
+
+        loadedRef.current = true;
+        clearTimers();
+        logEvent({message:'streetview loaded', elapsed, retries: retriesRef.current})
         onLoaded?.();
-    }, [onLoaded,logEvent]);
+
+        const pending = pendingRef.current;
+        pendingRef.current = undefined;
+        if (pending && !samePosition(pending, sentRef.current))
+            applyPosition(pending, 'pending');
+    }, [onLoaded,logEvent,clearTimers,applyPosition]);
 
     const handleNoPanorama = useCallback(() => {
+        // the SDK answered - whatever it answered, the view is no longer waiting
+        clearTimers();
         logEvent({message:'streetview panorama not available'})
         onNoPanorama?.();
-    }, [onNoPanorama,logEvent]);
+    }, [onNoPanorama,logEvent,clearTimers]);
 
     const handlePanoramaChanged = useCallback(() => {
+        clearTimers();
         logEvent({message:'streetview panorama changed'})
         onPanoramaChanged?.();
-    }, [onPanoramaChanged,logEvent]);
+    }, [onPanoramaChanged,logEvent,clearTimers]);
 
     const handleNativeError = useCallback(
         (event: NativeSyntheticEvent<{ reason: string }>) => {
+            const elapsed = sentAtRef.current ? Date.now() - sentAtRef.current : undefined;
+
             onError?.(event.nativeEvent.reason as StreetViewErrorReason);
-            logEvent({message:'streetview error', ...event.nativeEvent})
+            logEvent({
+                message: 'streetview error',
+                ...event.nativeEvent,
+                elapsed,
+                retries: retriesRef.current,
+                loaded: loadedRef.current,
+                ...sizeRef.current,
+            })
         },
         [onError,logEvent],
     );
 
-    useWhyDidYouRender('StreetView',props)
+    const handleLayout = useCallback((event: LayoutChangeEvent) => {
+        const {width, height} = event.nativeEvent.layout;
+        const prev = sizeRef.current;
+
+        sizeRef.current = {width, height};
+        // a zero-sized surface is a plausible reason for the Maps SDK never to load a
+        // panorama, so the size the view actually got is worth having in the logs
+        if (prev?.width !== width || prev?.height !== height)
+            logEvent({message:'streetview layout', width, height})
+    }, [logEvent]);
+
+    useWhyDidYouRender('StreetView',props,true)
+
+    const mergedStyle = useMemo(() => [styles.container, style], [style]);
+
+    // Rendering before a position is known would ask the SDK for a panorama at (0,0)
+    if (!applied)
+        return null;
 
     return (
         <StreetViewNativeComponent
-            latitude={position?.lat ?? 0}
-            longitude={position?.lng ?? 0}
-            heading={position?.heading ?? 0}
+            latitude={applied.lat}
+            longitude={applied.lng}
+            heading={applied.heading ?? 0}
             readyTimeout={readyTimeout}
-            positionTimeout={positionTimeout}
+            positionTimeout={positionTimeout ?? DEFAULT_POSITION_TIMEOUT}
             onLicenseConsumed={handleLicenseConsumed}
             onLoaded={handleLoaded}
             onNoPanorama={handleNoPanorama}
             onPanoramaChanged={handlePanoramaChanged}
             onError={handleNativeError}
-            style={[styles.container, style]}
+            onLayout={handleLayout}
+            style={mergedStyle}
         />
     );
 };

--- a/src/components/StreetView/StreetView.tsx
+++ b/src/components/StreetView/StreetView.tsx
@@ -19,6 +19,21 @@ const WATCHDOG_MARKS = [2000, 5000, 10000, 20000, 30000];
 const RETRY_DELAYS = [8000, 20000, 40000];
 
 /**
+ * Age at which an unanswered request stops being treated as in-flight. Position updates are
+ * held back while a load is outstanding, but only up to this point: on a device where the
+ * panorama never resolves, continuing to hold them back would leave the component making no
+ * further attempts at all once the retries are exhausted.
+ */
+const STALE_AFTER = RETRY_DELAYS[0];
+
+/**
+ * Number of unanswered load attempts reported in full. The first attempt happens while the
+ * start overlay is up and carries the diagnostic payload; repeating all of it for every
+ * attempt of a permanently failing ride would flood the log without adding information.
+ */
+const REPORTED_ATTEMPTS = 2;
+
+/**
  * Offset applied to a retried position: large enough that neither our own comparison nor the
  * Maps SDK can treat the request as a no-op, small enough (~1cm) to be invisible to the rider.
  */
@@ -60,6 +75,7 @@ export const StreetView = (props: StreetViewProps) => {
     const pendingRef = useRef<IPosition | undefined>(undefined);
     const loadedRef = useRef(false);
     const retriesRef = useRef(0);
+    const attemptsRef = useRef(0);
     const timersRef = useRef<Array<ReturnType<typeof setTimeout>>>([]);
     const sizeRef = useRef<{ width: number, height: number } | undefined>(undefined);
 
@@ -68,29 +84,38 @@ export const StreetView = (props: StreetViewProps) => {
         timersRef.current = [];
     }, []);
 
-    const armWatchdog = useCallback((sent: IPosition) => {
-        WATCHDOG_MARKS.forEach(elapsed => {
-            timersRef.current.push(setTimeout(() => {
-                logEvent({
-                    message: 'streetview still waiting',
-                    elapsed,
-                    retries: retriesRef.current,
-                    lat: sent.lat,
-                    lng: sent.lng,
-                    ...sizeRef.current,
-                });
-            }, elapsed));
-        });
+    const armWatchdog = useCallback((sent: IPosition, attempt: number) => {
+        if (attempt <= REPORTED_ATTEMPTS) {
+            WATCHDOG_MARKS.forEach(elapsed => {
+                timersRef.current.push(setTimeout(() => {
+                    logEvent({
+                        message: 'streetview still waiting',
+                        elapsed,
+                        attempt,
+                        retries: retriesRef.current,
+                        lat: sent.lat,
+                        lng: sent.lng,
+                        ...sizeRef.current,
+                    });
+                }, elapsed));
+            });
+        }
+
+        // Retries only matter for the first attempt: it happens while the start overlay is up
+        // and nothing else is driving the view. Once the ride is running, position updates
+        // supply the re-attempts themselves (see the staleness check below).
+        if (attempt > 1)
+            return;
 
         RETRY_DELAYS.forEach((delay, i) => {
             timersRef.current.push(setTimeout(() => {
-                const attempt = i + 1;
-                const retried = { ...sent, lat: sent.lat + RETRY_OFFSET * attempt };
+                const retry = i + 1;
+                const retried = { ...sent, lat: sent.lat + RETRY_OFFSET * retry };
 
-                retriesRef.current = attempt;
+                retriesRef.current = retry;
                 sentRef.current = retried;
                 sentAtRef.current = Date.now();
-                logEvent({ message: 'streetview retry', attempt, lat: retried.lat, lng: retried.lng });
+                logEvent({ message: 'streetview retry', retry, lat: retried.lat, lng: retried.lng });
                 setApplied(retried);
             }, delay));
         });
@@ -100,14 +125,20 @@ export const StreetView = (props: StreetViewProps) => {
         clearTimers();
         sentRef.current = next;
         sentAtRef.current = Date.now();
+        pendingRef.current = undefined;
         setApplied(next);
 
+        const attempt = loadedRef.current ? 0 : attemptsRef.current + 1;
+        if (!loadedRef.current)
+            attemptsRef.current = attempt;
+
         // steady-state updates are already logged by the service - only log what the service
-        // cannot see, i.e. everything around an initial load that has not completed yet
+        // cannot see, i.e. everything around a load that has not completed yet
         if (!loadedRef.current || reason !== 'update') {
             logEvent({
                 message: 'streetview position applied',
                 reason,
+                attempt: attempt || undefined,
                 lat: next.lat,
                 lng: next.lng,
                 heading: next.heading,
@@ -116,7 +147,7 @@ export const StreetView = (props: StreetViewProps) => {
         }
 
         if (!loadedRef.current)
-            armWatchdog(next);
+            armWatchdog(next, attempt);
     }, [clearTimers, armWatchdog, logEvent]);
 
     useEffect(() => {
@@ -125,12 +156,17 @@ export const StreetView = (props: StreetViewProps) => {
         if (samePosition(position, sentRef.current))
             return;
 
-        // While the first panorama is still in flight, queue the update instead of sending it:
-        // every setPosition() supersedes the outstanding request, so a stream of updates on a
-        // slow connection can keep the initial load from ever completing.
+        // While a panorama is still in flight, queue the update instead of sending it: every
+        // setPosition() supersedes the outstanding request, so a stream of updates on a slow
+        // connection can keep the load from ever completing. Past STALE_AFTER the request is
+        // no longer treated as in-flight - on a device where the panorama never resolves,
+        // holding updates back forever would stop the view from ever trying again.
         if (!loadedRef.current && sentRef.current) {
-            pendingRef.current = position;
-            return;
+            const age = Date.now() - (sentAtRef.current ?? 0);
+            if (age < STALE_AFTER) {
+                pendingRef.current = position;
+                return;
+            }
         }
 
         applyPosition(position, sentRef.current ? 'update' : 'initial');
@@ -148,7 +184,7 @@ export const StreetView = (props: StreetViewProps) => {
 
         loadedRef.current = true;
         clearTimers();
-        logEvent({message:'streetview loaded', elapsed, retries: retriesRef.current})
+        logEvent({message:'streetview loaded', elapsed, attempts: attemptsRef.current, retries: retriesRef.current})
         onLoaded?.();
 
         const pending = pendingRef.current;

--- a/src/pages/RidePage/GPX/View.tsx
+++ b/src/pages/RidePage/GPX/View.tsx
@@ -73,7 +73,7 @@ export const GPXTourPageView = (props: GPXTourPageViewProps) => {
         onStopWorkout,
     } = props;
 
-    const { startOverlayProps,menuProps,rideView,route,displayObserver,workoutAttached,graph,steps,dashboard,cornerWidget} = displayProps??{};
+    const { startOverlayProps,menuProps,rideView,route,displayObserver,displayPosition,onDisplayEvent,workoutAttached,graph,steps,dashboard,cornerWidget} = displayProps??{};
 
     // Derived properties
     const routeData = route?.details;
@@ -176,10 +176,56 @@ export const GPXTourPageView = (props: GPXTourPageViewProps) => {
         return val
     }, []);
 
+    // The native component's event names are translated onto the service's (desktop-derived)
+    // StreetViewEvent vocabulary here, so `onStreetViewEvent()` stays a single code path for
+    // both platforms.
+    //
+    // 'Loaded' is what releases the start overlay - without it the overlay used to be torn
+    // down onto a panorama that had not loaded yet, i.e. a black screen.
+    const onSVLoaded = useCallback(() => {
+        onDisplayEvent?.('Loaded')
+    }, [onDisplayEvent]);
+
+    // confirms a position update actually rendered - feeds the service's adaptive update delay
+    const onSVPanoramaChanged = useCallback(() => {
+        onDisplayEvent?.('pano_changed')
+    }, [onDisplayEvent]);
+
+    // no imagery at the requested position: a valid answer, not a failure
+    const onSVNoPanorama = useCallback(() => {
+        onDisplayEvent?.('status_changed')
+    }, [onDisplayEvent]);
+
+    // Deliberately NOT reported as 'Error': the native 'unavailable' reason is only a timeout
+    // and the panorama may still arrive, while a mapStateError puts the start overlay into a
+    // dead end whose only button is Cancel. The component logs the error for telemetry.
+    const svPosition = displayPosition as IPosition | undefined;
+
     return (
         <View style={styles.container} testID='gpx-tour-page-view'>
 
-            
+            {/* Street View lives outside the start-overlay gate on purpose: the panorama can
+                only start loading once the native view is mounted, so gating it on the overlay
+                being gone guaranteed the rider saw an empty screen for the whole load. It now
+                loads behind the overlay (which covers it via MainBackground) and the service
+                closes the overlay when 'Loaded' arrives. */}
+            { (rideView === 'sv') && (
+                <Dynamic
+                    observer={displayObserver}
+                    event='position-update'
+                    prop='position'
+                    transform={transformSVPosition}
+                >
+                    <SV
+                        position={svPosition}
+                        style={styles.fullScreenMap}
+                        onLoaded={onSVLoaded}
+                        onPanoramaChanged={onSVPanoramaChanged}
+                        onNoPanorama={onSVNoPanorama}
+                    />
+                </Dynamic>
+            )}
+
             {/* Main content layer, conditionally hidden by start overlay */}
             {!startOverlayProps && (
                 <View style={StyleSheet.absoluteFill}>
@@ -202,20 +248,6 @@ export const GPXTourPageView = (props: GPXTourPageViewProps) => {
                             />
                         </Dynamic>
                     )}
-                    { (rideView === 'sv' ) && (
-                        <Dynamic
-                            observer={displayObserver}
-                            event='position-update'
-                            prop='position'
-                            transform={transformSVPosition}
-                        >
-                            <SV
-                                position={routeData?.points?.[0] as IPosition}                                
-                                style={styles.fullScreenMap}
-                            />
-                        </Dynamic>
-                    )}
-
                     {/* Corner orientation map — shown only when the main view above isn't itself a map.
                         Route-only rendering, untouched (HLD §9.1). Replaced by WorkoutRideOverlay's
                         own corner-widget rects when a workout is attached and the combo toggle is on. */}

--- a/src/pages/RidePage/GPX/View.tsx
+++ b/src/pages/RidePage/GPX/View.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { View, StyleSheet, useWindowDimensions  } from 'react-native';
 import {
     IObserver,
@@ -180,21 +180,27 @@ export const GPXTourPageView = (props: GPXTourPageViewProps) => {
     // StreetViewEvent vocabulary here, so `onStreetViewEvent()` stays a single code path for
     // both platforms.
     //
+    // The service re-binds onDisplayEvent on every getDisplayProperties() call, so it is held
+    // in a ref: handlers that changed identity on every page update would push new props to
+    // the native view roughly once a second and drown the render trace in noise.
+    const displayEventRef = useRef(onDisplayEvent);
+    displayEventRef.current = onDisplayEvent;
+
     // 'Loaded' is what releases the start overlay - without it the overlay used to be torn
     // down onto a panorama that had not loaded yet, i.e. a black screen.
     const onSVLoaded = useCallback(() => {
-        onDisplayEvent?.('Loaded')
-    }, [onDisplayEvent]);
+        displayEventRef.current?.('Loaded')
+    }, []);
 
     // confirms a position update actually rendered - feeds the service's adaptive update delay
     const onSVPanoramaChanged = useCallback(() => {
-        onDisplayEvent?.('pano_changed')
-    }, [onDisplayEvent]);
+        displayEventRef.current?.('pano_changed')
+    }, []);
 
     // no imagery at the requested position: a valid answer, not a failure
     const onSVNoPanorama = useCallback(() => {
-        onDisplayEvent?.('status_changed')
-    }, [onDisplayEvent]);
+        displayEventRef.current?.('status_changed')
+    }, []);
 
     // Deliberately NOT reported as 'Error': the native 'unavailable' reason is only a timeout
     // and the panorama may still arrive, while a mapStateError puts the start overlay into a


### PR DESCRIPTION
## Summary

Users reported a black screen when starting a Street View ride. Two distinct problems, both addressed here.

**1. A black screen every ride, by construction.** The start overlay never waited for the panorama, and the native view was not even *mounted* until the overlay was gone — so the load could not begin until the rider was already looking at an empty screen. Production logs show the first panorama takes ~2.2s even on a fast device on a fast network. The container's background is `colors.background` (`#1E1E1E`), which is what "black screen" looks like.

**2. Loads that never complete.** In the failing production case the native change listener never fired at all — no `license consumed`, no `loaded`, not even `panorama not available` — only repeated `unavailable` timeouts. `setPosition()` was issued and the Maps SDK never resolved it, with nothing in the app retrying or reporting it. Nothing here can *make* the SDK answer, so this half is about recovery and about producing telemetry that can tell the remaining hypotheses apart.

Requires `incyclist-services` 1.7.106 (companion PR incyclist/services#525).

## What changed

**`StreetView` now owns the load lifecycle**

- Position updates are held back while a load is genuinely in flight — every `setPosition()` supersedes the outstanding request, so a stream of updates on a slow connection can keep a load from ever completing. Past `STALE_AFTER` (8s) the request stops counting as in-flight, so on a device where the panorama never resolves the updates resume driving attempts rather than being queued forever.
- Retries at 8/20/40s while the initial load is outstanding, offset by ~1cm so neither our comparison nor the SDK can treat them as a no-op. Retries are armed for the first attempt only — once the ride is running, position updates supply the re-attempts.
- Watchdog reports at 2/5/10/20/30s, for the first two attempts only, so a permanently failing ride does not flood the log.
- `positionTimeout` defaults to 12s. The native 2s default sits right on top of the real ~2.2s first-load time, so `unavailable` fired as a false alarm on nearly every ride — in the successful reference log the change listener beat the timeout by about 1ms.
- The native view is no longer rendered before a position is known, which previously requested a panorama at (0,0).
- Error payload and a new layout log carry `elapsed` / `attempts` / `retries` / `width` / `height`.

**GPX ride view**

- Street View is mounted outside the start-overlay gate, so the panorama loads *behind* the overlay (covered by `MainBackground`) and the service releases the overlay on the real `Loaded` event.
- The native component's events are translated onto the service's `StreetViewEvent` vocabulary (`Loaded`, `pano_changed`, `status_changed`) so `onStreetViewEvent()` stays a single code path for both platforms. `onError` is deliberately **not** reported as `'Error'`: `unavailable` is only a timeout and the panorama may still arrive, while a `mapStateError` puts the start overlay into a dead end whose only button is Cancel.
- Handlers are held in a ref — the service re-binds `onDisplayEvent` on every `getDisplayProperties()` call, so dependency-tracked handlers changed identity roughly once a second.

**`Dynamic`**

- No longer rebuilds the child's `style` object on every render. That defeated any `React.memo` on the child and, for array styles, spread them into `{0:…, 1:…}`.

## Test plan

- 14 unit tests on the load lifecycle: gating, queue-then-apply, retry, retry cessation on load/no-imagery, and the failing-device case (updates must keep reaching the view when the load never completes).
- Full suite green (708 tests), `tsc --noEmit` clean, both against the published 1.7.106.
- Validated end-to-end on a real Android device: overlay shows `mapState:'Loading'`, panorama loads behind it (`streetview loaded elapsed:1387 retries:0`), overlay releases on the real event, no deadlock, first visible frame is a rendered panorama. Zero `unavailable` errors, zero watchdog marks, zero retries. `streetview layout width:1331 height:798`.

## What this does not fix

The device-specific case where the Maps SDK never resolves a panorama at all. One tester reports Street View works in other cycling apps — but those typically use the Street View Static API or the Maps JavaScript API in a WebView, not `StreetViewPanoramaView`, so that does not clear the pipeline we depend on. The remaining suspects (Play Services Maps renderer, `MapsInitializer`'s discarded `ConnectionResult`) are native-only and need a separate branch.

This bundle is what tells them apart: `loaded elapsed:…` separates "slow" from "never"; `attempts`/`retries` > 0 on a successful load would mean re-issuing `setPosition` *recovers* it; `width`/`height` settles the zero-sized-surface hypothesis; and total silence through every attempt is the outcome that justifies the native round-trip.