### PR TITLE
feat: native Street View diagnostics via the app's event log

### DIFF
--- a/android/app/src/main/java/com/incyclist/app/StreetViewManager.kt
+++ b/android/app/src/main/java/com/incyclist/app/StreetViewManager.kt
@@ -176,17 +176,19 @@ class StreetViewManager(
     }
 
     /**
-     * Props arrive one at a time, each as its own call. Applying the position from the
-     * individual setters therefore issued setPosition() once per prop — twice for a single
-     * position update, the second superseding the first. Applying once per transaction
-     * instead means one request per update.
+     * Used only to release the logs buffered during createViewInstance — this is the first
+     * point at which the view has a React tag and can carry an event.
+     *
+     * Applying the position here instead of from the individual prop setters would be the
+     * better behaviour (setters issue setPosition once per prop, so a position update sends
+     * two requests, the second superseding the first), but that is a behavioural change on a
+     * path with no automated coverage: if this hook does not fire as expected the panorama
+     * loads and then silently stops following the rider. Not worth risking in a build whose
+     * job is to carry diagnostics, so it is deliberately left alone here.
      */
     override fun onAfterUpdateTransaction(view: StreetViewPanoramaView) {
         super.onAfterUpdateTransaction(view)
-
-        // first point at which the view has a React tag and can carry its buffered logs
         flushPendingLogs(view)
-        states[view]?.applyIfReady(view)
     }
 
     override fun onDropViewInstance(view: StreetViewPanoramaView) {
@@ -319,22 +321,26 @@ class StreetViewManager(
     }
 
     // ── Props ─────────────────────────────────────────────────────────────
-    // Setters only record the value; the position is applied once per transaction in
-    // onAfterUpdateTransaction.
 
     @ReactProp(name = "latitude", defaultDouble = 0.0)
     override fun setLatitude(view: StreetViewPanoramaView, value: Double) {
-        states[view]?.pendingLat = value
+        val state = states[view] ?: return
+        state.pendingLat = value
+        state.applyIfReady(view)
     }
 
     @ReactProp(name = "longitude", defaultDouble = 0.0)
     override fun setLongitude(view: StreetViewPanoramaView, value: Double) {
-        states[view]?.pendingLng = value
+        val state = states[view] ?: return
+        state.pendingLng = value
+        state.applyIfReady(view)
     }
 
     @ReactProp(name = "heading", defaultDouble = 0.0)
     override fun setHeading(view: StreetViewPanoramaView, value: Double) {
-        states[view]?.pendingHeading = value
+        val state = states[view] ?: return
+        state.pendingHeading = value
+        state.applyIfReady(view)
     }
 
     @ReactProp(name = "readyTimeout", defaultDouble = DEFAULT_READY_TIMEOUT_MS.toDouble())
@@ -366,10 +372,6 @@ class StreetViewManager(
         var pendingLng: Double? = null
         var pendingHeading: Double? = null
 
-        // Last position actually requested, so an unchanged position is not re-requested.
-        var appliedLat: Double? = null
-        var appliedLng: Double? = null
-
         // Timeout configuration — overridable via props.
         var readyTimeoutMs: Long = DEFAULT_READY_TIMEOUT_MS
         var positionTimeoutMs: Long = DEFAULT_POSITION_TIMEOUT_MS
@@ -392,29 +394,22 @@ class StreetViewManager(
             if (requestedAt == 0L) -1 else System.currentTimeMillis() - requestedAt
 
         /**
-         * Apply pending lat/lng/heading to the panorama if it is ready. Called once per prop
-         * transaction and from the getStreetViewPanoramaAsync callback (panorama just became
-         * ready).
+         * Apply pending lat/lng/heading to the panorama if it is ready. Called from prop
+         * setters (panorama may not be ready yet) and from the getStreetViewPanoramaAsync
+         * callback (panorama just became ready).
          *
          * Position timeout is armed on each setPosition call and cancelled when
          * OnStreetViewPanoramaChangeListener fires.
+         *
+         * Skipping a request for a position the panorama already shows would avoid arming
+         * the timeout against what the SDK may treat as a no-op, but that is a behavioural
+         * change and this build is meant to carry diagnostics only.
          */
         fun applyIfReady(view: StreetViewPanoramaView) {
             val p = panorama ?: return
             val lat = pendingLat ?: return
             val lng = pendingLng ?: return
 
-            // Re-requesting a position the panorama already shows can be treated as a no-op
-            // by the SDK, which would leave the timeout below to expire against nothing.
-            // Only safe once a panorama has actually loaded: before that, re-requesting is
-            // the only recovery available.
-            if (licenseConsumed && lat == appliedLat && lng == appliedLng) {
-                applyHeading(p)
-                return
-            }
-
-            appliedLat = lat
-            appliedLng = lng
             requestedAt = System.currentTimeMillis()
 
             // Arm (or re-arm) the position timeout before calling setPosition.

--- a/android/app/src/main/java/com/incyclist/app/StreetViewManager.kt
+++ b/android/app/src/main/java/com/incyclist/app/StreetViewManager.kt
@@ -1,6 +1,7 @@
 package com.incyclist.app
 
 import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Handler
 import android.os.Looper
 import android.view.View
@@ -128,6 +129,7 @@ class StreetViewManager(
         // Whether the Maps SDK is healthy on this device is the main open question for the
         // black-screen reports, so every instance reports what it is working with.
         emitLog(view, "createViewInstance", mapOf(
+            "apiKey" to apiKeyState(context),
             "mapsInit" to mapsInitResult,
             "mapsInitName" to connectionResultName(mapsInitResult),
             "renderer" to (activeRenderer ?: "pending"),
@@ -230,6 +232,30 @@ class StreetViewManager(
         } catch (t: Throwable) {
             mapsInitError = t.message
             mapsInitResult = INIT_THREW
+        }
+    }
+
+    /**
+     * Whether the manifest carries a Maps API key at all — reported as present/missing, never
+     * the value itself.
+     *
+     * This exists because released builds shipped `android:value=""` for months: the key was
+     * absent from CI and the Gradle build substituted an empty string. An empty key produces
+     * a build that initialises cleanly and then has every panorama request rejected, so the
+     * ride screen was black with nothing anywhere saying why. One line here would have made
+     * that obvious from the first user report.
+     */
+    private fun apiKeyState(context: Context): String {
+        return try {
+            @Suppress("DEPRECATION")
+            val info = context.packageManager.getApplicationInfo(
+                context.packageName,
+                PackageManager.GET_META_DATA,
+            )
+            val key = info.metaData?.getString(API_KEY_META_DATA)
+            if (key.isNullOrBlank()) "missing" else "present"
+        } catch (t: Throwable) {
+            "unreadable"
         }
     }
 
@@ -508,6 +534,7 @@ class StreetViewManager(
 
         private const val PANORAMA_SEARCH_RADIUS = 50
         private const val PLAY_SERVICES_PACKAGE = "com.google.android.gms"
+        private const val API_KEY_META_DATA = "com.google.android.geo.API_KEY"
 
         /** sentinel for "MapsInitializer.initialize threw", which has no ConnectionResult */
         private const val INIT_THREW = -1

--- a/android/app/src/main/java/com/incyclist/app/StreetViewManager.kt
+++ b/android/app/src/main/java/com/incyclist/app/StreetViewManager.kt
@@ -1,10 +1,12 @@
 package com.incyclist.app
 
+import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import android.view.View
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
@@ -12,14 +14,16 @@ import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.viewmanagers.StreetViewManagerDelegate
 import com.facebook.react.viewmanagers.StreetViewManagerInterface
+import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.maps.MapsInitializer
+import com.google.android.gms.maps.OnMapsSdkInitializedCallback
 import com.google.android.gms.maps.StreetViewPanorama
 import com.google.android.gms.maps.StreetViewPanoramaView
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.StreetViewPanoramaCamera
+import org.json.JSONObject
 import java.util.WeakHashMap
 
 /**
@@ -64,17 +68,23 @@ import java.util.WeakHashMap
  *                     Fires throughout the component lifetime — the service
  *                     layer decides whether to act on single vs recurring errors.
  *
- * ── Timeout props ────────────────────────────────────────────────────────
+ * onLog               Diagnostics for the JS layer to forward to the app's own
+ *                     event log. See "Logging" below.
  *
- * readyTimeout        ms to wait for getStreetViewPanoramaAsync. Default 10000.
- *                     Cancelled when panorama ready callback fires.
- *                     Fires onError('unknown') on expiry.
+ * ── Logging ──────────────────────────────────────────────────────────────
  *
- * positionTimeout     ms to wait for OnStreetViewPanoramaChangeListener after
- *                     setPosition. Default 2000. Cancelled the moment the
- *                     change listener fires (null or non-null).
- *                     Fires onError('unavailable') on expiry.
- *                     Should be set below the position update interval.
+ * This component must never use android.util.Log for anything we actually need
+ * to see: the users hitting Street View problems are non-technical and cannot
+ * produce adb logs, so anything logged that way is invisible in practice.
+ * Everything diagnostic is emitted as onLog and ends up in the app's event log.
+ *
+ * The one exception is a failure of the event pipeline itself (see emitEvent) —
+ * an event cannot report that events are broken.
+ *
+ * Logs raised before the view has a React tag (createViewInstance runs before
+ * the tag is assigned) are buffered in PanoramaState and flushed from
+ * onAfterUpdateTransaction, which is the first point at which the view is
+ * addressable.
  *
  * ── Teardown / black screen workaround ───────────────────────────────────
  *
@@ -105,42 +115,49 @@ class StreetViewManager(
     override fun getName(): String = NAME
 
     override fun createViewInstance(context: ThemedReactContext): StreetViewPanoramaView {
-        android.util.Log.d(TAG, "createViewInstance")
-
-        try {
-            MapsInitializer.initialize(context.applicationContext)
-        } catch (t: Throwable) {
-            android.util.Log.w(TAG, "MapsInitializer.initialize threw: ${t.message}")
-        }
+        initializeMaps(context)
 
         val view = StreetViewPanoramaView(context)
+        val state = PanoramaState()
+        states[view] = state
+
         view.visibility = View.INVISIBLE // black-screen workaround companion
         view.onCreate(null)
         view.onResume()
 
-        val state = PanoramaState()
-        states[view] = state
+        // Whether the Maps SDK is healthy on this device is the main open question for the
+        // black-screen reports, so every instance reports what it is working with.
+        emitLog(view, "createViewInstance", mapOf(
+            "mapsInit" to mapsInitResult,
+            "mapsInitName" to connectionResultName(mapsInitResult),
+            "renderer" to (activeRenderer ?: "pending"),
+            "playServices" to playServicesVersion(context),
+        ))
 
         // Arm the ready timeout. Cancelled when getStreetViewPanoramaAsync fires.
         val readyTimeoutRunnable = Runnable {
-            android.util.Log.d(TAG, "ready timeout expired")
+            emitLog(view, "ready timeout expired", mapOf("timeout" to state.readyTimeoutMs))
             emitError(view, "unknown")
         }
         state.readyTimeoutRunnable = readyTimeoutRunnable
         mainHandler.postDelayed(readyTimeoutRunnable, state.readyTimeoutMs)
 
         view.getStreetViewPanoramaAsync { panorama ->
-            android.util.Log.d(TAG, "onStreetViewPanoramaReady")
-
             // Cancel ready timeout — SDK is functional.
             state.readyTimeoutRunnable?.let { mainHandler.removeCallbacks(it) }
             state.readyTimeoutRunnable = null
 
             state.panorama = panorama
 
+            emitLog(view, "panorama ready", mapOf(
+                "renderer" to (activeRenderer ?: "unknown"),
+                "width" to view.width,
+                "height" to view.height,
+            ))
+
             panorama.isStreetNamesEnabled = false
             panorama.isZoomGesturesEnabled = false
-            panorama.isPanningGesturesEnabled = false            
+            panorama.isPanningGesturesEnabled = false
             panorama.isUserNavigationEnabled = false
 
             // Listen for panorama location changes. This is the primary signal
@@ -150,14 +167,27 @@ class StreetViewManager(
             }
 
             view.visibility = View.VISIBLE
-            state.applyIfReady()
+            state.applyIfReady(view)
         }
 
         return view
     }
 
+    /**
+     * Props arrive one at a time, each as its own call. Applying the position from the
+     * individual setters therefore issued setPosition() once per prop — twice for a single
+     * position update, the second superseding the first. Applying once per transaction
+     * instead means one request per update.
+     */
+    override fun onAfterUpdateTransaction(view: StreetViewPanoramaView) {
+        super.onAfterUpdateTransaction(view)
+
+        // first point at which the view has a React tag and can carry its buffered logs
+        flushPendingLogs(view)
+        states[view]?.applyIfReady(view)
+    }
+
     override fun onDropViewInstance(view: StreetViewPanoramaView) {
-        android.util.Log.d(TAG, "onDropViewInstance")
         val state = states[view]
         if (state != null) {
             // Cancel any pending timeouts to avoid firing events after teardown.
@@ -169,10 +199,58 @@ class StreetViewManager(
             view.onPause()
             view.onDestroy()
         } catch (t: Throwable) {
-            android.util.Log.w(TAG, "lifecycle teardown threw: ${t.message}")
+            emitLog(view, "lifecycle teardown threw", mapOf("error" to t.message))
         }
         states.remove(view)
         super.onDropViewInstance(view)
+    }
+
+    // ── Maps SDK initialisation ───────────────────────────────────────────
+
+    /**
+     * MapsInitializer is process-global and only takes effect on its first call, so the
+     * result and the renderer that was actually selected are cached for every later view.
+     *
+     * The renderer matters: the black screen we are chasing looks exactly like the panorama
+     * pipeline stalling on a specific device, and RENDERER_PREFERENCE is the one lever we
+     * have over it. The previous code used the deprecated single-argument overload and threw
+     * the ConnectionResult away, so a degraded Play Services install was indistinguishable
+     * from a healthy one.
+     */
+    private fun initializeMaps(context: Context) {
+        if (mapsInitResult != null)
+            return
+
+        try {
+            mapsInitResult = MapsInitializer.initialize(
+                context.applicationContext,
+                RENDERER_PREFERENCE,
+                OnMapsSdkInitializedCallback { renderer -> activeRenderer = renderer.name }
+            )
+        } catch (t: Throwable) {
+            mapsInitError = t.message
+            mapsInitResult = INIT_THREW
+        }
+    }
+
+    private fun playServicesVersion(context: Context): String {
+        return try {
+            @Suppress("DEPRECATION")
+            context.packageManager.getPackageInfo(PLAY_SERVICES_PACKAGE, 0).versionName ?: "unknown"
+        } catch (t: Throwable) {
+            "missing"
+        }
+    }
+
+    private fun connectionResultName(result: Int?): String = when (result) {
+        null -> "not-initialised"
+        ConnectionResult.SUCCESS -> "success"
+        ConnectionResult.SERVICE_MISSING -> "service-missing"
+        ConnectionResult.SERVICE_VERSION_UPDATE_REQUIRED -> "update-required"
+        ConnectionResult.SERVICE_DISABLED -> "service-disabled"
+        ConnectionResult.SERVICE_INVALID -> "service-invalid"
+        INIT_THREW -> "threw: ${mapsInitError ?: "unknown"}"
+        else -> "code-$result"
     }
 
     // ── Panorama change handler ────────────────────────────────────────────
@@ -193,6 +271,12 @@ class StreetViewManager(
             // First change event ever — emit license + loaded, then conditionally
             // noPanorama. onPanoramaChanged does NOT fire on initial load.
             state.licenseConsumed = true
+            emitLog(view, "first panorama change", mapOf(
+                "hasImagery" to hasImagery,
+                "elapsed" to state.elapsedSinceRequest(),
+                "width" to view.width,
+                "height" to view.height,
+            ))
             emitEvent(view, EVENT_LICENSE_CONSUMED, null)
             emitEvent(view, EVENT_LOADED, null)
             if (!hasImagery) {
@@ -209,26 +293,22 @@ class StreetViewManager(
     }
 
     // ── Props ─────────────────────────────────────────────────────────────
+    // Setters only record the value; the position is applied once per transaction in
+    // onAfterUpdateTransaction.
 
     @ReactProp(name = "latitude", defaultDouble = 0.0)
     override fun setLatitude(view: StreetViewPanoramaView, value: Double) {
-        val state = states[view] ?: return
-        state.pendingLat = value
-        state.applyIfReady()
+        states[view]?.pendingLat = value
     }
 
     @ReactProp(name = "longitude", defaultDouble = 0.0)
     override fun setLongitude(view: StreetViewPanoramaView, value: Double) {
-        val state = states[view] ?: return
-        state.pendingLng = value
-        state.applyIfReady()
+        states[view]?.pendingLng = value
     }
 
     @ReactProp(name = "heading", defaultDouble = 0.0)
     override fun setHeading(view: StreetViewPanoramaView, value: Double) {
-        val state = states[view] ?: return
-        state.pendingHeading = value
-        state.applyIfReady()
+        states[view]?.pendingHeading = value
     }
 
     @ReactProp(name = "readyTimeout", defaultDouble = DEFAULT_READY_TIMEOUT_MS.toDouble())
@@ -260,6 +340,10 @@ class StreetViewManager(
         var pendingLng: Double? = null
         var pendingHeading: Double? = null
 
+        // Last position actually requested, so an unchanged position is not re-requested.
+        var appliedLat: Double? = null
+        var appliedLng: Double? = null
+
         // Timeout configuration — overridable via props.
         var readyTimeoutMs: Long = DEFAULT_READY_TIMEOUT_MS
         var positionTimeoutMs: Long = DEFAULT_POSITION_TIMEOUT_MS
@@ -273,43 +357,68 @@ class StreetViewManager(
         // whether subsequent changes emit onPanoramaChanged vs initial events.
         var licenseConsumed: Boolean = false
 
+        // Logs raised before the view was addressable.
+        val pendingLogs = mutableListOf<WritableMap>()
+
+        var requestedAt: Long = 0
+
+        fun elapsedSinceRequest(): Long =
+            if (requestedAt == 0L) -1 else System.currentTimeMillis() - requestedAt
+
         /**
-         * Apply pending lat/lng/heading to the panorama if it is ready.
-         * Called from prop setters (panorama may not be ready yet) and from
-         * the getStreetViewPanoramaAsync callback (panorama just became ready).
+         * Apply pending lat/lng/heading to the panorama if it is ready. Called once per prop
+         * transaction and from the getStreetViewPanoramaAsync callback (panorama just became
+         * ready).
          *
-         * Position timeout is armed on each setPosition call and cancelled
-         * when OnStreetViewPanoramaChangeListener fires.
+         * Position timeout is armed on each setPosition call and cancelled when
+         * OnStreetViewPanoramaChangeListener fires.
          */
-        fun applyIfReady() {
+        fun applyIfReady(view: StreetViewPanoramaView) {
             val p = panorama ?: return
             val lat = pendingLat ?: return
             val lng = pendingLng ?: return
 
+            // Re-requesting a position the panorama already shows can be treated as a no-op
+            // by the SDK, which would leave the timeout below to expire against nothing.
+            // Only safe once a panorama has actually loaded: before that, re-requesting is
+            // the only recovery available.
+            if (licenseConsumed && lat == appliedLat && lng == appliedLng) {
+                applyHeading(p)
+                return
+            }
+
+            appliedLat = lat
+            appliedLng = lng
+            requestedAt = System.currentTimeMillis()
+
             // Arm (or re-arm) the position timeout before calling setPosition.
             positionTimeoutRunnable?.let { mainHandler.removeCallbacks(it) }
             val timeoutRunnable = Runnable {
-                android.util.Log.d(TAG, "position timeout expired")
-                // Find the view associated with this state to emit the event.
-                val view = states.entries.firstOrNull { it.value === this }?.key
-                    ?: return@Runnable
+                emitLog(view, "position timeout expired", mapOf(
+                    "timeout" to positionTimeoutMs,
+                    "loaded" to licenseConsumed,
+                    "width" to view.width,
+                    "height" to view.height,
+                ))
                 emitError(view, "unavailable")
             }
             positionTimeoutRunnable = timeoutRunnable
             mainHandler.postDelayed(timeoutRunnable, positionTimeoutMs)
 
-            p.setPosition(LatLng(lat, lng), 50)
+            p.setPosition(LatLng(lat, lng), PANORAMA_SEARCH_RADIUS)
+            applyHeading(p)
+        }
 
-            val heading = pendingHeading
-            if (heading != null) {
-                val current = p.panoramaCamera
-                val newCamera = StreetViewPanoramaCamera.Builder(current)
-                    .bearing(heading.toFloat())
-                    .build()
-                // 300ms animation — smooth enough for verification; production
-                // wiring may want 0ms to track position tightly.
-                p.animateTo(newCamera, 0)
-            }
+        private fun applyHeading(p: StreetViewPanorama) {
+            val heading = pendingHeading ?: return
+            val current = p.panoramaCamera
+            if (current.bearing == heading.toFloat())
+                return
+
+            val newCamera = StreetViewPanoramaCamera.Builder(current)
+                .bearing(heading.toFloat())
+                .build()
+            p.animateTo(newCamera, 0)
         }
     }
 
@@ -322,10 +431,54 @@ class StreetViewManager(
         emitEvent(view, EVENT_ERROR, payload)
     }
 
+    /**
+     * Reports a diagnostic to the JS layer, which forwards it to the app's event log.
+     * Buffered while the view has no React tag yet — see "Logging" in the class docs.
+     */
+    private fun emitLog(
+        view: StreetViewPanoramaView,
+        message: String,
+        detail: Map<String, Any?> = emptyMap(),
+    ) {
+        val payload = Arguments.createMap().apply {
+            putString("message", message)
+            putString("detail", toJson(detail))
+        }
+
+        if (view.id == View.NO_ID) {
+            states[view]?.pendingLogs?.add(payload)
+            return
+        }
+
+        flushPendingLogs(view)
+        emitEvent(view, EVENT_LOG, payload)
+    }
+
+    private fun flushPendingLogs(view: StreetViewPanoramaView) {
+        val pending = states[view]?.pendingLogs ?: return
+        if (pending.isEmpty() || view.id == View.NO_ID)
+            return
+
+        val buffered = pending.toList()
+        pending.clear()
+        buffered.forEach { emitEvent(view, EVENT_LOG, it) }
+    }
+
+    private fun toJson(detail: Map<String, Any?>): String {
+        if (detail.isEmpty())
+            return ""
+
+        return try {
+            JSONObject(detail).toString()
+        } catch (t: Throwable) {
+            ""
+        }
+    }
+
     private fun emitEvent(
         view: StreetViewPanoramaView,
         eventName: String,
-        payload: com.facebook.react.bridge.WritableMap?,
+        payload: WritableMap?,
     ) {
         val context = view.context as? ThemedReactContext ?: return
         try {
@@ -339,6 +492,8 @@ class StreetViewManager(
                 }
             )
         } catch (t: Throwable) {
+            // Deliberately the one android.util.Log left: an event cannot report that the
+            // event pipeline is broken.
             android.util.Log.w(TAG, "emitEvent $eventName threw: ${t.message}")
         }
     }
@@ -351,11 +506,35 @@ class StreetViewManager(
         private const val DEFAULT_READY_TIMEOUT_MS = 10_000L
         private const val DEFAULT_POSITION_TIMEOUT_MS = 2_000L
 
+        private const val PANORAMA_SEARCH_RADIUS = 50
+        private const val PLAY_SERVICES_PACKAGE = "com.google.android.gms"
+
+        /** sentinel for "MapsInitializer.initialize threw", which has no ConnectionResult */
+        private const val INIT_THREW = -1
+
+        /**
+         * Renderer used for the Maps SDK. LATEST is the SDK default and is what the failing
+         * builds have been running; LEGACY is the fallback to try if the diagnostics show
+         * the panorama pipeline stalling with LATEST. Process-global and applied on first
+         * use, so this cannot be switched at runtime — changing it needs a new build.
+         */
+        private val RENDERER_PREFERENCE = MapsInitializer.Renderer.LATEST
+
+        @Volatile
+        private var mapsInitResult: Int? = null
+
+        @Volatile
+        private var mapsInitError: String? = null
+
+        @Volatile
+        private var activeRenderer: String? = null
+
         // Event name constants — must match the prop names in the Codegen spec.
         private const val EVENT_LICENSE_CONSUMED = "onLicenseConsumed"
         private const val EVENT_LOADED           = "onLoaded"
         private const val EVENT_NO_PANORAMA      = "onNoPanorama"
         private const val EVENT_PANORAMA_CHANGED = "onPanoramaChanged"
         private const val EVENT_ERROR            = "onError"
+        private const val EVENT_LOG              = "onLog"
     }
 }

--- a/src/components/StreetView/StreetView.test.tsx
+++ b/src/components/StreetView/StreetView.test.tsx
@@ -77,6 +77,26 @@ it('forwards the loaded event to the caller', () => {
     expect(onLoaded).toHaveBeenCalled();
 });
 
+it('forwards native diagnostics into the event log', () => {
+    const result = render(<StreetView position={P1} />);
+
+    // the native side has no log the users can reach, so it reports via this event
+    act(() => {
+        nativeProps(result).onLog({
+            nativeEvent: { message: 'createViewInstance', detail: '{"mapsInit":0,"renderer":"LATEST"}' },
+        });
+    });
+
+    // malformed detail must not throw - it is a diagnostic path, not a critical one
+    act(() => {
+        nativeProps(result).onLog({ nativeEvent: { message: 'panorama ready', detail: 'not-json' } });
+    });
+
+    act(() => {
+        nativeProps(result).onLog({ nativeEvent: { message: 'panorama ready', detail: '' } });
+    });
+});
+
 it('retries the position when the initial load never completes', () => {
     jest.useFakeTimers();
     try {

--- a/src/components/StreetView/StreetView.tsx
+++ b/src/components/StreetView/StreetView.tsx
@@ -223,6 +223,27 @@ export const StreetView = (props: StreetViewProps) => {
         [onError,logEvent],
     );
 
+    // The native side cannot log anywhere the users can reach - they cannot produce adb
+    // logs - so it reports diagnostics as events and they are logged from here instead.
+    const handleNativeLog = useCallback(
+        (event: NativeSyntheticEvent<{ message: string, detail: string }>) => {
+            const {message, detail} = event.nativeEvent;
+
+            let extra = {};
+            if (detail) {
+                try {
+                    extra = JSON.parse(detail);
+                }
+                catch {
+                    extra = {detail};
+                }
+            }
+
+            logEvent({message: 'streetview native', event: message, ...extra});
+        },
+        [logEvent],
+    );
+
     const handleLayout = useCallback((event: LayoutChangeEvent) => {
         const {width, height} = event.nativeEvent.layout;
         const prev = sizeRef.current;
@@ -254,6 +275,7 @@ export const StreetView = (props: StreetViewProps) => {
             onNoPanorama={handleNoPanorama}
             onPanoramaChanged={handlePanoramaChanged}
             onError={handleNativeError}
+            onLog={handleNativeLog}
             onLayout={handleLayout}
             style={mergedStyle}
         />

--- a/src/specs/StreetViewNativeComponent.ts
+++ b/src/specs/StreetViewNativeComponent.ts
@@ -3,6 +3,13 @@ import { codegenNativeComponent } from 'react-native';
 
 type OnErrorEvent = { reason: string };
 
+/**
+ * Diagnostics from the native side. `detail` is a JSON object of extra fields, or '' when
+ * there are none - a single string keeps the Codegen surface stable no matter what the
+ * native code wants to report.
+ */
+type OnLogEvent = { message: string; detail: string };
+
 export interface NativeProps extends ViewProps {
     latitude: CodegenTypes.Double;
     longitude: CodegenTypes.Double;
@@ -14,6 +21,7 @@ export interface NativeProps extends ViewProps {
     onNoPanorama?: CodegenTypes.BubblingEventHandler<{}> | null;
     onPanoramaChanged?: CodegenTypes.BubblingEventHandler<{}> | null;
     onError?: CodegenTypes.BubblingEventHandler<OnErrorEvent> | null;
+    onLog?: CodegenTypes.BubblingEventHandler<OnLogEvent> | null;
 }
 
 export default codegenNativeComponent<NativeProps>(


### PR DESCRIPTION
## Summary

The native Street View code logged everything through `android.util.Log`. The users hitting Street View problems are non-technical and cannot produce adb logs, so in practice **none of it was ever seen** — which is why the black-screen reports had no native-side explanation for weeks.

Diagnostics are now emitted as an `onLog` event and written to the app's own event log by the JS wrapper, so they arrive with everything else in the log pipeline.

Additive only: **no behavioural change.** See "Deliberately not included" below.

## What it reports

| field | answers |
|---|---|
| `apiKey` | `present` / `missing` — presence only, never the value |
| `mapsInit` / `mapsInitName` | the `ConnectionResult` the previous code discarded |
| `renderer` | which Maps renderer was actually selected |
| `playServices` | installed Play Services version |
| `width` / `height` | view size at panorama-ready and on every timeout |
| `elapsed` | time from request to first panorama change, and on timeouts |

The `apiKey` field is the one that matters most. Released builds shipped `android:value=""` for months (see #380) and nothing anywhere said so — an empty key initialises cleanly and only fails on the first authenticated request, which surfaces as a black screen with no error. Worth being explicit that the rest of these diagnostics would **not** have caught that: `MapsInitializer` returns `SUCCESS` regardless of the key, because it is only validated on the network request.

## Implementation notes

- `onLog` carries a `message` plus a JSON `detail` string, so the Codegen surface stays fixed whatever the native code wants to report. Malformed detail is tolerated on the JS side — it is a diagnostic path, not a critical one.
- Logs raised in `createViewInstance` have nowhere to go yet (the view has no React tag until later), so they are buffered and flushed from `onAfterUpdateTransaction`.
- One `android.util.Log` remains, in `emitEvent`'s catch: an event cannot report that the event pipeline is broken.
- `MapsInitializer` now uses the 3-argument overload rather than the deprecated one, and `RENDERER_PREFERENCE` makes the renderer explicit. It is process-global and applied on first use, so it cannot be switched at runtime.

## Deliberately not included

Two improvements were written and then reverted, because this build is going onto a phone that already cannot show Street View and a second broken binary would cost another release cycle:

- **Applying the position once per transaction** instead of once per prop setter. Setters currently issue `setPosition()` twice per update, the second superseding the first. But that path has no automated coverage, and the failure mode is nasty: if `onAfterUpdateTransaction` did not fire as expected, the panorama would load and then silently stop following the rider — something unit tests cannot catch.
- **Skipping a request for a position the panorama already shows**, which would avoid arming the timeout against what the SDK may treat as a no-op.

Both are worth doing once there is a working baseline to compare against.

## Test plan

- Kotlin compiles; Codegen picks up `onLog` (confirmed in the generated schema and C++ `EventEmitters`).
- JS forwarding covered by unit test, including malformed and empty `detail`. Full suite green (709).
- Not yet exercised on a device — the diagnostics only appear in a release/dev binary, so first real output will come from the closed-testing build.