### PR TITLE
fix: upgrade MapLibre React Native v10.4.2 -> v11.3.6 (Android EGL context leak)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fdfedin/react-native-native-mqtt": "^0.1.12",
         "@kesha-antonov/react-native-background-downloader": "^4.5.4",
-        "@maplibre/maplibre-react-native": "^10.4.2",
+        "@maplibre/maplibre-react-native": "^11.3.6",
         "@pagopa/io-react-native-integrity": "^0.3.2",
         "@react-native-community/netinfo": "^12.0.1",
         "@react-native-documents/picker": "^12.0.1",
@@ -3948,37 +3948,67 @@
         "react-native": ">=0.57.0"
       }
     },
-    "node_modules/@maplibre/maplibre-react-native": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-react-native/-/maplibre-react-native-10.4.2.tgz",
-      "integrity": "sha512-5qAfaEe66eMXyILklm2DMHwyaXwXxsZWVop4BqfU7AyTg13LHAcaMmLJNJ3jPkMtiJvjH2m8ywGnobdIg2I0lg==",
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+      "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
       "license": "MIT",
-      "workspaces": [
-        "docs",
-        "examples/*"
-      ],
+      "engines": {
+        "node": ">= 22"
+      }
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "24.8.5",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.5.tgz",
+      "integrity": "sha512-EzEJmMt6thioRH7GI9LWS7ahXTcAhAPGWCe6oTP2Ps4YnsXOOAfeqx854lZaiDnwURfHmcCKV1mr6oo0i23x6w==",
+      "license": "ISC",
       "dependencies": {
-        "@turf/distance": "^7.1.0",
-        "@turf/helpers": "^7.1.0",
-        "@turf/length": "^7.1.0",
-        "@turf/nearest-point-on-line": "^7.1.0",
-        "debounce": "^2.2.0"
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/maplibre-react-native": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-react-native/-/maplibre-react-native-11.3.6.tgz",
+      "integrity": "sha512-XLl8mR7ogThpJKHnxG7PGK2TB9CwJJa8xOM2emsTgVGBzQZ3cc5mfW+mSTwP3PbBDfJe/WSFOIfOU2oHMD5mZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@maplibre/maplibre-gl-style-spec": "24.8.5",
+        "@turf/distance": "^7.3.5",
+        "@turf/helpers": "^7.3.5",
+        "@turf/length": "^7.3.5",
+        "@turf/nearest-point-on-line": "^7.3.5"
       },
       "peerDependencies": {
-        "@expo/config-plugins": ">=7",
         "@types/geojson": "^7946.0.0",
-        "@types/react": ">=16.6.1",
-        "react": ">=16.6.1",
-        "react-native": ">=0.59.9"
+        "@types/react": ">=19.1.0",
+        "expo": ">=54.0.0",
+        "react": ">=19.1.0",
+        "react-native": ">=0.80.0"
       },
       "peerDependenciesMeta": {
-        "@expo/config-plugins": {
-          "optional": true
-        },
         "@types/geojson": {
           "optional": true
         },
         "@types/react": {
+          "optional": true
+        },
+        "expo": {
           "optional": true
         }
       }
@@ -6044,13 +6074,13 @@
       }
     },
     "node_modules/@turf/distance": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.4.tgz",
-      "integrity": "sha512-9drWgd46uHPPyzgrcRQLgSvdS/SjVlQ6ZIBoRQagS5P2kSjUbcOXHIMeOSPwfxwlKhEtobLyr+IiR2ns1TfF8w==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.4.0.tgz",
+      "integrity": "sha512-ODkopQDG1m/U6Mx7OMmShncaCvneomwX3lZY1CDA7x40bhDdTTRYP/n/6LicZVyIO4/oK+aXkov4NOtWYthA2g==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
-        "@turf/invariant": "7.3.4",
+        "@turf/helpers": "7.4.0",
+        "@turf/invariant": "7.4.0",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -6059,9 +6089,9 @@
       }
     },
     "node_modules/@turf/helpers": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.4.tgz",
-      "integrity": "sha512-U/S5qyqgx3WTvg4twaH0WxF3EixoTCfDsmk98g1E3/5e2YKp7JKYZdz0vivsS5/UZLJeZDEElOSFH4pUgp+l7g==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.4.0.tgz",
+      "integrity": "sha512-7PAwLZqOdRzTI5g9bHvUwlloAXPDH/mlajtryk0tw4ZwGMtmXsAyF4QundsAMfy4u48Fyd3AUqMXY0SMxqJGWg==",
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.10",
@@ -6072,12 +6102,12 @@
       }
     },
     "node_modules/@turf/invariant": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.4.tgz",
-      "integrity": "sha512-88Eo4va4rce9sNZs6XiMJowWkikM3cS2TBhaCKlU+GFHdNf8PFEpiU42VDU8q5tOF6/fu21Rvlke5odgOGW4AQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.4.0.tgz",
+      "integrity": "sha512-OAsc3qdNx+tRqzWmMNFMnVlWWACIqnYqIejZKvb2oKkKPYJJrURPXZ6OdrGD58ljJMolLoqwIZGSx3VndaEjxg==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
+        "@turf/helpers": "7.4.0",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -6086,14 +6116,14 @@
       }
     },
     "node_modules/@turf/length": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/length/-/length-7.3.4.tgz",
-      "integrity": "sha512-Dg1GnQ/B2go5NIWXt91N4L7XTjIgIWCftBSYIXkrpIM7QGjItzglek0Z5caytvb8ZRWXzZOGs8//+Q5we91WuQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-7.4.0.tgz",
+      "integrity": "sha512-vQsJLuL7uy8m6HAMuJJKoiOHYY1de1Hd6mY/fM90qfu2RyIrkoF8J4bRUb72XZNCVnvob/eHpUMdhZeoUhSyfQ==",
       "license": "MIT",
       "dependencies": {
-        "@turf/distance": "7.3.4",
-        "@turf/helpers": "7.3.4",
-        "@turf/meta": "7.3.4",
+        "@turf/distance": "7.4.0",
+        "@turf/helpers": "7.4.0",
+        "@turf/meta": "7.4.0",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -6102,12 +6132,12 @@
       }
     },
     "node_modules/@turf/meta": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.4.tgz",
-      "integrity": "sha512-tlmw9/Hs1p2n0uoHVm1w3ugw1I6L8jv9YZrcdQa4SH5FX5UY0ATrKeIvfA55FlL//PGuYppJp+eyg/0eb4goqw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.4.0.tgz",
+      "integrity": "sha512-3cLUvlEyDuSnMSzrjhaLAEiYR8xhbfWyTVQlrlEw40xL81d4KF4PqUWbjTXKpXZStdYbet2GCurl79KMypNw6g==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
+        "@turf/helpers": "7.4.0",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -6116,15 +6146,15 @@
       }
     },
     "node_modules/@turf/nearest-point-on-line": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.3.4.tgz",
-      "integrity": "sha512-DQrP3lRju83rIXFN68tUEpc7ki/eRwdwBkK2CTT4RAcyCxbcH2NGJPQv8dYiww/Ar77u1WLVn+aINXZH904dWw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.4.0.tgz",
+      "integrity": "sha512-eKTKf/qODIsPankYMZrNfI3LjLaVtQvYV/1hcj9kH/Zr3GfLUszevjhTRDZtMgTFrv8+awW3+MyhmN+PJGuLdQ==",
       "license": "MIT",
       "dependencies": {
-        "@turf/distance": "7.3.4",
-        "@turf/helpers": "7.3.4",
-        "@turf/invariant": "7.3.4",
-        "@turf/meta": "7.3.4",
+        "@turf/distance": "7.4.0",
+        "@turf/helpers": "7.4.0",
+        "@turf/invariant": "7.4.0",
+        "@turf/meta": "7.4.0",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -8944,18 +8974,6 @@
       "license": "MIT",
       "dependencies": {
         "lodash.isequal": "^4.5.0"
-      }
-    },
-    "node_modules/debounce": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
-      "integrity": "sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/debug": {
@@ -13248,6 +13266,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -14352,7 +14376,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -15904,6 +15927,12 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
     },
     "node_modules/random-id": {
       "version": "1.0.4",
@@ -18802,6 +18831,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "node_modules/tinyrainbow": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@fdfedin/react-native-native-mqtt": "^0.1.12",
     "@kesha-antonov/react-native-background-downloader": "^4.5.4",
-    "@maplibre/maplibre-react-native": "^10.4.2",
+    "@maplibre/maplibre-react-native": "^11.3.6",
     "@pagopa/io-react-native-integrity": "^0.3.2",
     "@react-native-community/netinfo": "^12.0.1",
     "@react-native-documents/picker": "^12.0.1",

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.test.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialogView.test.tsx
@@ -5,12 +5,13 @@ import { ActivitySummaryDialogViewProps } from './types';
 import { ActivityDetailsUI } from 'incyclist-services';
 
 jest.mock('@maplibre/maplibre-react-native', () => ({
-    MapView: 'MapView',
+    Map: 'Map',
     Camera: 'Camera',
-    ShapeSource: 'ShapeSource',
-    LineLayer: 'LineLayer',
-    setAccessToken: jest.fn(),
-    default: { createFragment: jest.fn() },
+    GeoJSONSource: 'GeoJSONSource',
+    Layer: 'Layer',
+    ViewAnnotation: 'ViewAnnotation',
+    LogManager: { onLog: jest.fn() },
+    NetworkManager: { setConnected: jest.fn() },
 }));
 
 jest.mock('incyclist-services', () => ({

--- a/src/components/FreeMap/FreeMap.tsx
+++ b/src/components/FreeMap/FreeMap.tsx
@@ -113,14 +113,17 @@ export const FreeMap = (props: TFreeMapProps) => {
         const effectiveBounds = bounds || computeBoundsFromPoints(points, routeOptions);
 
         if (effectiveBounds) {
+            const [swLng, swLat] = toMapCoord(effectiveBounds.southwest);
+            const [neLng, neLat] = toMapCoord(effectiveBounds.northeast);
+
             return {
-                bounds: {
-                    ne: toMapCoord(effectiveBounds.northeast),
-                    sw: toMapCoord(effectiveBounds.southwest),
-                    paddingLeft: 20,
-                    paddingRight: 20,
-                    paddingTop: 20,
-                    paddingBottom: 20,
+                // MapLibre v11 Camera bounds are a flat [west, south, east, north] tuple
+                bounds: [swLng, swLat, neLng, neLat] as [number, number, number, number],
+                padding: {
+                    top: 20,
+                    right: 20,
+                    bottom: 20,
+                    left: 20,
                 },
             };
         }
@@ -130,8 +133,8 @@ export const FreeMap = (props: TFreeMapProps) => {
         const mapZoom = zoom || viewport?.zoom || 10;
 
         return {
-            centerCoordinate: toMapCoord(mapCenter),
-            zoomLevel: mapZoom,
+            center: toMapCoord(mapCenter),
+            zoom: mapZoom,
         };
     }, [bounds, center, viewport, zoom, points, routeOptions]);
 

--- a/src/components/FreeMap/FreeMapView.android.tsx
+++ b/src/components/FreeMap/FreeMapView.android.tsx
@@ -1,22 +1,17 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
-import { Platform, StyleSheet, Text, View, DimensionValue } from 'react-native';
-import MapLibreRN, { 
-    MapView, 
-    Camera, 
-    ShapeSource, 
-    Logger,
-    LineLayer, 
-    PointAnnotation, 
-    setAccessToken 
+import { Platform, StyleSheet, Text, View, DimensionValue, NativeSyntheticEvent } from 'react-native';
+import {
+    Map,
+    Camera,
+    GeoJSONSource,
+    Layer,
+    ViewAnnotation,
+    LogManager,
+    NetworkManager,
+    type ViewAnnotationEvent,
 } from '@maplibre/maplibre-react-native';
 import { FreeMapViewProps } from './types';
 import { fromMapCoord } from './utils';
-
-// MapLibre needs to be initialized
-if (Platform.OS !== 'web') {
-    setAccessToken(null);
-
-}
 
 let cachedMapStyle: any = null;
 
@@ -48,15 +43,15 @@ export const FreeMapView = ({
             return
 
         getMapStyle().then(osStyle => {
-            MapLibreRN.setConnected(true);
-            Logger.setLogCallback(log => {
+            NetworkManager.setConnected(true);
+            LogManager.onLog(log => {
                 if (log.message.includes('Canceled')) return true;
                 return false;
             });
             setMapStyle(osStyle);
         });
 
-        
+
     }, [mapStyle]);
 
     // Reset when bounds change (route extension mid-ride)
@@ -67,9 +62,9 @@ export const FreeMapView = ({
     const dynamicStyle = { width: width as DimensionValue, height: height as DimensionValue };
 
     const handleDragEnd = useCallback(
-        (e: any) => {
+        (e: NativeSyntheticEvent<ViewAnnotationEvent>) => {
             if (onPositionChanged) {
-                const coords = e.geometry.coordinates;
+                const coords = e.nativeEvent.lngLat;
                 onPositionChanged(fromMapCoord(coords));
             }
         },
@@ -96,56 +91,65 @@ export const FreeMapView = ({
         // Apply bounds only for the initial fit
         effectiveCameraProps = cameraProps;
     } else {
-        // After initial fit, remove bounds property and handle followPosition
+        // After initial fit, remove bounds/padding and handle followPosition
         const rest = Object.fromEntries(
-            Object.entries(cameraProps).filter(([key]) => key !== 'bounds')
-        ) as Omit<typeof cameraProps, 'bounds'>;
+            Object.entries(cameraProps).filter(([key]) => key !== 'bounds' && key !== 'padding')
+        ) as Omit<typeof cameraProps, 'bounds' | 'padding'>;
         if (followPosition && markerCoordinate) {
-            effectiveCameraProps = { ...rest, centerCoordinate: markerCoordinate };
+            effectiveCameraProps = { ...rest, center: markerCoordinate };
         } else {
             effectiveCameraProps = rest;
         }
     }
-    
+
 
     return (
         <View style={[styles.container, dynamicStyle, style]}>
-            <MapView
+            <Map
                 style={styles.map}
                 mapStyle={JSON.stringify(mapStyle)} // Replaced styleJSON with mapStyle
-                scrollEnabled={scrollWheelZoom}
-                logoEnabled={false}
-                attributionEnabled={true}
+                dragPan={scrollWheelZoom}
+                logo={false}
+                attribution={true}
                 onDidFinishRenderingMapFully={() => { refBoundsApplied.current = true; }}
             >
-                <Camera 
+                <Camera
                     {...effectiveCameraProps}
-                    animationDuration={0}
+                    duration={0}
                 />
 
-                <ShapeSource id='routeSource' shape={polylineData}>
-                    <LineLayer
+                <GeoJSONSource id='routeSource' data={polylineData}>
+                    <Layer
                         id='routeLayer'
-                        style={styles.routeLayer}
+                        type='line'
+                        paint={{
+                            'line-color': ['get', 'color'],
+                            'line-width': 5,
+                            'line-opacity': 0.8,
+                        }}
+                        layout={{
+                            'line-cap': 'round',
+                            'line-join': 'round',
+                        }}
                     />
-                </ShapeSource>
+                </GeoJSONSource>
 
                 {markerCoordinate && (
-                    <PointAnnotation
+                    <ViewAnnotation
                         id='marker'
                         key={`marker-${markerCoordinate[0].toFixed(5)}-${markerCoordinate[1].toFixed(5)}`}
-                        coordinate={markerCoordinate}
+                        lngLat={markerCoordinate}
                         draggable={draggable}
                         onDragEnd={handleDragEnd}
                     >
                         <View style={styles.markerTouchTarget}>
                             <View style={styles.marker} />
                         </View>
-                    </PointAnnotation>
+                    </ViewAnnotation>
                 )}
 
                 {children}
-            </MapView>
+            </Map>
         </View>
     );
 };
@@ -183,11 +187,4 @@ const styles = StyleSheet.create({
     webContainer: {
         backgroundColor: '#e0e0e0',
     },
-    routeLayer: {
-        lineColor: ['get', 'color'],
-        lineWidth: 5,
-        lineOpacity: 0.8,
-        lineCap: 'round',
-        lineJoin: 'round',
-    } as any,
 });

--- a/src/components/FreeMap/FreeMapView.ios.tsx
+++ b/src/components/FreeMap/FreeMapView.ios.tsx
@@ -54,9 +54,9 @@ export const FreeMapView = ({
     }, [polylineData]);
 
     const initialRegion = useMemo<Region>(() => {
-        if (cameraProps.centerCoordinate && cameraProps.zoomLevel !== undefined) {
-            const { latitude, longitude } = toRNLatLng(cameraProps.centerCoordinate);
-            const delta = getDeltaForZoom(cameraProps.zoomLevel);
+        if (cameraProps.center && cameraProps.zoom !== undefined) {
+            const { latitude, longitude } = toRNLatLng(cameraProps.center);
+            const delta = getDeltaForZoom(cameraProps.zoom);
             return {
                 latitude,
                 longitude,
@@ -71,25 +71,26 @@ export const FreeMapView = ({
             latitudeDelta: 0.0922,
             longitudeDelta: 0.0421,
         };
-    }, [cameraProps.centerCoordinate, cameraProps.zoomLevel]);
+    }, [cameraProps.center, cameraProps.zoom]);
 
     // Effect to handle `fitToCoordinates` when bounds are provided, ensuring it runs once.
     useEffect(() => {
         if (mapRef.current && cameraProps.bounds && !initialRegionSet) {
-            const { ne, sw } = cameraProps.bounds;
-            const coordinatesToFit = [toRNLatLng(ne), toRNLatLng(sw)];
+            // cameraProps.bounds is a flat [west, south, east, north] tuple
+            const [west, south, east, north] = cameraProps.bounds;
+            const coordinatesToFit = [toRNLatLng([east, north]), toRNLatLng([west, south])];
             mapRef.current.fitToCoordinates(coordinatesToFit, {
                 edgePadding: {
-                    top: cameraProps.bounds.paddingTop || 50,
-                    right: cameraProps.bounds.paddingRight || 50,
-                    bottom: cameraProps.bounds.paddingBottom || 50,
-                    left: cameraProps.bounds.paddingLeft || 50,
+                    top: cameraProps.padding?.top || 50,
+                    right: cameraProps.padding?.right || 50,
+                    bottom: cameraProps.padding?.bottom || 50,
+                    left: cameraProps.padding?.left || 50,
                 },
                 animated: false, // Prevents initial jarring animation
             });
             setInitialRegionSet(true); // Mark as set to avoid re-running if bounds are static
         }
-    }, [mapRef, cameraProps.bounds, initialRegionSet]);
+    }, [mapRef, cameraProps.bounds, cameraProps.padding, initialRegionSet]);
 
     // Reset initialRegionSet when bounds change (route extension mid-ride)
     useEffect(() => {
@@ -124,7 +125,7 @@ export const FreeMapView = ({
     const regionProp = cameraProps.bounds ? undefined : initialRegion;
 
     // If no polyline, marker, or center coordinate, return null (matches Android's behavior before style loads)
-    if (!polylineCoordinates.length && !markerCoordinate && !cameraProps?.centerCoordinate) {
+    if (!polylineCoordinates.length && !markerCoordinate && !cameraProps?.center) {
         return null;
     }
 

--- a/src/components/FreeMap/types.ts
+++ b/src/components/FreeMap/types.ts
@@ -72,17 +72,19 @@ export interface TFreeMapProps {
 // Internal type for MapLibre which uses [longitude, latitude]
 export type MapCoord = [number, number];
 
+// Internal type for MapLibre v11's Camera `bounds` prop: [west, south, east, north]
+export type MapBounds = [number, number, number, number];
+
 export interface FreeMapViewProps extends TFreeMapProps {
     cameraProps: {
-        centerCoordinate?: MapCoord;
-        zoomLevel?: number;
-        bounds?: {
-            ne: MapCoord;
-            sw: MapCoord;
-            paddingLeft?: number;
-            paddingRight?: number;
-            paddingTop?: number;
-            paddingBottom?: number;
+        center?: MapCoord;
+        zoom?: number;
+        bounds?: MapBounds;
+        padding?: {
+            top?: number;
+            right?: number;
+            bottom?: number;
+            left?: number;
         };
     };
     polylineData: GeoJSON.FeatureCollection<GeoJSON.LineString>;

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.test.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.test.tsx
@@ -91,12 +91,13 @@ jest.mock('../../hooks', () => ({
 }));
 
 jest.mock('@maplibre/maplibre-react-native', () => ({
-    MapView: 'MapView',
+    Map: 'Map',
     Camera: 'Camera',
-    ShapeSource: 'ShapeSource',
-    LineLayer: 'LineLayer',
-    setAccessToken: jest.fn(),
-    default: { createFragment: jest.fn() },
+    GeoJSONSource: 'GeoJSONSource',
+    Layer: 'Layer',
+    ViewAnnotation: 'ViewAnnotation',
+    LogManager: { onLog: jest.fn() },
+    NetworkManager: { setConnected: jest.fn() },
 }));
 
 jest.mock('../SecureImage', () => ({

--- a/src/components/RouteDetailsDialog/RouteDetailsView.test.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.test.tsx
@@ -17,12 +17,13 @@ jest.mock('../../hooks', () => ({
 }));
 
 jest.mock('@maplibre/maplibre-react-native', () => ({
-    MapView: 'MapView',
+    Map: 'Map',
     Camera: 'Camera',
-    ShapeSource: 'ShapeSource',
-    LineLayer: 'LineLayer',
-    setAccessToken: jest.fn(),
-    default: { createFragment: jest.fn() },
+    GeoJSONSource: 'GeoJSONSource',
+    Layer: 'Layer',
+    ViewAnnotation: 'ViewAnnotation',
+    LogManager: { onLog: jest.fn() },
+    NetworkManager: { setConnected: jest.fn() },
 }));
 
 jest.mock('../DownloadModal', () => {


### PR DESCRIPTION
## Summary

Fixes `FIXES_BACKLOG.md` item #36: upgrades `@maplibre/maplibre-react-native` from `10.4.2` to `11.3.6` (latest v11.x) to fix an Android EGL-context leak that eventually crashes the process with `RuntimeException: createContext` in `GLTextureViewRenderThread$EGLHolder.prepare`.

## Confirmed root cause

Not hypothetical — confirmed via real-device runtime instrumentation on 2026-08-09 (see item #36 for the full trace):

- `@maplibre/maplibre-react-native@10.4.2`'s Android teardown path (`MapShadowNode.dispose()`) relies on React Native's **legacy Paper-architecture shadow-node `dispose()` hook** to tear down each `<MapView>`'s EGL context on unmount.
- This app runs `newArchEnabled=true` (Fabric). Under Fabric, that hook **never fires**. Temporary `[DEBUG-eglctx]` logging added directly to the vendored package and tested on a real device confirmed: every `<MapView>` unmount reaches `onDropViewInstance` with `isDestroyed=false`, and `MapShadowNode.dispose()` never logs at all — the shadow-node dispose path is simply dead code under Fabric.
- Every map mount/unmount (route list scroll virtualization, Activity Summary/Route Details/Activity Details dialogs, etc.) therefore leaks one EGL context, unconditionally, until the device's GPU driver's context ceiling is exceeded and the process crashes.
- v11 is described by its own docs as "the first release to exclusively support React Native's new architecture" (rebuilt for Fabric, not interop-shimmed) and additionally defaults Android rendering to `GLSurfaceView` instead of `TextureView` (the exact class in the crash trace) — this targets the root cause directly rather than working around it.

## API translations made

Verified against the official ["Migrating to v11"](https://maplibre.org/maplibre-react-native/docs/setup/migrations/v11/) guide and the v11 source (`Camera.tsx`, `GeoJSONSource.tsx`, `Layer.tsx`, `ViewAnnotation.tsx`, `LogManager.ts`, `NetworkManager.ts`, `Map.tsx`) on GitHub.

`src/components/FreeMap/FreeMapView.android.tsx`:
- `MapView` → `Map`
- `ShapeSource` → `GeoJSONSource`; `shape` prop → unified `data` prop (accepts the GeoJSON object directly, no `JSON.stringify` needed)
- `LineLayer` → unified `Layer` with `type="line"`; moved off the deprecated `style` prop onto style-spec `paint`/`layout` (kebab-case: `line-color`, `line-width`, `line-opacity` under `paint`, `line-cap`/`line-join` under `layout`) — `source` is auto-injected onto nested `Layer` children by `GeoJSONSource`, same as v10's nesting behaviour
- `PointAnnotation` → `ViewAnnotation`; `coordinate` → `lngLat`; `onDragEnd` payload moved from a raw GeoJSON-Feature-shaped object to `NativeSyntheticEvent<ViewAnnotationEvent>`, read via `e.nativeEvent.lngLat`
- `Logger.setLogCallback` → `LogManager.onLog`
- `setAccessToken(null)` call dropped — the method (and `getAccessToken`) no longer exist in v11
- `MapLibreRN.setConnected` → `NetworkManager.setConnected` — v11's package index has **no default export**, so the `import MapLibreRN, {...}` default import is dropped entirely
- `Map` props: `logoEnabled`/`attributionEnabled` → `logo`/`attribution`; `scrollEnabled` → `dragPan`
- `Camera` props: `centerCoordinate` → `center`, `zoomLevel` → `zoom`, `animationDuration` → `duration`

`src/components/FreeMap/FreeMap.tsx` (`cameraProps` builder) and `src/components/FreeMap/types.ts` (`FreeMapViewProps.cameraProps`):
- Bounds restructured: v10's `{ ne, sw, paddingLeft/Right/Top/Bottom }` → v11's flat `LngLatBounds` tuple `[west, south, east, north]` plus a **sibling** `padding: { top, right, bottom, left }` object (padding is no longer nested inside `bounds`). This is a real structural change, not just a rename — confirmed against v11's `Camera.tsx`/`LngLatBounds.ts`/`ViewPadding.ts` source.

Test mocks updated for the renamed component names (`Map`/`Camera`/`GeoJSONSource`/`Layer`/`ViewAnnotation`, `LogManager.onLog`, `NetworkManager.setConnected`; dropped the removed `setAccessToken` and the nonexistent `default` export) in:
- `src/components/ActivitySummaryDialog/ActivitySummaryDialogView.test.tsx`
- `src/components/RouteDetailsDialog/RouteDetailsDialog.test.tsx`
- `src/components/RouteDetailsDialog/RouteDetailsView.test.tsx`

These 3 test-mock files were not listed in the backlog item's file scope but were found by re-grepping the whole `src` tree for `@maplibre/maplibre-react-native` before starting.

## ⚠️ This upgrade also touches iOS — not anticipated by the backlog

The backlog scoped this item as "Android-only; iOS uses `react-native-maps`, unaffected" — true of the **library**, but not of the **shared prop contract**. `FreeMapViewProps.cameraProps` (in `types.ts`) is consumed by both `FreeMapView.android.tsx` **and** `FreeMapView.ios.tsx`. Renaming `centerCoordinate`→`center`/`zoomLevel`→`zoom` and restructuring `bounds` therefore broke `FreeMapView.ios.tsx`'s consumption of that shared type (`tsc` caught this immediately — see below).

`src/components/FreeMap/FreeMapView.ios.tsx` was updated to unpack the new shape (`cameraProps.center`/`.zoom` instead of `.centerCoordinate`/`.zoomLevel`; `ne`/`sw` derived from the new `[west, south, east, north]` tuple; padding read from the new sibling `cameraProps.padding` object instead of `bounds.paddingTop/Right/Bottom/Left`). **No `react-native-maps` API changed** — this is purely adapting to the renamed/restructured shared prop shape, with the intent of preserving identical runtime behaviour. But it is still a change to a file the backlog explicitly said not to touch, on a platform where the crash being fixed does not even occur, so it carries its own regression risk and needs explicit verification (see below).

## Automated validation

- ✅ `npx tsc --noEmit` — clean (this is the main signal that the API translation, including the `bounds`/`padding` restructuring, is complete and correct — it caught the iOS breakage above)
- ✅ `npm run lint` (`eslint src/`) — 0 errors, only pre-existing warnings unrelated to this change
- ✅ `npm test` — 108 suites / 727 tests / 6 snapshots, all passing
- ✅ **`./gradlew :app:assembleDebug` — full native Gradle build, `BUILD SUCCESSFUL in 32m 50s`, 905 tasks, debug APK produced at `android/app/build/outputs/apk/debug/app-debug.apk`.** This included real native compilation (NDK/CMake) of dependent native modules, so it's a genuine build against the new MapLibre native SDK — not just a dependency-resolution check. No environmental blockers hit (Android SDK platform 36 / build-tools 36.0.0 were already installed; no licence prompts).

## 🔴 Real-device validation required before merge

No Android or iOS device was available in this environment, so the validation this item actually requires **has not been done** and must happen before merge:

**Android** (the crash this PR fixes):
- Rapid Routes ⇄ Pairing navigation bounces
- Rapid open/close of the Activity Summary dialog
- Rapid open/close of the Route Details dialog
- Fast scrolling through a long route list (scroll-virtualized map mount/unmount)
- No `createContext`/EGL crash under any of the above
- Full regression of every map-bearing screen: Routes list thumbnails, Route Details, Activity Details/Summary previews, GPX and Video ride maps

**iOS** (unplanned blast radius from the shared `cameraProps` type change, above):
- Visual verification of initial region + fit-to-bounds behaviour on: Route Details, Activity Details/Summary previews, GPX ride map, Video ride map
- Confirm the `react-native-maps` region/bounds/padding math still renders the same map framing as before this change

Do not merge until both device passes are done.