### PR TITLE
fix(android): widen MainActivity configChanges to reduce Activity/RN-root recreation

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -39,7 +39,7 @@
         <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|density|uiMode"
         android:screenOrientation="sensorLandscape"         
         android:launchMode="singleTask"
         android:windowSoftInputMode="adjustResize"


### PR DESCRIPTION
## Summary

Widens `MainActivity`'s `android:configChanges` in `android/app/src/main/AndroidManifest.xml` to reduce how often Android destroys and recreates the app's Activity/RN root while the app is running. Ref: `FIXES_BACKLOG.md` item #41.

## What changed

```
- android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+ android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|density|uiMode"
```

Added: `screenLayout`, `smallestScreenSize`, `density`.

### Why these three, and not others

- **`screenLayout`, `smallestScreenSize`** — match the current React Native community template's own recommended `configChanges` list. Verified directly against `react-native-community/template@0.83.1` (this repo's `react-native` version, confirmed via `package.json`):
  ```
  android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
  ```
  Adopting these matches the community-vetted baseline for this RN version rather than inventing a bespoke list.

- **`density`** — added beyond the template baseline. Item #41's confirmed repro (Wave 6 real-device testing, 2026-08-13 update) used `adb shell wm size` on a Samsung tablet to force logical resolutions, which 100% reliably threw the app back to its `DEVICES` landing page — a clean Activity/RN-root recreation, not a live re-layout. The item notes real tablets also reach the same trigger organically via **DeX / split-screen docking**, and DeX mode in particular also changes display **density**, not just size — so `density` is directly in-scope for the same real-world trigger this item targets, not a speculative addition. The codebase audit (below) found no code path that depends on `density`/`PixelRatio` being read once and cached, so it carries no identified regression risk.

- **Left out**: `fontScale`, `locale`, `layoutDirection`, `navigation`, `touchscreen`. None of these are part of the RN 0.83.1 template's own list, none have an observed or plausible trigger for this app (single-locale, no navigation-hardware/touchscreen-hotswap scenario), and this is a native change that cannot be validated on a device in this environment — the added surface is kept to what's concretely justified rather than copied blindly from other config-change checklists.

`orientation` was already declared and is unaffected (the Activity is additionally locked via `android:screenOrientation="sensorLandscape"` and `Orientation.lockToLandscape()` in `Loader.tsx`).

## Audit: does anything rely on Activity recreation instead of RN's live dimension listeners?

Widening `configChanges` means Android no longer destroys+recreates the Activity for `screenLayout`/`smallestScreenSize`/`density` changes — any code that (incorrectly) depended on that recreation to pick up new dimensions would silently stop updating. Audited for this specifically:

**Checked:**
- `grep -rn "Dimensions.get"` and every `useWindowDimensions` call site across `src/` (~30 files).
- `grep` for `breakpoint`/`tier`/`Tier` keywords app-wide.
- `RoutesTable.tsx` (item #36's scroll-driven layout logic, called out explicitly in item #41).
- The ride-screen overlay layout stack: `useScreenLayout.ts`, `useRideOverlayLayout.ts`, `RideDashboard*`, `WorkoutDashboard.tsx`, `GPX/View.tsx`, `Video/View.tsx`.
- Every `useState({width:.../height:...})` initializer app-wide, to catch a one-time seed from a stale read.
- `PixelRatio` usage (relevant to the added `density` dimension specifically) — none found anywhere in `src/`.
- Native side: `MainActivity.kt`'s `onConfigurationChanged` override and whether anything (native or JS) listens for the broadcast Intent it sends.
- `MainApplication.kt`'s `reactHost`/`reactNativeHost` — confirmed these live at `Application` scope (`by lazy` on the `Application` instance), i.e. the JS engine/instance is **not** torn down on Activity recreation; only the Activity + `ReactRootView` are recreated and a new root view is attached to the same running JS context. This is the mechanism behind `Loader.tsx`'s boot effect re-firing that item #40/#41 identified: it's a component remount, not a JS-context restart.

**Result — nothing found that would regress:**
- Every screen-dimension-driven layout in the app (`RideDashboard`, `WorkoutDashboard`, `useRideOverlayLayout`, `useScreenLayout`, `NavigationBar`, `FilterPanel`, `DeviceSelector`, ride pages, dialogs, etc.) reads dimensions via the live `useWindowDimensions()` hook, which subscribes to RN's own dimension-change events — these fire correctly on an in-place `onConfigurationChanged` (the standard, template-default configuration for any RN app) independent of whether the Activity is recreated.
- `RoutesTable.tsx` does not read `Dimensions`/`useWindowDimensions` at all — its layout logic is driven by `onLayout`/scroll `nativeEvent.layoutMeasurement`, which is always live regardless of Activity lifecycle. Confirmed, not assumed.
- All local `useState({width, height})`-style state (`ActivityGraph`, `ElevationGraph`, `FilterPanel`, `SingleSelect`, `WorkoutGraph`) is populated via `onLayout` callbacks, not a one-time dimension read — safe.
- No `PixelRatio` usage anywhere, so the newly-added `density` dimension has no static/cached consumer to break.
- `MainActivity.kt`'s `onConfigurationChanged` override broadcasts an `Intent("onConfigurationChanged")` that **nothing listens for** (no native `BroadcastReceiver`, no JS `DeviceEventEmitter`/`NativeEventEmitter` subscriber found anywhere in the repo) — dead code, unaffected either way by this change.

**One pre-existing bug found, not a regression from this change:**
- `src/pages/PairingPage/View.tsx:9` — `const { height } = Dimensions.get('window'); const compact = height < 420` is read once at **module scope** (import time), not inside a hook. This value is already stale for the life of the JS engine regardless of this PR: as established above, Activity recreation does not re-execute JS module top-level code (only the component tree remounts) — the JS context and its module registry persist across Activity recreation today, before this change, and continue to after it. So this file's `compact` value was never live-updating on any config change, screenLayout/smallestScreenSize/density included, and widening `configChanges` does not change its behavior in either direction. Left unfixed as out-of-scope for this item — flagging here rather than silently leaving it undiscovered. (Compare `useScreenLayout.ts`, which computes the equivalent `compact` threshold correctly via the live `useWindowDimensions()` hook — a good candidate to align `PairingPage/View.tsx` to in a follow-up, but that's a separate, pre-existing issue.)

## Validation outstanding

**This is a native-only change requiring a full `mobile` app-store release** — it is not hot-updatable via `update-server`'s JS-bundle path.

**No real-device validation has been performed for this PR.** `adb devices` shows no device attached in this environment. Per item #41's own validation checklist, still outstanding before this should be considered production-ready:
- Repro on a low/mid-RAM Android device (ideally a Motorola moto g31(w) or similar, matching the original production report) confirming `RoutesPage`/`Loader` unmount frequency drops during the Import Routes → Add GPX → leave picker open repro.
- `adb shell wm size <W>x<H>` resize check on a real device (e.g. the Samsung tablet used in the Wave 6 test that confirmed this trigger) confirming the app **no longer** resets to the `DEVICES` landing page after this change.
- This PR does not attempt to distinguish whether config-change recreation was *also* the trigger in the original moto g31(w) production report, vs. genuine low-memory reclaim running in parallel — that still requires an `adb logcat` capture around a live repro on that device class, per item #41's original prompt. The config-change half of the hypothesis is independently confirmed (Wave 6, 2026-08-13) and is what this PR addresses; the memory-reclaim half remains open.

## Test plan

- [x] `npm test` — full suite: 104 suites / 709 tests, all passing.
- [ ] Real-device validation (see "Validation outstanding" above) — not performed, no device attached.

Ref: `FIXES_BACKLOG.md` item #41.
