### PR TITLE
fix: abort route import when file picker resolves after unmount

### DIFF
--- a/src/components/RouteImportDialog/RouteImportDialog.test.tsx
+++ b/src/components/RouteImportDialog/RouteImportDialog.test.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { RouteImportDialog } from './RouteImportDialog';
+import { RouteImportDialogViewProps } from './types';
+
+// FIXES_BACKLOG.md item #40 - when the native file/document picker backgrounds the app
+// long enough for RoutesPage to unmount before the picker's promise resolves, the dialog's
+// own unmount effect already ran getRoutesPageService().onImportClosed(), which tears down
+// the RouteLibraryScannerService's internal importProps state. onAddGpx/onAddVideoRoute
+// already detected this race via refIsMounted.current, but only logged it and fell through
+// into importSingleRoute() regardless, crashing deep inside the scanner. These tests assert
+// the picker-resolved-after-unmount path now actually aborts instead of continuing.
+
+const mockObserver = { on: jest.fn(), off: jest.fn() };
+const mockSingleObserver = { on: jest.fn(), off: jest.fn() };
+
+const mockImportSingleRoute = jest.fn(() => mockSingleObserver);
+const mockOnImportClosed = jest.fn();
+
+const mockPageService = {
+    getImportDisplayProps: jest.fn(() => ({ phase: 'landing', routes: [] })),
+    getPageObserver: jest.fn(() => mockObserver),
+    importSingleRoute: mockImportSingleRoute,
+    onImportClosed: mockOnImportClosed,
+    cancelLibraryImport: jest.fn(),
+    startLibraryScan: jest.fn(),
+    startLibraryParse: jest.fn(),
+    importSelected: jest.fn(),
+};
+
+jest.mock('incyclist-services', () => ({
+    getRoutesPageService: () => mockPageService,
+}));
+
+jest.mock('../../bindings/ui', () => ({}));
+
+// Deferred, controllable pickFile() so we can unmount the dialog *while* the picker
+// promise is still pending, mirroring the production race (picker backgrounds the app,
+// RoutesPage unmounts, and only then does the picker promise finally resolve).
+let resolvePickFile: (value: any) => void;
+const mockPickFile = jest.fn(
+    () =>
+        new Promise((resolve) => {
+            resolvePickFile = resolve;
+        })
+);
+
+jest.mock('../../hooks/files/useFilePicker', () => ({
+    useFilePicker: () => ({ pickFile: mockPickFile }),
+}));
+
+// Stub out the pure view: RouteImportDialogView passes onAddGpx/onAddVideoRoute straight
+// through as props regardless of phase, but the real LandingView currently hides the "Add
+// Video Route" tile behind a disabled feature flag, making it unreachable via the rendered
+// UI. Exposing both handlers as plain testable buttons here lets the test drive
+// RouteImportDialog's actual onAddGpx/onAddVideoRoute callbacks - the code under test -
+// without depending on that unrelated UI-visibility detail.
+jest.mock('./RouteImportDialogView', () => ({
+    RouteImportDialogView: (props: RouteImportDialogViewProps) => {
+        const { View: RNView, TouchableOpacity: RNTouchableOpacity, Text: RNText } = require('react-native');
+        return (
+            <RNView>
+                <RNTouchableOpacity testID="add-gpx" onPress={props.onAddGpx}>
+                    <RNText>Add GPX</RNText>
+                </RNTouchableOpacity>
+                <RNTouchableOpacity testID="add-video-route" onPress={props.onAddVideoRoute}>
+                    <RNText>Add Video Route</RNText>
+                </RNTouchableOpacity>
+            </RNView>
+        );
+    },
+}));
+
+const fileInfo = {
+    type: 'file',
+    name: 'route.gpx',
+    ext: 'gpx',
+    filename: 'route.gpx',
+    delimiter: '/',
+    dir: '/tmp',
+    url: undefined,
+};
+
+describe('RouteImportDialog - picker resolves after unmount (FIXES_BACKLOG item #40)', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockPageService.getImportDisplayProps.mockReturnValue({ phase: 'landing', routes: [] });
+    });
+
+    it('onAddGpx does not call importSingleRoute() when the picker resolves after unmount', async () => {
+        const { getByTestId, unmount } = render(<RouteImportDialog onClose={jest.fn()} />);
+
+        fireEvent.press(getByTestId('add-gpx'));
+        await waitFor(() => expect(mockPickFile).toHaveBeenCalledTimes(1));
+
+        // RoutesPage/dialog unmounts while the native picker still has focus - this runs
+        // useUnmountEffect's real cleanup, which sets refIsMounted.current = false and
+        // calls onImportClosed() (tearing down the scanner's importProps on the services side).
+        unmount();
+
+        // ...and only now does the backgrounded picker's promise finally resolve.
+        resolvePickFile(fileInfo);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(mockImportSingleRoute).not.toHaveBeenCalled();
+    });
+
+    it('onAddVideoRoute does not call importSingleRoute() when the picker resolves after unmount', async () => {
+        const { getByTestId, unmount } = render(<RouteImportDialog onClose={jest.fn()} />);
+
+        fireEvent.press(getByTestId('add-video-route'));
+        await waitFor(() => expect(mockPickFile).toHaveBeenCalledTimes(1));
+
+        unmount();
+
+        resolvePickFile(fileInfo);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(mockImportSingleRoute).not.toHaveBeenCalled();
+    });
+
+    it('onAddGpx still imports normally when the dialog stays mounted', async () => {
+        const { getByTestId } = render(<RouteImportDialog onClose={jest.fn()} />);
+
+        fireEvent.press(getByTestId('add-gpx'));
+        await waitFor(() => expect(mockPickFile).toHaveBeenCalledTimes(1));
+
+        resolvePickFile(fileInfo);
+        await waitFor(() => expect(mockImportSingleRoute).toHaveBeenCalledWith(fileInfo));
+    });
+
+    it('onAddVideoRoute still imports normally when the dialog stays mounted', async () => {
+        const { getByTestId } = render(<RouteImportDialog onClose={jest.fn()} />);
+
+        fireEvent.press(getByTestId('add-video-route'));
+        await waitFor(() => expect(mockPickFile).toHaveBeenCalledTimes(1));
+
+        resolvePickFile(fileInfo);
+        await waitFor(() => expect(mockImportSingleRoute).toHaveBeenCalledWith(fileInfo));
+    });
+});

--- a/src/components/RouteImportDialog/RouteImportDialog.tsx
+++ b/src/components/RouteImportDialog/RouteImportDialog.tsx
@@ -35,9 +35,11 @@ export const RouteImportDialog = ({ onClose }: RouteImportDialogProps) => {
     const refParseObserver = useRef<IObserver | null>(null);
     const refIngestObserver = useRef<IObserver | null>(null);
     const refSingleObserver = useRef<IObserver | null>(null);
-    // diagnostic-only: tracks whether this dialog is still mounted when an async picker
-    // continuation resumes, to help diagnose crashes from a picker result landing after
-    // the dialog/page has already torn down (importProps/pageObserver already cleared)
+    // Tracks whether this dialog is still mounted when an async picker continuation
+    // resumes. Guards onAddGpx/onAddVideoRoute against continuing into
+    // importSingleRoute() after the dialog/page has already torn down (importProps/
+    // pageObserver already cleared), which otherwise crashes deep inside
+    // RouteLibraryScannerService (see FIXES_BACKLOG.md item #40).
     const refIsMounted = useRef(true);
 
     // --- Stable Event Handlers ---
@@ -193,6 +195,7 @@ export const RouteImportDialog = ({ onClose }: RouteImportDialogProps) => {
 
             if (!refIsMounted.current) {
                 logEvent({ message: 'picker resolved after unmount', fn: 'onAddGpx', fileName: fileInfo.filename });
+                return;
             }
 
             setIsSingleImporting(true);
@@ -213,6 +216,7 @@ export const RouteImportDialog = ({ onClose }: RouteImportDialogProps) => {
 
             if (!refIsMounted.current) {
                 logEvent({ message: 'picker resolved after unmount', fn: 'onAddVideoRoute', fileName: fileInfo.filename });
+                return;
             }
 
             setIsSingleImporting(true);


### PR DESCRIPTION
## Summary

Fixes `FIXES_BACKLOG.md` item #40. Companion services-repo defense-in-depth PR: incyclist/services#532.

## Root cause

Sequence from a production log (2026-08-11, `app-channel:mobile`, `version:0.0.42`): user taps "Add GPX", the native document picker opens and backgrounds the app, and while it's still in the foreground `RoutesPage` unmounts (most likely Android recreating the hosting Activity while the picker holds focus — see item #40's full writeup for why). ~17s later the picker's promise finally resolves into the *original* `onAddGpx` closure.

`RouteImportDialog.tsx`'s `onAddGpx`/`onAddVideoRoute` already detected this exact race — a `refIsMounted.current` check that logs `'picker resolved after unmount'` (confirmed by that exact log line in the production report) — but the check only logged; it never aborted. Execution fell through into `getRoutesPageService().importSingleRoute(fileInfo)` regardless, which crashes deep inside `RouteLibraryScannerService` with `Cannot set property 'phase' of undefined`, because the dialog's own unmount effect had already called `onImportClosed()` → `getRouteLibraryScanner().done()`, clearing the scanner's `importProps` state. Import UI is already torn down by this point, so from the user's side this is a silent, total loss of the import attempt — no error shown anywhere.

## What changed

`src/components/RouteImportDialog/RouteImportDialog.tsx`:
- `onAddGpx` and `onAddVideoRoute`: the existing `if (!refIsMounted.current) { logEvent(...) }` check now `return`s right after logging instead of falling through into `importSingleRoute()`.
- Updated the stale "diagnostic-only" comment on `refIsMounted` to reflect that it's now a real guard.

## Test plan

- Added `src/components/RouteImportDialog/RouteImportDialog.test.tsx`: renders the real smart component (stubbing only the pure `RouteImportDialogView` to expose `onAddGpx`/`onAddVideoRoute` as pressable buttons, since the "Add Video Route" tile is currently hidden behind a disabled feature flag in `LandingView` and unreachable via the real UI), with a deferred/controllable `pickFile()` mock. For both handlers: press → picker pending → **unmount the dialog** (runs the real `useUnmountEffect` cleanup, setting `refIsMounted.current = false`) → resolve the picker promise → assert `importSingleRoute()` was **not** called. Companion tests confirm both handlers still import normally when the dialog stays mounted.
- **Red-then-green verified**: temporarily removed both `return` statements, reran the suite — the two "resolves after unmount" tests failed with `importSingleRoute` called once (expected 0), confirming they're not vacuous; the two "still mounted" tests kept passing. Restored the fix and reran — all 4 tests pass.
- Full `npx jest`: 109 suites / 731 tests passed, no pre-existing failures.
- `npx tsc --noEmit`: clean.

## Manual validation still needed

Open Import Routes → Add GPX → background the app while the picker is open long enough for the Routes page to unmount → return the picker result → confirm no crash log and the import is simply abandoned with no partial/inconsistent state, rather than the current silent double-fault.

Pure JS change (this file + the `incyclist-services` defense-in-depth companion), ships via the `update-server` hot-update path — no app-store release needed. No dependency on item #41 (the native `AndroidManifest` mitigation): this fix stands regardless of which manifest version is installed, since it only makes the JS-side continuation check-and-return instead of assuming the page is still mounted.

References `FIXES_BACKLOG.md` item #40.