### PR TITLE
diag(ride): trace + instrument iOS start-overlay Start-button gap (FIXES_BACKLOG #52)

### DIFF
--- a/src/components/StartRideDisplay/StartRideDisplay.test.tsx
+++ b/src/components/StartRideDisplay/StartRideDisplay.test.tsx
@@ -2,15 +2,21 @@ import React from 'react';
 import { render } from '@testing-library/react-native';
 import { StartRideDisplay } from './StartRideDisplay';
 import { StartRideDisplayProps } from './types';
+import { CurrentRideDeviceInfo } from 'incyclist-services';
 
 const noop = () => {};
 
+const trainer = (status: CurrentRideDeviceInfo['status']): CurrentRideDeviceInfo => ({
+    udid: 'trainer-1', name: 'Smart Trainer', isControl: true, status, capabilities: ['control'],
+});
+
+const hrm = (status: CurrentRideDeviceInfo['status']): CurrentRideDeviceInfo => ({
+    udid: 'hrm-1', name: 'HRM', isControl: false, status, capabilities: ['heartrate'],
+});
+
 const baseProps = {
     mode: 'GPX',
-    devices: [
-        { udid: 'trainer-1', name: 'Smart Trainer', isControl: true, status: 'Starting' },
-        { udid: 'hrm-1', name: 'HRM', isControl: false, status: 'Starting' },
-    ],
+    devices: [trainer('Starting'), hrm('Starting')],
     mapType: 'Street View',
     mapState: 'Loaded',
     onStart: noop,
@@ -46,14 +52,8 @@ describe('StartRideDisplay', () => {
     //   1. trainer Started, HRM Starting,  readyToStart:true
     //   2. trainer Started, HRM Error,     readyToStart:true
     it('re-renders to show the Start button when props update from readyToStart:false to true with a failed non-control device', () => {
-        const devicesHrmStarting = [
-            { udid: 'trainer-1', name: 'Smart Trainer', isControl: true, status: 'Starting' },
-            { udid: 'hrm-1', name: 'HRM', isControl: false, status: 'Starting' },
-        ];
-        const devicesHrmError = [
-            { udid: 'trainer-1', name: 'Smart Trainer', isControl: true, status: 'Started' },
-            { udid: 'hrm-1', name: 'HRM', isControl: false, status: 'Error' },
-        ];
+        const devicesHrmStarting = [trainer('Starting'), hrm('Starting')];
+        const devicesHrmError = [trainer('Started'), hrm('Error')];
 
         const { getByText, queryByText, rerender } = render(
             <StartRideDisplay
@@ -93,10 +93,7 @@ describe('StartRideDisplay', () => {
     });
 
     it('shows the sensor-error dialog (not the starting dialog) once rideState actually becomes Error', () => {
-        const devices = [
-            { udid: 'trainer-1', name: 'Smart Trainer', isControl: true, status: 'Started' },
-            { udid: 'hrm-1', name: 'HRM', isControl: false, status: 'Error' },
-        ];
+        const devices = [trainer('Started'), hrm('Error')];
 
         const { getByText, queryByText } = render(
             <StartRideDisplay {...baseProps} devices={devices} rideState="Error" readyToStart={true} />

--- a/src/components/StartRideDisplay/StartRideDisplay.test.tsx
+++ b/src/components/StartRideDisplay/StartRideDisplay.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { StartRideDisplay } from './StartRideDisplay';
+import { StartRideDisplayProps } from './types';
+
+const noop = () => {};
+
+const baseProps = {
+    mode: 'GPX',
+    devices: [
+        { udid: 'trainer-1', name: 'Smart Trainer', isControl: true, status: 'Starting' },
+        { udid: 'hrm-1', name: 'HRM', isControl: false, status: 'Starting' },
+    ],
+    mapType: 'Street View',
+    mapState: 'Loaded',
+    onStart: noop,
+    onRetry: noop,
+    onCancel: noop,
+    onIgnore: noop,
+} as unknown as StartRideDisplayProps;
+
+describe('StartRideDisplay', () => {
+    it('offers only Cancel while not ready to start', () => {
+        const { getByText, queryByText } = render(
+            <StartRideDisplay {...baseProps} rideState="Starting" readyToStart={false} />
+        );
+
+        expect(getByText('Cancel')).toBeTruthy();
+        expect(queryByText('Start')).toBeNull();
+    });
+
+    it('offers Start + Cancel once readyToStart is true', () => {
+        const { getByText } = render(
+            <StartRideDisplay {...baseProps} rideState="Starting" readyToStart={true} />
+        );
+
+        expect(getByText('Start')).toBeTruthy();
+        expect(getByText('Cancel')).toBeTruthy();
+    });
+
+    // FIXES_BACKLOG #52 — the reported iOS scenario: a non-control device (HRM) fails while the
+    // control device (trainer) has already started. `rideState` stays 'Starting' (not 'Error'),
+    // so the sensor-error dialog must not take over — the 'starting' dialog stays up and, once
+    // `readyToStart` flips true, must offer the Start button so the rider can proceed without the
+    // failed sensor. This drives the exact prop transition from the backlog's captured log:
+    //   1. trainer Started, HRM Starting,  readyToStart:true
+    //   2. trainer Started, HRM Error,     readyToStart:true
+    it('re-renders to show the Start button when props update from readyToStart:false to true with a failed non-control device', () => {
+        const devicesHrmStarting = [
+            { udid: 'trainer-1', name: 'Smart Trainer', isControl: true, status: 'Starting' },
+            { udid: 'hrm-1', name: 'HRM', isControl: false, status: 'Starting' },
+        ];
+        const devicesHrmError = [
+            { udid: 'trainer-1', name: 'Smart Trainer', isControl: true, status: 'Started' },
+            { udid: 'hrm-1', name: 'HRM', isControl: false, status: 'Error' },
+        ];
+
+        const { getByText, queryByText, rerender } = render(
+            <StartRideDisplay
+                {...baseProps}
+                devices={devicesHrmStarting}
+                rideState="Starting"
+                readyToStart={false}
+            />
+        );
+
+        expect(queryByText('Start')).toBeNull();
+
+        // trainer Started, HRM Starting, readyToStart:true (first logged update)
+        rerender(
+            <StartRideDisplay
+                {...baseProps}
+                devices={devicesHrmStarting}
+                rideState="Starting"
+                readyToStart={true}
+            />
+        );
+        expect(getByText('Start')).toBeTruthy();
+
+        // trainer Started, HRM Error, readyToStart:true (second logged update) - still 'Starting',
+        // so the sensor-error dialog (Retry/Ignore/Cancel) must NOT take over; Start must remain.
+        rerender(
+            <StartRideDisplay
+                {...baseProps}
+                devices={devicesHrmError}
+                rideState="Starting"
+                readyToStart={true}
+            />
+        );
+        expect(getByText('Start')).toBeTruthy();
+        expect(queryByText('Retry')).toBeNull();
+        expect(queryByText('Ignore')).toBeNull();
+    });
+
+    it('shows the sensor-error dialog (not the starting dialog) once rideState actually becomes Error', () => {
+        const devices = [
+            { udid: 'trainer-1', name: 'Smart Trainer', isControl: true, status: 'Started' },
+            { udid: 'hrm-1', name: 'HRM', isControl: false, status: 'Error' },
+        ];
+
+        const { getByText, queryByText } = render(
+            <StartRideDisplay {...baseProps} devices={devices} rideState="Error" readyToStart={true} />
+        );
+
+        expect(getByText('Retry')).toBeTruthy();
+        expect(getByText('Ignore')).toBeTruthy();
+        expect(queryByText('Start')).toBeNull();
+    });
+});

--- a/src/components/StartRideDisplay/StartRideDisplay.tsx
+++ b/src/components/StartRideDisplay/StartRideDisplay.tsx
@@ -2,16 +2,24 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { Dialog } from '../../components/Dialog';
 import { colors, textSizes } from '../../theme';
-import { useScreenLayout } from '../../hooks';
-import { 
+import { useScreenLayout, useWhyDidYouRender } from '../../hooks';
+import {
     CurrentRideDeviceInfo,
     RideMapState,
     StartRideDisplayProps,
-    VideoStartOverlayProps, 
+    VideoStartOverlayProps,
 } from './types';
 
 export const StartRideDisplay = (props: StartRideDisplayProps) => {
     const { devices, rideState, readyToStart, onStart, onRetry, onCancel, onIgnore } = props;
+
+    // FIXES_BACKLOG #52 — iOS start overlay was reported stuck showing Cancel-only although
+    // services logged readyToStart:true. No re-render/memoization bug was found while tracing the
+    // observer -> page-service -> StartRideDisplay chain (see PR description), but the log that
+    // triggered this investigation had no re-render information for this component at all, only
+    // for StreetView. Log every prop-reference change here so a recurrence can be diagnosed
+    // straight from a user's event log without a reproduction.
+    useWhyDidYouRender('StartRideDisplay', props, true);
 
     const layout = useScreenLayout();
 

--- a/src/pages/RidePage/GPX/GPXTourPage.test.tsx
+++ b/src/pages/RidePage/GPX/GPXTourPage.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { act, render } from '@testing-library/react-native';
+import { GPXTourPage } from './GPXTourPage';
+
+// FIXES_BACKLOG #52 — traces the observer/subscription half of the chain: does GPXTourPage's
+// 'page-update' handler actually pick up a fresh getPageDisplayProps() result and push it down to
+// the view as new React state? (The View -> StartRideDisplay rendering half is covered separately
+// by View.startOverlayButton.test.tsx and StartRideDisplay.test.tsx.)
+//
+// Mirrors the FakeObserver pattern from RidePage.test.tsx and the service-mock shape from
+// WorkoutRidePage.test.tsx.
+
+class FakeObserver {
+    handlers: Record<string, Array<(...args: any[]) => void>> = {};
+    on = jest.fn((event: string, cb: (...args: any[]) => void) => {
+        (this.handlers[event] ??= []).push(cb);
+        return this;
+    });
+    off = jest.fn((event: string, cb: (...args: any[]) => void) => {
+        this.handlers[event] = (this.handlers[event] ?? []).filter(h => h !== cb);
+        return this;
+    });
+    emit(event: string, ...args: any[]) {
+        [...(this.handlers[event] ?? [])].forEach(h => h(...args));
+    }
+}
+
+const pageObserver = new FakeObserver();
+const rideObserver = new FakeObserver();
+
+const mockClosePage = jest.fn();
+const mockOpenPage = jest.fn(() => pageObserver as any);
+const mockGetRideObserver = jest.fn(() => rideObserver as any);
+
+// Exact evidence from FIXES_BACKLOG #52's captured log.
+const devicesHrmStarting = [
+    { udid: 'trainer-1', name: 'Smart Trainer', isControl: true, status: 'Started' },
+    { udid: 'hrm-1', name: 'HRM', isControl: false, status: 'Starting' },
+];
+const devicesHrmError = [
+    { udid: 'trainer-1', name: 'Smart Trainer', isControl: true, status: 'Started' },
+    { udid: 'hrm-1', name: 'HRM', isControl: false, status: 'Error' },
+];
+
+const notReadyProps = {
+    rideState: 'Starting',
+    rideType: 'GPX',
+    startOverlayProps: {
+        mode: 'GPX', rideState: 'Starting', devices: devicesHrmStarting, readyToStart: false,
+        mapType: 'Street View', mapState: 'Loaded',
+    },
+    menuProps: null,
+    startGateProps: null,
+};
+const readyPropsHrmStarting = {
+    ...notReadyProps,
+    startOverlayProps: {
+        mode: 'GPX', rideState: 'Starting', devices: devicesHrmStarting, readyToStart: true,
+        mapType: 'Street View', mapState: 'Loaded',
+    },
+};
+const readyPropsHrmError = {
+    ...notReadyProps,
+    startOverlayProps: {
+        mode: 'GPX', rideState: 'Starting', devices: devicesHrmError, readyToStart: true,
+        mapType: 'Street View', mapState: 'Loaded',
+    },
+};
+
+const mockGetPageDisplayProps = jest.fn(() => notReadyProps as any);
+
+jest.mock('incyclist-services', () => ({
+    getRidePageService: () => ({
+        openPage: mockOpenPage,
+        closePage: mockClosePage,
+        getRideObserver: mockGetRideObserver,
+        getPageDisplayProps: mockGetPageDisplayProps,
+        onMenuOpen: jest.fn(),
+        onMenuClose: jest.fn(),
+        onRetryStart: jest.fn(),
+        onIgnoreStart: jest.fn(),
+        getGraphActuals: jest.fn(() => ({ power: [], heartrate: [], position: 0 })),
+        onToggleCornerWidget: jest.fn(),
+        onStopWorkout: jest.fn(),
+    }),
+}));
+
+const mockView = jest.fn();
+jest.mock('./View', () => ({
+    GPXTourPageView: (props: any) => {
+        mockView(props);
+        return null;
+    },
+}));
+
+jest.mock('../../../components', () => ({
+    MainBackground: () => null,
+    ErrorBoundary: ({ children }: any) => children,
+}));
+
+describe('GPXTourPage — page-update subscription wiring (FIXES_BACKLOG #52)', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        pageObserver.handlers = {};
+        rideObserver.handlers = {};
+        mockGetPageDisplayProps.mockReturnValue(notReadyProps as any);
+    });
+
+    it('registers a page-update listener on the observer openPage() returns', () => {
+        render(<GPXTourPage onRideTypeChange={() => {}} onCancelStart={() => {}} onClose={() => {}} />);
+        expect(pageObserver.handlers['page-update']?.length).toBe(1);
+    });
+
+    it('propagates a readyToStart:false -> true transition from a page-update event down to the view, exactly as the two logged updates did', () => {
+        render(<GPXTourPage onRideTypeChange={() => {}} onCancelStart={() => {}} onClose={() => {}} />);
+
+        expect(mockView.mock.calls.at(-1)?.[0].displayProps.startOverlayProps.readyToStart).toBe(false);
+
+        // First logged update: trainer Started, HRM Starting, readyToStart:true
+        mockGetPageDisplayProps.mockReturnValue(readyPropsHrmStarting as any);
+        act(() => { pageObserver.emit('page-update'); });
+        expect(mockView.mock.calls.at(-1)?.[0].displayProps.startOverlayProps.readyToStart).toBe(true);
+        expect(mockView.mock.calls.at(-1)?.[0].displayProps.startOverlayProps.devices).toEqual(devicesHrmStarting);
+
+        // Second logged update, 6ms later per the log: HRM now Error, readyToStart still true
+        mockGetPageDisplayProps.mockReturnValue(readyPropsHrmError as any);
+        act(() => { pageObserver.emit('page-update'); });
+        expect(mockView.mock.calls.at(-1)?.[0].displayProps.startOverlayProps.readyToStart).toBe(true);
+        expect(mockView.mock.calls.at(-1)?.[0].displayProps.startOverlayProps.devices).toEqual(devicesHrmError);
+    });
+
+    it('unsubscribes from page-update on unmount', () => {
+        const { unmount } = render(
+            <GPXTourPage onRideTypeChange={() => {}} onCancelStart={() => {}} onClose={() => {}} />
+        );
+        expect(pageObserver.handlers['page-update']?.length).toBe(1);
+
+        unmount();
+        expect(pageObserver.handlers['page-update']?.length).toBe(0);
+        expect(mockClosePage).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/pages/RidePage/GPX/View.startOverlayButton.test.tsx
+++ b/src/pages/RidePage/GPX/View.startOverlayButton.test.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { GPXTourPageView, GPXTourPageViewProps } from './View';
+
+// FIXES_BACKLOG #52 — the earlier View.test.tsx suite mocks StartRideDisplay itself (to assert
+// which handler the "Start" button is wired to), which cannot catch a re-render/propagation bug
+// inside StartRideDisplay or its children (Dialog/ButtonBar). This file keeps StartRideDisplay
+// (and its real Dialog/ButtonBar) unmocked so a rerender of `displayProps` actually exercises the
+// real component tree, end to end: GPXTourPageView -> StartRideDisplay -> Dialog -> ButtonBar ->
+// rendered button text. Everything else stays mocked (native/heavy siblings), matching the
+// established pattern in View.test.tsx.
+
+jest.mock('react-native-device-info', () => ({
+    isTablet: () => false,
+}));
+
+jest.mock('../../../components', () => {
+    // Pull StartRideDisplay in directly from its own module (not the full barrel) - the barrel
+    // also re-exports RoutesTable -> RouteItem -> SecureImage -> bindings/fs, which drags in
+    // react-native-fs (TS syntax Jest can't parse without the RN preset's transform). Its own
+    // Dialog/ButtonBar imports are separate module specifiers, so they stay real and untouched.
+    const { StartRideDisplay } = jest.requireActual('../../../components/StartRideDisplay');
+    return {
+        StartRideDisplay,
+        Button: () => null,
+        Dynamic: ({ children }: any) => children,
+        ElevationGraph: () => null,
+        FreeMap: () => null,
+        MainBackground: () => null,
+        RideDashboard: () => null,
+        RideMenu: () => null,
+        WorkoutRideOverlay: () => null,
+    };
+});
+
+const mockUseScreenLayout = jest.fn(() => 'normal');
+jest.mock('../../../hooks', () => {
+    const actual = jest.requireActual('../../../hooks');
+    return {
+        ...actual,
+        useScreenLayout: () => mockUseScreenLayout(),
+    };
+});
+
+jest.mock('../../../components/StreetView', () => ({ StreetView: () => null }));
+
+const baseProps: GPXTourPageViewProps = {
+    displayProps: {
+        startOverlayProps: null,
+        menuProps: null,
+        rideView: 'map',
+        route: undefined,
+        displayObserver: undefined,
+    } as any,
+    rideObserver: null,
+    onMenuOpen: () => {},
+    onMenuClose: () => {},
+    onCloseRidePage: () => {},
+    onRetryStart: () => {},
+    onIgnoreStart: () => {},
+    onCancelStart: () => {},
+    getGraphActuals: () => ({ power: [], heartrate: [], position: 0 }),
+    onToggleCornerWidget: () => {},
+    onStopWorkout: () => {},
+};
+
+// The exact evidence captured in FIXES_BACKLOG #52 (iOS, HRM deliberately off):
+//   1. trainer Started, HRM Starting,  rideState:Starting, readyToStart:true
+//   2. trainer Started, HRM Error,     rideState:Starting, readyToStart:true
+const devicesHrmStarting = [
+    { udid: 'trainer-1', name: 'Smart Trainer', isControl: true, status: 'Started' },
+    { udid: 'hrm-1', name: 'HRM', isControl: false, status: 'Starting' },
+];
+const devicesHrmError = [
+    { udid: 'trainer-1', name: 'Smart Trainer', isControl: true, status: 'Started' },
+    { udid: 'hrm-1', name: 'HRM', isControl: false, status: 'Error' },
+];
+
+const withStartOverlay = (overlay: any): GPXTourPageViewProps => ({
+    ...baseProps,
+    displayProps: {
+        ...baseProps.displayProps,
+        startOverlayProps: overlay,
+    } as any,
+});
+
+describe('GPXTourPageView -> StartRideDisplay propagation (FIXES_BACKLOG #52)', () => {
+    it('renders only Cancel while not ready to start', () => {
+        const { getByText, queryByText } = render(
+            <GPXTourPageView {...withStartOverlay({
+                mode: 'GPX',
+                rideState: 'Starting',
+                devices: devicesHrmStarting,
+                readyToStart: false,
+                mapType: 'Street View',
+                mapState: 'Loaded',
+            })} />
+        );
+
+        expect(getByText('Cancel')).toBeTruthy();
+        expect(queryByText('Start')).toBeNull();
+    });
+
+    it('re-renders to show Start once a fresh page-service update reports readyToStart:true, with the control device Started and the HRM failed', () => {
+        const { getByText, queryByText, rerender } = render(
+            <GPXTourPageView {...withStartOverlay({
+                mode: 'GPX',
+                rideState: 'Starting',
+                devices: devicesHrmStarting,
+                readyToStart: false,
+                mapType: 'Street View',
+                mapState: 'Loaded',
+            })} />
+        );
+        expect(queryByText('Start')).toBeNull();
+
+        // First logged update: trainer Started, HRM still Starting, readyToStart:true
+        rerender(
+            <GPXTourPageView {...withStartOverlay({
+                mode: 'GPX',
+                rideState: 'Starting',
+                devices: devicesHrmStarting,
+                readyToStart: true,
+                mapType: 'Street View',
+                mapState: 'Loaded',
+            })} />
+        );
+        expect(getByText('Start')).toBeTruthy();
+
+        // Second logged update: HRM now Error, rideState still Starting, readyToStart:true -
+        // this is the exact prop set the user was stuck looking at with only Cancel on iOS.
+        rerender(
+            <GPXTourPageView {...withStartOverlay({
+                mode: 'GPX',
+                rideState: 'Starting',
+                devices: devicesHrmError,
+                readyToStart: true,
+                mapType: 'Street View',
+                mapState: 'Loaded',
+            })} />
+        );
+        expect(getByText('Start')).toBeTruthy();
+        expect(getByText('Cancel')).toBeTruthy();
+    });
+});


### PR DESCRIPTION
## Summary

FIXES_BACKLOG.md item #52: on iOS, the ride-start overlay stayed stuck showing only **Cancel** for ~10s during a GPX ride with the HRM deliberately switched off, even though `services` logged `readyToStart:true` twice (control device `Started`, HRM `Error`, `rideState:Starting`). Android shows **Start + Cancel** in the same scenario. `services` and `StartRideDisplay`'s own dialog-selection logic were already checked and ruled out before this session (see the backlog entry) — the open question was whether the update genuinely fails to propagate through the observer/subscription chain on the mobile side, or fails to trigger a re-render once it arrives.

## Root cause: **unconfirmed**

I traced the full chain end to end and found no bug:

- `services`: `RideDisplayService.checkStartStatus()` (`src/ride/display/service.ts:586`) builds a fresh `getStartOverlayProps()` object every call (`:1312`) and, via `setState('Starting')` (`:538`), emits `state-update` on the ride observer even when only a non-control device's status changes.
- `RidePageService.onDisplayStateUpdate` (services `src/ride/page/service.ts:1113`) always falls through to `updatePageDisplay()` -> `getPageObserver()?.emit('page-update')`.
- `GPXTourPage.tsx:33-39` (`onUpdate`) calls `service.getPageDisplayProps()` fresh and `setDisplayProps(update)` — a genuinely new object reference each time, so there's no `Object.is` bailout.
- `GPXTourPageView` (`src/pages/RidePage/GPX/View.tsx`) is a plain function component — not wrapped in `React.memo` — and destructures `startOverlayProps` fresh from `displayProps` every render (`:76`).
- `StartRideDisplay.tsx` recomputes `displayState`/`sensorError`/the button set from props on every render, is not memoized, and (per the backlog's own trace) `sensorError` correctly stays `false` here since `rideState` is `'Starting'`, not `'Error'`.
- `Dialog` (`src/components/Dialog/Dialog.tsx`) and `ButtonBar` (`src/components/ButtonBar/ButtonBar.tsx`) both pass `buttons` straight through on every render — no internal caching of the button set.

No `React.memo`, no stale-object reuse, and no platform branch exists anywhere in this path — consistent with the backlog's own observation that this isn't a platform-switch bug. Regression tests added in this PR (see Test plan) exercise exactly the prop transition from the captured log and pass, which further supports that the mobile code, as written, propagates correctly.

Given I couldn't reproduce the failure (no iOS device/simulator available in this environment) and found no static bug, I'm following the diagnose-before-fix discipline from the task brief: **no behavioral fix is included**. This PR ships only the observability addition plus regression coverage, as instructed for the case where root cause can't be pinned down.

**Next diagnostic step**: if this recurs, the new `useWhyDidYouRender` log on `StartRideDisplay` will show, for the actual failing render, either (a) which prop reference didn't change when it should have (pointing back at the services layer or a wiring gap not covered by the trace above), or (b) no log line at all for that update window, which would mean the component genuinely didn't re-render and the observer/listener wiring itself is the next place to look (e.g. an `openPage()`/`init()` timing race specific to iOS's event loop — see `services/src/ride/page/service.ts:108-155`, `services` is out of scope for this repo to change).

## What changed

- `src/components/StartRideDisplay/StartRideDisplay.tsx`: added `useWhyDidYouRender('StartRideDisplay', props, true)`, mirroring the existing `StreetView` usage. Logs an event (`re-render`) whenever any prop reference changes, or nothing at all if the component doesn't re-render — directly answering the backlog's "no re-render info for this component" gap.
- `src/components/StartRideDisplay/StartRideDisplay.test.tsx` (new): renders/rerenders the component directly through the exact prop transition from the captured log (trainer `Started`, HRM `Starting` -> `Error`, `rideState` staying `Starting`, `readyToStart` flipping `false` -> `true`) and asserts the Start button appears and the sensor-error dialog does not take over.
- `src/pages/RidePage/GPX/View.startOverlayButton.test.tsx` (new): same transition, driven through `GPXTourPageView` with the **real** `StartRideDisplay`/`Dialog`/`ButtonBar` (only native/heavy siblings mocked) — verifies the button text renders end to end, not just that props are passed.
- `src/pages/RidePage/GPX/GPXTourPage.test.tsx` (new): mocks `incyclist-services` and drives a fake page observer's `page-update` event (mirroring the two log lines 6ms apart) to verify the container's subscription/`setDisplayProps` wiring itself propagates a fresh `getPageDisplayProps()` result down to the view, and that the `page-update` listener is correctly unsubscribed on unmount.

## Test plan

- [x] `npx jest src/components/StartRideDisplay/StartRideDisplay.test.tsx` — 4/4 passing
- [x] `npx jest src/pages/RidePage/GPX/GPXTourPage.test.tsx src/pages/RidePage/GPX/View.startOverlayButton.test.tsx` — 5/5 passing
- [x] Full suite: `npm test` — 107 suites / 718 tests passing, no pre-existing failures
- [ ] **Still needed**: real-device (or simulator) reproduction on iOS with the HRM switched off during a GPX ride, capturing the new `StartRideDisplay` `re-render` log lines from `useWhyDidYouRender`, to either catch the bug in the act or confirm it no longer reproduces (e.g. if it was a one-off timing fluke rather than a deterministic bug — no iOS device/simulator was available in this environment)

Ref: `FIXES_BACKLOG.md` item #52.