### PR TITLE
fix(ios): dialog footer painted one button-set change late inside RN Modal

### DIFF
--- a/src/components/Dialog/Dialog.test.tsx
+++ b/src/components/Dialog/Dialog.test.tsx
@@ -39,4 +39,70 @@ describe('Dialog', () => {
 
         expect(getByText('my content')).toBeTruthy();
     });
+
+    // FIXES_BACKLOG #52. These guard the footer `key` that works around the RN new-architecture
+    // iOS Modal defect (children added to a mounted subtree are never finalized/laid out until a
+    // later commit). Jest renders to a JS tree and cannot exercise the native mounting path, so
+    // this proves only that the footer remounts when the button set changes — not that the
+    // workaround fixes the device symptom. Real-device iOS validation is the actual evidence.
+    describe('footer remount on button-set change (FIXES_BACKLOG #52)', () => {
+        it('renders the updated button set when buttons change while open', () => {
+            const { getByText, queryByText, rerender } = render(
+                <Dialog title="Starting activity ..." buttons={[{ id: 'cancel', label: 'Cancel', onClick: () => {} }]}>
+                    <Text>content</Text>
+                </Dialog>
+            );
+
+            expect(queryByText('Start')).toBeNull();
+
+            rerender(
+                <Dialog
+                    title="Starting activity ..."
+                    buttons={[
+                        { id: 'start', label: 'Start', primary: true, onClick: () => {} },
+                        { id: 'cancel', label: 'Cancel', onClick: () => {} },
+                    ]}
+                >
+                    <Text>content</Text>
+                </Dialog>
+            );
+
+            expect(getByText('Start')).toBeTruthy();
+            expect(getByText('Cancel')).toBeTruthy();
+        });
+
+        it('remounts the footer subtree when the button ids change', () => {
+            const footerOf = (root: any) =>
+                root.findAllByType(View).find((v: any) => Array.isArray(v.props.children)
+                    ? false
+                    : v.props.children?.props?.buttons !== undefined);
+
+            const { UNSAFE_root, rerender } = render(
+                <Dialog title="Starting activity ..." buttons={[{ id: 'cancel', label: 'Cancel', onClick: () => {} }]}>
+                    <Text>content</Text>
+                </Dialog>
+            );
+
+            const before = footerOf(UNSAFE_root);
+            expect(before).toBeTruthy();
+
+            rerender(
+                <Dialog
+                    title="Could not start Sensor(s)"
+                    buttons={[
+                        { id: 'retry', label: 'Retry', onClick: () => {} },
+                        { id: 'ignore', label: 'Ignore', primary: true, onClick: () => {} },
+                        { id: 'cancel', label: 'Cancel', onClick: () => {} },
+                    ]}
+                >
+                    <Text>content</Text>
+                </Dialog>
+            );
+
+            // A changed key means React discarded the old footer instance rather than reusing it.
+            const after = footerOf(UNSAFE_root);
+            expect(after).toBeTruthy();
+            expect(after).not.toBe(before);
+        });
+    });
 });

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -133,6 +133,17 @@ export const Dialog = ({
 
     const styles = getStyles({ width, height, minWidth, minHeight, variant, isCompact, stripHeight,nested });
 
+    // FIXES_BACKLOG #52 — workaround for a React Native new-architecture defect on iOS: when a
+    // child view is added to an already-mounted subtree inside a <Modal>, Fabric calls
+    // mountChildComponentView without a following finalizeUpdates, so the new view is never laid
+    // out until some *later* commit forces the pass. The visible effect is a footer that paints
+    // one structural change late: the rider's Start button appeared only once the button set
+    // changed again (or a tap forced a commit), leaving them with Cancel as the only option on a
+    // slow ride start. Initial mount is unaffected, so keying the footer on the button set turns
+    // every change into a fresh subtree mount instead of an insertion into a mounted one.
+    // Remove once RN fixes this upstream — facebook/react-native#49717, #47694, #48245, #51424.
+    const buttonSignature = buttons?.map(b => b.id).join('|') ?? '';
+
     const gradientColors = colors.dialogBackground;
 
     const BackgroundContainer = Platform.OS === 'web' ? View : LinearGradient;
@@ -194,7 +205,7 @@ export const Dialog = ({
                                 )}
 
                                 {buttons?.length ? (
-                                    <View style={styles.footer}>
+                                    <View key={buttonSignature} style={styles.footer}>
                                         <ButtonBar buttons={buttons} />
                                     </View>
                                 ) : <></>}
@@ -244,7 +255,7 @@ export const Dialog = ({
                                 )}
 
                                 {buttons?.length ? (
-                                    <View style={styles.footer}>
+                                    <View key={buttonSignature} style={styles.footer}>
                                         <ButtonBar buttons={buttons} />
                                     </View>
                                 ) : <></>}


### PR DESCRIPTION
Fixes the real defect behind `FIXES_BACKLOG.md` item #52. PR #388 added the diagnostics that made this findable; it did not fix anything.

## Root cause — an upstream React Native defect, not app logic

The device log settled it:

```
13:17:50.650  start overlay update ... readyToStart:true, videoState:Started
13:17:50.669  re-render, componentName:StartRideDisplay,
              cause:readyToStart: boolean → boolean, videoProgress: object → object
```

`useWhyDidYouRender` only lists props where `prevProps[key] !== props[key]`, and logs from a `useEffect` — i.e. **after** commit. So React committed the Start button 19ms after `services` published `readyToStart:true`. It just never reached the screen.

Three device observations pin the mechanism:

1. Device rows (`Starting → Started`) and video status (`Loading → Loaded`) repainted live in the same Modal — the subtree is not frozen.
2. Pressing Cancel briefly revealed the Start button before dismissal.
3. The sensor-error dialog displayed **`Start` + `Cancel`** — the *previous* button set — instead of `Retry`/`Ignore`/`Cancel`.

(3) is decisive: the footer paints **one structural change late**. Everything that worked was a prop update on a mounted view; the only failure was a view *insertion*. That is the known RN new-architecture iOS defect where `mountChildComponentView` is called without a following `finalizeUpdates`, leaving an added child unlaid-out until a later commit forces the pass — facebook/react-native#49717, #47694, #48245, #51424.

It also retro-explains the original GPX log in item #52: `readyToStart` flipped true at 11:18:47.594 and the HRM errored at .600, but `rideState` stayed `Starting`, so the button set **did not change** at .600 — no second structural change, no repaint, Cancel-only for the full 10s. Android uses a different mounting layer and is unaffected, which is why this first looked like a platform branch in business logic.

Note the sensor-error framing of item #52 was incidental — the confirming log is a video ride with no HRM failure at all.

## What changed

`src/components/Dialog/Dialog.tsx` — the footer `View` is keyed on the button-id signature in both the `full` and default returns. Initial mount is unaffected by the RN defect, so keying turns every button-set change into a fresh subtree mount instead of an insertion into a mounted one. Applied in the shared `Dialog`, so it covers the 3-button sensor-error dialog and any other dialog whose buttons change while open.

Rejected alternatives: *always render Start disabled* (doesn't generalise — the count varies three ways: 1, 2 and 3 buttons), and *a no-op state bump to force a second commit* (a commit with no tree change may emit no mutation instructions and be coalesced away).

## Test plan

- `src/components/Dialog/Dialog.test.tsx` — two new cases: the updated button set renders after a change while open, and the footer subtree is discarded rather than reused when the button ids change. Verified **red without the key**, green with it.
- Full suite: 108 suites / 729 tests pass. `tsc --noEmit` clean, eslint clean.

## Validation still outstanding

**Jest renders to a JS tree and cannot exercise the native mounting path**, so the tests above only guard that the footer remounts — they do not prove the device symptom is fixed. Real-device iOS validation is the actual evidence:

- Start a ride with the HRM off; confirm Start appears as soon as `readyToStart` flips, rather than staying Cancel-only.
- Reach the sensor-error dialog; confirm it shows `Retry`/`Ignore`/`Cancel` and not a stale set.

If keying the footer alone proves insufficient, escalate to keying the dialog's whole content container, then to a forced invisible mutation on the footer.