### PR TITLE
fix: release builds must not ship an empty Maps API key

### DIFF
--- a/.github/workflows/upload-google-play.yml
+++ b/.github/workflows/upload-google-play.yml
@@ -59,6 +59,10 @@ jobs:
           MYAPP_UPLOAD_STORE_PASSWORD: ${{ secrets.MYAPP_UPLOAD_STORE_PASSWORD }}
           MYAPP_UPLOAD_KEY_ALIAS: ${{ secrets.MYAPP_UPLOAD_KEY_ALIAS }}
           MYAPP_UPLOAD_KEY_PASSWORD: ${{ secrets.MYAPP_UPLOAD_KEY_PASSWORD }}
+          # Without this the manifest ships an empty com.google.android.geo.API_KEY and
+          # Street View shows a black screen on every released build. The Gradle build now
+          # fails rather than substituting an empty key, so this must stay set.
+          MAPS_API_KEY: ${{ secrets.MAPS_API_KEY }}
         run: |
           ./gradlew clean bundleRelease
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -29,6 +29,35 @@ def getEnv = { propName ->
 }
 
 /**
+ * A release build with an empty MAPS_API_KEY looks completely healthy: it compiles, installs,
+ * and the Maps SDK initialises — but every Street View panorama request is rejected, so the
+ * ride screen stays black and nothing reports why. That shipped to production undetected
+ * because `getEnv("MAPS_API_KEY") ?: ""` substituted an empty string in silence.
+ *
+ * Release builds now fail instead. Debug/dev builds only warn, so the app can still be built
+ * without a local .env — Street View is simply unavailable in those builds.
+ */
+gradle.taskGraph.whenReady { graph ->
+    if (getEnv("MAPS_API_KEY"))
+        return
+
+    // Matched on the release variant's own tasks, not on "release" anywhere in the name:
+    // the dev variant is `initWith release` and pulls in preReleaseBuild, so a substring
+    // match would block every dev build made without a .env.
+    def releaseTask = graph.allTasks.find { it.name ==~ /(?i)^(assemble|bundle|install|package)Release$/ }
+    if (releaseTask != null) {
+        throw new GradleException(
+            "MAPS_API_KEY is not set, and a release build with an empty Maps API key breaks " +
+            "Street View silently (black ride screen, no error). Set it in .env for local " +
+            "builds, or as a repository secret wired into the workflow env for CI " +
+            "(see .github/workflows/upload-google-play.yml). Triggered by task '${releaseTask.name}'."
+        )
+    }
+
+    logger.warn("MAPS_API_KEY is not set — Street View will not work in this build")
+}
+
+/**
  * This is the configuration block to customize your React Native Android app.
  * By default you don't need to apply any configuration, just uncomment the lines you need.
  */

--- a/app.json
+++ b/app.json
@@ -2,6 +2,6 @@
   "name": "Incyclist",
   "displayName": "Incyclist",
   "appVersion": "1.0.20",
-  "bundleVersion" : "0.0.45",
+  "bundleVersion" : "0.0.46",
   "androidVersionCode": 36
 }


### PR DESCRIPTION
## Summary

**This is the cause of the Street View black screen.**

The production APK on the Play Store ships an empty Maps API key. Verified directly by pulling the installed APK off a phone:

```
A: android:name="com.google.android.geo.API_KEY"
A: android:value=""
```

A locally built dev APK from the same commit carries a real key. The difference is where the key comes from: `.env` is not in the repo, `MAPS_API_KEY` was not among the repository secrets, and `upload-google-play.yml` ran `./gradlew clean bundleRelease` without passing it. `android/app/build.gradle` then did `getEnv("MAPS_API_KEY") ?: ""` and substituted an empty string in silence.

So every locally built variant worked and every released build was broken — which is why this was invisible for so long, and why it reproduced on a maintainer's phone (Play Store build) but never on the dev tablet.

## Why it presents as a black screen with no error

An empty key still produces a healthy-looking build. `MapsInitializer` and `getStreetViewPanoramaAsync` need no authentication, so they succeed — which is why the logs never showed `reason:'unknown'`. The first `setPosition()` issues an authenticated request, it is rejected, and `OnStreetViewPanoramaChangeListener` never fires at all: no `onLicenseConsumed`, no `onLoaded`, not even `onNoPanorama`, only the position timeout expiring.

That is exactly the signature in the production logs — and it explains every observation: all Play Store users affected, dev builds always fine, retries useless (a hard rejection, not a stalled request), view size irrelevant, and identical behaviour on the bundle before and after the recent Street View changes.

## What changed

- `upload-google-play.yml` passes `MAPS_API_KEY` into the Gradle build.
- Release variant tasks **fail** when the key is absent instead of substituting one. This is the bug-class fix: the silent fallback is what let this ship.
- Debug/dev builds only warn, so the app can still be built without a local `.env` — Street View is simply unavailable there.

The task match is on the release variant's own tasks (`assemble|bundle|install|package` + `Release`) rather than any task whose name contains "release". The `dev` variant is `initWith release` and pulls in `preReleaseBuild`, so a substring match blocked every dev build made without a `.env` — caught while testing this.

## Test plan

Verified by temporarily forcing the missing-key branch:

| scenario | result |
|---|---|
| `bundleRelease`, key missing | **fails** — `Triggered by task 'bundleRelease'` |
| `assembleDev`, key missing | succeeds, warns `Street View will not work in this build` |
| `bundleRelease`, key present | builds normally |

## Required before this actually fixes anything

Adding the secret is necessary but **not sufficient**. The key's Android restrictions must include the **Play App Signing** SHA-1 (Play Console → Test and release → App integrity), not just the upload or debug certificate — Play re-signs the AAB, so the certificate that reaches users is not the one it was uploaded with. If the key is currently restricted to the debug SHA-1 only, released builds will still be rejected.

Users will keep seeing a black screen until a **new binary** ships; no JS bundle can fix this.