### PR TITLE
fix: use installed native app version, not bundle-baked-in app.json value

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ import { MainPage } from './pages/MainPage/MainPage';
 import { NavigationBar } from '@zoontek/react-native-navigation-bar';
 import { SecretsStatus } from './bindings/secret/types';
 import { getMessageQueueBinding  } from './bindings/mq';
-import { isProdVariant } from './bindings/appInfo';
+import { getAppInfo, isProdVariant } from './bindings/appInfo';
 import { getUserSettingsBinding } from './bindings/user-settings';
 import { getSystemVersion, getTotalMemory, isEmulator } from 'react-native-device-info';
 
@@ -169,7 +169,7 @@ export const App = ({ secretsStatus }: AppProps) => {
 
     if (!initialized) {
         
-        return <LoadingScreen appVersion={app.appVersion} bundleVersion={app.bundleVersion} statusMessage='connecting ...' />;
+        return <LoadingScreen appVersion={getAppInfo().version} bundleVersion={app.bundleVersion} statusMessage='connecting ...' />;
     }
 
     return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ import { MainPage } from './pages/MainPage/MainPage';
 import { NavigationBar } from '@zoontek/react-native-navigation-bar';
 import { SecretsStatus } from './bindings/secret/types';
 import { getMessageQueueBinding  } from './bindings/mq';
-import { getAppInfo, isProdVariant } from './bindings/appInfo';
+import { getAppVersion, isProdVariant } from './bindings/appInfo';
 import { getUserSettingsBinding } from './bindings/user-settings';
 import { getSystemVersion, getTotalMemory, isEmulator } from 'react-native-device-info';
 
@@ -169,7 +169,7 @@ export const App = ({ secretsStatus }: AppProps) => {
 
     if (!initialized) {
         
-        return <LoadingScreen appVersion={getAppInfo().version} bundleVersion={app.bundleVersion} statusMessage='connecting ...' />;
+        return <LoadingScreen appVersion={getAppVersion()} bundleVersion={app.bundleVersion} statusMessage='connecting ...' />;
     }
 
     return (

--- a/src/Loader.tsx
+++ b/src/Loader.tsx
@@ -12,6 +12,7 @@ import { UpdateService } from './services/UpdateManager';
 import { getSecret, getSecretsStatus, initSecrets } from './bindings/secret';
 import { SecretsStatus } from './bindings/secret/types';
 import { getUserSettingsBinding } from './bindings/user-settings';
+import { getAppInfo } from './bindings/appInfo';
 
 const initApi = async ()=> {
     const apiKey = getSecret('INCYCLIST_API_KEY');
@@ -79,8 +80,8 @@ export const Loader = () =>{
 
     if (isLoading) {
         return (
-            <LoadingScreen 
-                appVersion={app.appVersion} 
+            <LoadingScreen
+                appVersion={getAppInfo().version}
                 bundleVersion={app.bundleVersion}
                 statusMessage={statusMessage}
             />

--- a/src/Loader.tsx
+++ b/src/Loader.tsx
@@ -12,7 +12,7 @@ import { UpdateService } from './services/UpdateManager';
 import { getSecret, getSecretsStatus, initSecrets } from './bindings/secret';
 import { SecretsStatus } from './bindings/secret/types';
 import { getUserSettingsBinding } from './bindings/user-settings';
-import { getAppInfo } from './bindings/appInfo';
+import { getAppVersion } from './bindings/appInfo';
 
 const initApi = async ()=> {
     const apiKey = getSecret('INCYCLIST_API_KEY');
@@ -81,7 +81,7 @@ export const Loader = () =>{
     if (isLoading) {
         return (
             <LoadingScreen
-                appVersion={getAppInfo().version}
+                appVersion={getAppVersion()}
                 bundleVersion={app.bundleVersion}
                 statusMessage={statusMessage}
             />

--- a/src/bindings/appInfo/index.ts
+++ b/src/bindings/appInfo/index.ts
@@ -18,13 +18,18 @@ export const getChannel = ():AppChannel=> {
     return 'mobile' as AppChannel
 }
 
+/**
+ * The real installed native app version - the single place this value is defined.
+ *
+ * appJson.appVersion must never be used for this: it is baked into the JS bundle at build time,
+ * and that bundle is served as a hot update to every installed native version, so it would report
+ * the same value on every device regardless of what native version is actually installed.
+ */
+export const getAppVersion = ():string => DeviceInfo.getVersion();
+
 export const getAppInfo = () => {
     const {name} = info;
-    // DeviceInfo.getVersion() reads the real installed native app version. appJson.appVersion
-    // must not be used here: it is baked into this JS bundle at build time, and this bundle is
-    // served as a hot update to every installed native version, so it would report the same
-    // value on every device regardless of what native version is actually installed.
-    const appVersion = DeviceInfo.getVersion();
+    const appVersion = getAppVersion();
     const appDir = RNFS.DocumentDirectoryPath;
     const tempDir = RNFS.TemporaryDirectoryPath;
 
@@ -48,8 +53,7 @@ export const getAppInfoBinding = async () => {
 
     return {
         getOS,
-        // Real installed native version - see getAppInfo() above for why appJson.appVersion is wrong here.
-        getAppVersion:()=>DeviceInfo.getVersion(),
+        getAppVersion,
         getUIVersion,
         getAppDir:()=>RNFS.DocumentDirectoryPath,
         getSourceDir:()=>'',

--- a/src/services/UpdateManager/UpdateService.test.ts
+++ b/src/services/UpdateManager/UpdateService.test.ts
@@ -26,7 +26,7 @@ jest.mock('react-native-default-preference', () => ({
 jest.mock('../../bindings/appInfo', () => ({
     isDevVariant: false,
     isProdVariant: true,
-    getAppInfoBinding: jest.fn(),
+    getAppVersion: jest.fn(),
 }));
 
 jest.mock('../../bindings/user-settings', () => ({
@@ -48,13 +48,13 @@ jest.mock('../../../app.json', () => ({
 }));
 
 import DefaultPreference from 'react-native-default-preference';
-import { getAppInfoBinding } from '../../bindings/appInfo';
+import { getAppVersion } from '../../bindings/appInfo';
 import { getUserSettingsBinding } from '../../bindings/user-settings';
 import { getSecret } from '../../bindings/secret';
 import { UpdateService } from './UpdateService';
 
 describe('UpdateService - x-app-version header', () => {
-    const NATIVE_VERSION = '9.9.9'; // the real installed native version, per DeviceInfo/getAppInfoBinding
+    const NATIVE_VERSION = '9.9.9'; // the real installed native version, per DeviceInfo/getAppVersion
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -66,9 +66,7 @@ describe('UpdateService - x-app-version header', () => {
 
         (getSecret as jest.Mock).mockReturnValue(undefined);
 
-        (getAppInfoBinding as jest.Mock).mockResolvedValue({
-            getAppVersion: () => NATIVE_VERSION,
-        });
+        (getAppVersion as jest.Mock).mockReturnValue(NATIVE_VERSION);
 
         (DefaultPreference.get as jest.Mock).mockResolvedValue(null);
 

--- a/src/services/UpdateManager/UpdateService.test.ts
+++ b/src/services/UpdateManager/UpdateService.test.ts
@@ -1,0 +1,92 @@
+jest.mock('@settings', () => ({ __esModule: true, default: { APP_ENV: 'test' } }), { virtual: true });
+
+jest.mock('react-native-fs', () => ({
+    __esModule: true,
+    exists: jest.fn().mockResolvedValue(false),
+    mkdir: jest.fn().mockResolvedValue(undefined),
+    unlink: jest.fn().mockResolvedValue(undefined),
+    readDir: jest.fn().mockResolvedValue([]),
+    downloadFile: jest.fn(),
+    DocumentDirectoryPath: '/doc',
+    CachesDirectoryPath: '/cache',
+}));
+
+jest.mock('react-native-zip-archive', () => ({
+    unzip: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('react-native-default-preference', () => ({
+    __esModule: true,
+    default: {
+        get: jest.fn(),
+        set: jest.fn().mockResolvedValue(undefined),
+    },
+}));
+
+jest.mock('../../bindings/appInfo', () => ({
+    isDevVariant: false,
+    isProdVariant: true,
+    getAppInfoBinding: jest.fn(),
+}));
+
+jest.mock('../../bindings/user-settings', () => ({
+    getUserSettingsBinding: jest.fn(),
+}));
+
+jest.mock('../../bindings/secret', () => ({
+    getSecret: jest.fn(),
+}));
+
+// app.json's appVersion is baked into the JS bundle at build time and can trail (or lead) the
+// real installed native version once this bundle is served as a hot update - deliberately
+// different from the mocked getAppVersion() below so the test fails if the header regresses
+// to reading app.json again.
+jest.mock('../../../app.json', () => ({
+    name: 'incyclist',
+    appVersion: '1.0.20',
+    bundleVersion: '0.1.0',
+}));
+
+import DefaultPreference from 'react-native-default-preference';
+import { getAppInfoBinding } from '../../bindings/appInfo';
+import { getUserSettingsBinding } from '../../bindings/user-settings';
+import { getSecret } from '../../bindings/secret';
+import { UpdateService } from './UpdateService';
+
+describe('UpdateService - x-app-version header', () => {
+    const NATIVE_VERSION = '9.9.9'; // the real installed native version, per DeviceInfo/getAppInfoBinding
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        (getUserSettingsBinding as jest.Mock).mockReturnValue({
+            getAll: jest.fn().mockResolvedValue(undefined),
+            getValue: jest.fn().mockReturnValue('test-uuid'),
+        });
+
+        (getSecret as jest.Mock).mockReturnValue(undefined);
+
+        (getAppInfoBinding as jest.Mock).mockResolvedValue({
+            getAppVersion: () => NATIVE_VERSION,
+        });
+
+        (DefaultPreference.get as jest.Mock).mockResolvedValue(null);
+
+        global.fetch = jest.fn().mockResolvedValue({ ok: false });
+    });
+
+    afterEach(() => {
+        // @ts-ignore - test-only cleanup of the global fetch stub
+        delete global.fetch;
+    });
+
+    test('sends the installed native version (device-info binding), not app.json`s bundle-baked-in appVersion', async () => {
+        await UpdateService.checkForUpdates();
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+
+        const [, options] = (global.fetch as jest.Mock).mock.calls[0];
+        expect(options.headers['x-app-version']).toBe(NATIVE_VERSION);
+        expect(options.headers['x-app-version']).not.toBe('1.0.20');
+    });
+});

--- a/src/services/UpdateManager/UpdateService.ts
+++ b/src/services/UpdateManager/UpdateService.ts
@@ -2,7 +2,7 @@ import { unzip } from 'react-native-zip-archive';
 import DefaultPreference from 'react-native-default-preference';
 import { name as appName } from '../../../app.json';
 import { CachesDirectoryPath, DocumentDirectoryPath, downloadFile, DownloadFileOptions, exists, mkdir, readDir, unlink } from 'react-native-fs';
-import { isDevVariant, isProdVariant, getAppInfoBinding  } from '../../bindings/appInfo';
+import { isDevVariant, isProdVariant, getAppVersion  } from '../../bindings/appInfo';
 import settings from '@settings'
 import { EventLogger } from 'gd-eventlog';
 import { getUserSettingsBinding } from '../../bindings/user-settings';
@@ -115,9 +115,7 @@ export class UpdateService {
 
         this.logger.logEvent({message:'Request bundle info',url});
 
-        // Real installed native version, not app.json's bundle-baked-in appVersion - see
-        // bindings/appInfo/index.ts for why the latter would misreport the running device.
-        const appVersion = (await getAppInfoBinding()).getAppVersion();
+        const appVersion = getAppVersion();
 
         const headers: Record<string, string> = {
             'x-uuid': uuid,
@@ -163,9 +161,7 @@ export class UpdateService {
         const BASE_URL = await getBaseUrl()
         const url = bundleInfo.bundleUrl?.startsWith('http') ?  bundleUrl : `${BASE_URL}${bundleUrl}`
 
-        // Real installed native version, not app.json's bundle-baked-in appVersion - see
-        // bindings/appInfo/index.ts for why the latter would misreport the running device.
-        const appVersion = (await getAppInfoBinding()).getAppVersion();
+        const appVersion = getAppVersion();
 
         const headers: Record<string, string> = {
             'x-uuid': uuid,

--- a/src/services/UpdateManager/UpdateService.ts
+++ b/src/services/UpdateManager/UpdateService.ts
@@ -1,8 +1,8 @@
 import { unzip } from 'react-native-zip-archive';
 import DefaultPreference from 'react-native-default-preference';
-import { name as appName, appVersion } from '../../../app.json';
+import { name as appName } from '../../../app.json';
 import { CachesDirectoryPath, DocumentDirectoryPath, downloadFile, DownloadFileOptions, exists, mkdir, readDir, unlink } from 'react-native-fs';
-import { isDevVariant, isProdVariant  } from '../../bindings/appInfo';
+import { isDevVariant, isProdVariant, getAppInfoBinding  } from '../../bindings/appInfo';
 import settings from '@settings'
 import { EventLogger } from 'gd-eventlog';
 import { getUserSettingsBinding } from '../../bindings/user-settings';
@@ -115,6 +115,10 @@ export class UpdateService {
 
         this.logger.logEvent({message:'Request bundle info',url});
 
+        // Real installed native version, not app.json's bundle-baked-in appVersion - see
+        // bindings/appInfo/index.ts for why the latter would misreport the running device.
+        const appVersion = (await getAppInfoBinding()).getAppVersion();
+
         const headers: Record<string, string> = {
             'x-uuid': uuid,
             'x-app-channel': 'mobile',
@@ -158,6 +162,10 @@ export class UpdateService {
 
         const BASE_URL = await getBaseUrl()
         const url = bundleInfo.bundleUrl?.startsWith('http') ?  bundleUrl : `${BASE_URL}${bundleUrl}`
+
+        // Real installed native version, not app.json's bundle-baked-in appVersion - see
+        // bindings/appInfo/index.ts for why the latter would misreport the running device.
+        const appVersion = (await getAppInfoBinding()).getAppVersion();
 
         const headers: Record<string, string> = {
             'x-uuid': uuid,


### PR DESCRIPTION
## Summary

`app.json` is baked into the JS bundle at build time, but that bundle is served as a hot update to devices on *any* installed native version — so `app.json`'s `appVersion` reports whatever version was current when the bundle was built, not what's actually installed on the device. `src/bindings/appInfo/index.ts` already documents this and correctly reads `DeviceInfo.getVersion()`, but three call sites still read `app.json.appVersion` directly.

Fixes `FIXES_BACKLOG.md` item #50. See also §2.1 of `mobile/internal/designs/ota-bundle-native-compat-design.md` (root-cause writeup for this same misreport, filed as a prerequisite for the native-version-gate design in that doc).

## What changed

- `src/Loader.tsx` — `LoadingScreen`'s `appVersion` now comes from `getAppInfo().version` (the existing `bindings/appInfo` helper wrapping `DeviceInfo.getVersion()`) instead of `app.appVersion`.
- `src/App.tsx` — same fix for the second `LoadingScreen` render.
- `src/services/UpdateManager/UpdateService.ts` — no longer imports `appVersion` from `app.json`. Both outgoing requests (`fetchBundleInfo` and `applyUpdate`) now await `getAppInfoBinding().getAppVersion()` and send that as the `x-app-version` header — the header the update-server matches `minAppVersion`/`maxAppVersion` ranges against.
- `src/services/UpdateManager/UpdateService.test.ts` — new unit test asserting the `x-app-version` header comes from the device-info binding, not `app.json`, with the two values deliberately set to differ. Verified the test fails against the pre-fix code and passes against the fix.

`bundleVersion`/UI-version handling is untouched — `app.json`'s `bundleVersion` correctly describes the bundle it's baked into; only `appVersion` was wrong.

## Rollout note

This changes which `mobile.json` range some devices match against the update-server — that's the intended effect of the fix, but **it is not a no-op**. Any device whose baked-in `app.json` version trailed (or led) its real native version moves ranges the moment this bundle ships, and will then be offered whatever that other range specifies, or 404 if no range covers its true version.

**Before publishing this bundle:** review the live `mobile.json` against the real installed-native-version spread to confirm no range gap opens up.

This also **invalidates the per-uuid override workaround** described in §8 of the design doc, which works precisely because the affected devices currently misreport 1.0.20 as their app version — confirm those specific devices are already on bundle 0.1.0 before shipping, or recover them another way.

## Test plan

- [x] `npx jest` — full suite: 105 suites / 710 tests passed (including the new `UpdateService.test.ts`)
- [x] `npx tsc --noEmit` — clean
- [x] Confirmed the new test fails against the pre-fix `UpdateService.ts` (stashed the fix, re-ran, got `Expected: "9.9.9", Received: "1.0.20"`) and passes with the fix restored