### PR TITLE
fix: crash on Street View position with no imagery (null-panorama NPE)

### DIFF
--- a/android/app/src/main/java/com/incyclist/app/NullSafeStreetViewPanoramaChangeListener.java
+++ b/android/app/src/main/java/com/incyclist/app/NullSafeStreetViewPanoramaChangeListener.java
@@ -1,0 +1,38 @@
+package com.incyclist.app;
+
+import androidx.annotation.Nullable;
+import com.google.android.gms.maps.StreetViewPanorama;
+import com.google.android.gms.maps.model.StreetViewPanoramaLocation;
+
+/**
+ * Java implementation of OnStreetViewPanoramaChangeListener.
+ *
+ * The Maps SDK annotates `location` as @NonNull, but its documented, actual runtime behaviour
+ * is to call this listener with location=null when there is no Street View imagery at the
+ * requested position - that IS how "no panorama" is reported. A Kotlin lambda or override is
+ * forced to match that (incorrect) @NonNull annotation, and Kotlin's compiler then generates
+ * a null-check that crashes the app the moment the SDK does exactly what its own contract
+ * says it will.
+ *
+ * Implementing the interface in Java sidesteps Kotlin's null-check codegen entirely - only the
+ * Kotlin compiler inserts those checks, and only for parameters it declares non-null itself.
+ * Callback.onChange is declared @Nullable, so Kotlin treats it correctly on the calling side.
+ */
+public class NullSafeStreetViewPanoramaChangeListener
+        implements StreetViewPanorama.OnStreetViewPanoramaChangeListener {
+
+    public interface Callback {
+        void onChange(@Nullable StreetViewPanoramaLocation location);
+    }
+
+    private final Callback callback;
+
+    public NullSafeStreetViewPanoramaChangeListener(Callback callback) {
+        this.callback = callback;
+    }
+
+    @Override
+    public void onStreetViewPanoramaChange(StreetViewPanoramaLocation location) {
+        callback.onChange(location);
+    }
+}

--- a/android/app/src/main/java/com/incyclist/app/StreetViewManager.kt
+++ b/android/app/src/main/java/com/incyclist/app/StreetViewManager.kt
@@ -164,9 +164,20 @@ class StreetViewManager(
 
             // Listen for panorama location changes. This is the primary signal
             // for all position-related events.
-            panorama.setOnStreetViewPanoramaChangeListener { location ->
-                handlePanoramaChange(view, state, location)
-            }
+            //
+            // Deliberately routed through the Java NullSafeStreetViewPanoramaChangeListener
+            // shim rather than a Kotlin lambda/override: the SDK annotates this parameter
+            // @NonNull yet legitimately calls it with null when there is no Street View
+            // imagery at the requested position - that IS how "no panorama" is reported. A
+            // Kotlin implementation is forced to match the (incorrect) @NonNull annotation,
+            // and Kotlin's compiler then generates a null-check that crashes the app the
+            // moment the SDK does exactly what its own contract says it will. See the shim's
+            // class doc. handlePanoramaChange already expects and handles null (hasImagery).
+            panorama.setOnStreetViewPanoramaChangeListener(
+                NullSafeStreetViewPanoramaChangeListener { location ->
+                    handlePanoramaChange(view, state, location)
+                }
+            )
 
             view.visibility = View.VISIBLE
             state.applyIfReady(view)


### PR DESCRIPTION
## Summary

The app crashed on the closed-testing build shortly after the Street View fix (#380/#381) started working. Crash pulled directly from the device via logcat:

```
com.google.maps.api.android.lib6.common.apiexception.f: java.lang.NullPointerException:
Parameter specified as non-null is null: method
StreetViewManager.createViewInstance$lambda$3$lambda$2, parameter location
```

## Root cause

`OnStreetViewPanoramaChangeListener.onStreetViewPanoramaChange`'s `location` parameter is annotated `@NonNull` in the compiled Maps SDK — verified by decompiling `play-services-maps` **19.1.0**, the version actually resolved at build time (`build.gradle` pins `18.2.0`, but it's transitively bumped; this repo's copy is the same 19.1.0 that crashed on-device).

The SDK's real, documented behaviour is to call this listener with `location = null` when there is no Street View imagery at the requested position — that **is** how "no panorama" is reported, and `handlePanoramaChange` already expects and handles it (`hasImagery = location != null`, the `onNoPanorama` event). Google's own SDK contradicts its own annotation.

This isn't reachable from Kotlin at all, in either form: Kotlin enforces that an override's parameter nullability matches the annotated Java signature exactly, so neither a SAM lambda nor an explicit anonymous-object override can declare the parameter nullable — the compiler generates a null-check tied to whatever type Kotlin is forced to use, and that check throws the instant the SDK does exactly what its own contract says it will.

## Fix

`NullSafeStreetViewPanoramaChangeListener.java` implements the interface in **Java**, where Kotlin's null-check codegen doesn't apply, and forwards to a callback interface that's correctly annotated `@Nullable` on the Kotlin-facing side.

## Why this only surfaced today

This exact code is unchanged since the original implementation (`a46ac86`). It was never reachable before: the empty production API key (fixed in #380) rejected every panorama request outright, so the app never processed a real SDK response of any kind. Today's key fix is what let a request finally succeed — and it hit a real GPX route (Port Douglas, QLD) passing through an area with no Street View coverage within about an hour of testing. Not a rare edge case: most real-world routes will eventually cross a coverage gap, so every sufficiently long ride would have hit this.

## Test plan

- `compileDevKotlin` and `compileDevJavaWithJavac` both green.
- No automated test seam exists: the crash depends on Kotlin's compiled null-check bytecode interacting with a real Android runtime (JVM unit tests in this repo don't exercise that). Verified by decompiling the actually-resolved SDK class to confirm the `@NonNull` annotation and reproduce the exact failure mechanism.
- **Needs on-device confirmation** — ideally against a route/position with a known Street View coverage gap, to confirm the fix against the exact failure mode rather than just "didn't crash for a while."