### PR TITLE
ci(ios): pass MAPS_API_KEY_IOS to the archive step

### DIFF
--- a/.github/workflows/upload-testflight.yml
+++ b/.github/workflows/upload-testflight.yml
@@ -114,6 +114,16 @@ jobs:
 
       # ── Archive ─────────────────────────────────────────────────────────────
       - name: Archive
+        env:
+          # Read by ios/scripts/write-maps-key.sh, which writes GMSApiKey.plist
+          # into the built app. Without it the Release guard fails the archive
+          # deliberately: on Android an empty Maps key produced a build that
+          # installed and initialised cleanly, then had every Street View
+          # panorama request rejected, and shipped that way for months.
+          #
+          # The value never reaches the log — the build phase sets
+          # showEnvVarsInLog = 0 and the script reports presence only.
+          MAPS_API_KEY_IOS: ${{ secrets.MAPS_API_KEY_IOS }}
         run: |
           # Remove stale MapLibre signature if present (known MapLibre bug)
           find "$BUILD_DIR" -name "MapLibre.xcframework-ios.signature" -delete 2>/dev/null || true


### PR DESCRIPTION
## Summary

One-line change (plus comment) required before the first iOS TestFlight build containing Street View. **Without it the archive fails.**

```yaml
      - name: Archive
        env:
          MAPS_API_KEY_IOS: ${{ secrets.MAPS_API_KEY_IOS }}
        run: |
```

## Why the build fails without it

`ios/scripts/write-maps-key.sh` (added in #383) reads `MAPS_API_KEY_IOS` to write `GMSApiKey.plist` into the app bundle, and exits 1 when it is absent and `CONFIGURATION` is `Release`.

That guard is deliberate — a direct port of the one in `android/app/build.gradle` — and exists because an empty Maps key produces a build that compiles, installs and initialises cleanly, then has every Street View panorama request rejected. A black ride screen with nothing anywhere explaining it. That shipped to Android production undetected for months.

So the failure without this change is the guard working correctly, just 20 minutes into a CI run instead of immediately.

## Key safety

The value does not reach the build log:

- the Run Script phase sets `showEnvVarsInLog = 0` in `project.pbxproj` rather than relying on the Xcode checkbox, since `MAPS_API_KEY_IOS` is in the build environment by construction and Xcode prints the whole environment when that option is on
- the script reports presence only (`key present` / `key MISSING`), never the value, never a prefix, never a length

Verified on device builds: **0 key-shaped strings across a 7,276-line build log.**

Scoped to the Archive step rather than the job, so the value is absent from the environment of the checkout, dependency install and code-signing steps.

## Prerequisite

The `MAPS_API_KEY_IOS` repository secret must exist, with the key restricted to iOS apps / bundle ID `com.incyclist.app` and "Maps SDK for iOS" enabled.

## Test plan

- [x] YAML parses
- [ ] TestFlight archive succeeds and the log shows `note: GMSApiKey.plist written (key present)`
- [ ] Installed build reports `apiKey:present` / `provideAPIKey:true` in the app's event log — the M5 acceptance, and the only check that proves the CI key wiring rather than a local `.env`