### PR TITLE
ci(ios): pin Xcode to 26.3 — 26.6 cannot compile the fmt pod

### DIFF
--- a/.github/workflows/upload-testflight.yml
+++ b/.github/workflows/upload-testflight.yml
@@ -13,6 +13,34 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # ── Toolchain ───────────────────────────────────────────────────────────
+      # Pinned. The macos-26 image defaults to the newest Xcode installed, and
+      # GitHub raises that silently on image updates — so "latest" is a moving
+      # target that changes the compiler under a build nobody touched.
+      #
+      # Xcode 26.6 cannot compile the `fmt` pod that React Native depends on
+      # (pinned at 11.0.2): its newer clang rejects fmt's FMT_STRING with
+      # "call to consteval function ... is not a constant expression", five
+      # errors in format-inl.h, and the archive fails. Nothing in this repo is
+      # involved.
+      #
+      # 26.3 (17C529) is the build all device testing has been done against, so
+      # this makes CI compile with the identical toolchain rather than merely a
+      # working one.
+      #
+      # Removing this pin needs `fmt` to build on the newer clang first — that
+      # means a React Native version carrying fmt 11.1+, not a change here.
+      - name: Select Xcode
+        run: |
+          XCODE=/Applications/Xcode_26.3.app
+          if [ ! -d "$XCODE" ]; then
+            echo "::error::$XCODE is not on this runner image. Installed versions:"
+            ls -d /Applications/Xcode*.app
+            exit 1
+          fi
+          sudo xcode-select -s "$XCODE"
+          xcodebuild -version
+
       # ── Node ────────────────────────────────────────────────────────────────
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

The TestFlight archive fails. Pinning the runner's Xcode fixes it. **Not caused by the Street View work** — see below.

## The failure

```
ios/Pods/fmt/include/fmt/format-inl.h:59:24: error: call to consteval function
'fmt::basic_format_string<char, fmt::basic_string_view<char> &, const char (&)[3]>
::basic_format_string<FMT_COMPILE_STRING, 0>' is not a constant expression
```

Five of these, all in `fmt` — a React Native dependency pinned at 11.0.2. Xcode 26.6's clang rejects fmt's `FMT_STRING` construct. Nothing in this repo participates.

## Isolating it

Two things differed between CI and every build done during the Street View work:

| | CI | local |
|---|---|---|
| Xcode | 26.6 / iOS 26.5 SDK | 26.3 / iOS 26.2 SDK |
| Configuration | Release | Dev |

A **Release** build on **26.3**, from the same commit including the Street View changes, compiles clean: exit 0, zero `consteval` errors, 1242s. So the Release configuration is not the trigger and the toolchain is.

## The fix

```yaml
- name: Select Xcode
  run: sudo xcode-select -s /Applications/Xcode_26.3.app
```

The `macos-26` image ships seven Xcode versions and defaults to the newest, which GitHub raises silently on image updates — so this workflow's compiler was a moving target changing under builds nobody touched.

The image also carries **26.3, build 17C529**, byte-identical to the Mac all device testing was done on. So this pins CI to the *same* toolchain rather than merely to a working one.

The step fails loudly and lists the installed versions if that Xcode ever leaves the image, instead of silently falling back to the default and reintroducing this failure.

## This is pre-existing, not a regression

The workflow had not run since well before Xcode 26.6 reached the runner image — the last TestFlight build was 1.0.10-era. The first archive in that window exposed it. **It would equally have blocked the 1.0.23 release with no Street View involved.**

## Removing the pin later

Requires `fmt` to compile on the newer clang, i.e. a React Native version carrying fmt 11.1+. That is not a change to this workflow, and pinning is the correct interim answer rather than a workaround to feel bad about — reproducible builds want a fixed toolchain regardless.

## Test plan

- [x] YAML parses
- [x] Release build on Xcode 26.3 compiles clean from the same commit
- [ ] TestFlight archive succeeds
- [ ] `note: GMSApiKey.plist written (key present)` in the archive log
- [ ] Installed build reports `apiKey:present` / `provideAPIKey:true` — the M5 acceptance