### PR TITLE
fix(ios): keep dialog button slots mounted so a changing button set repaints

### DIFF
--- a/src/components/ButtonBar/ButtonBar.tsx
+++ b/src/components/ButtonBar/ButtonBar.tsx
@@ -1,45 +1,101 @@
-import React from 'react'
-import { View, TouchableOpacity, Text, StyleSheet } from 'react-native'
+import React, { useRef } from 'react'
+import { View, TouchableOpacity, Text, StyleSheet, LayoutChangeEvent } from 'react-native'
 import { colors } from '../../theme'
 import { ButtonBarProps, ButtonProps } from './types'
 import { useLogging, useScreenLayout } from '../../hooks'
 
-export const Button = ({ id,label, primary,attention, onClick }:ButtonProps) => {
-    const {logEvent} = useLogging('Incyclist')
-    const layout  = useScreenLayout()        
+/**
+ * FIXES_BACKLOG #52 - the bar always renders this many slots, even when fewer buttons are
+ * passed. On iOS, React Native's new architecture does not lay out a view that is mounted into
+ * an already-presented <Modal> subtree, so a button added after the dialog opened stayed
+ * invisible until some later change forced a layout pass. Keeping every slot mounted from the
+ * first render means a changing button set only ever updates props on existing views - the path
+ * that demonstrably works (text in the same dialog repaints correctly, including width changes).
+ *
+ * Raise this if any dialog ever needs more buttons; a bar passed more than MAX_SLOTS still
+ * renders all of them, it just loses the guarantee for the ones beyond the initial count.
+ */
+const MAX_SLOTS = 3
+
+type SlotProps = ButtonProps & {
+    hidden?: boolean
+    slotIndex?: number
+    debugLayout?: boolean
+}
+
+export const Button = ({ id, label, primary, attention, onClick, hidden, slotIndex, debugLayout }: SlotProps) => {
+    const { logEvent } = useLogging('Incyclist')
+    const layout = useScreenLayout()
     const isCompact = layout === 'compact'
-    
-    const onPress=()=> {
-        logEvent( {message:'button clicked', button:label??id, eventSource:'user'  })
+    const refLastLogged = useRef<string>('')
+
+    const onPress = () => {
+        if (hidden) return
+        logEvent({ message: 'button clicked', button: label ?? id, eventSource: 'user' })
         onClick()
     }
+
+    // Diagnostic only, and only where explicitly enabled: reports whether a slot that became
+    // visible after the dialog opened actually received a layout, and at what size. A missing
+    // event, or width 0, means the view was mounted but never laid out.
+    const onLayout = debugLayout
+        ? (e: LayoutChangeEvent) => {
+            const { x, y, width, height } = e.nativeEvent.layout
+            const signature = `${label}|${hidden}|${width}x${height}`
+            if (refLastLogged.current === signature) return
+            refLastLogged.current = signature
+            logEvent({ message: 'button layout', slot: slotIndex, button: label ?? id, hidden: !!hidden, x, y, width, height })
+        }
+        : undefined
 
     let bgStyle = primary ? styles.primary : styles.secondary
     if (attention) bgStyle = styles.attention
 
     return (
         <TouchableOpacity onPress={onPress}
-            style={[styles.btn, bgStyle, isCompact && styles.btnCompact]}>
-            <Text style={[ (primary||attention) ? styles.textPrimary : styles.textSecondary, isCompact && styles.textCompact]}>
+            onLayout={onLayout}
+            accessible={!hidden}
+            importantForAccessibility={hidden ? 'no-hide-descendants' : 'auto'}
+            style={[styles.btn, bgStyle, isCompact && styles.btnCompact, hidden && styles.hidden]}>
+            <Text style={[(primary || attention) ? styles.textPrimary : styles.textSecondary, isCompact && styles.textCompact]}>
                 {label}
             </Text>
         </TouchableOpacity>
     )
 }
 
+export const ButtonBar = ({ buttons, debugLayout }: ButtonBarProps) => {
 
-export const ButtonBar = ( {buttons}: ButtonBarProps) => {
+    const slotCount = Math.max(MAX_SLOTS, buttons.length)
 
     return (
         <View style={styles.bar}>
-            {buttons.map( (props:ButtonProps) => <Button key = {props.label} {...props} />)}
-            
+            {Array.from({ length: slotCount }, (_, i) => {
+                const button = buttons[i]
+                // Positional keys, deliberately: keying on the label would remount a slot whenever
+                // the button set changed, which is the very thing this component avoids.
+                return (
+                    <Button
+                        key={`slot-${i}`}
+                        slotIndex={i}
+                        debugLayout={debugLayout}
+                        hidden={!button}
+                        label={button?.label ?? ''}
+                        id={button?.id}
+                        primary={button?.primary}
+                        attention={button?.attention}
+                        onClick={button?.onClick ?? (() => { })}
+                    />
+                )
+            })}
         </View>
     )
 }
 
-
 const styles = StyleSheet.create({
+    hidden: {
+        display: 'none',
+    },
     bar: {
         flexDirection: 'row',
         justifyContent: 'center',

--- a/src/components/ButtonBar/types.ts
+++ b/src/components/ButtonBar/types.ts
@@ -1,5 +1,11 @@
 export interface ButtonBarProps {
     buttons: Array<ButtonProps>
+    /**
+     * Opt-in layout diagnostics (FIXES_BACKLOG #52). Off everywhere by default - ButtonBar is
+     * used by nearly every dialog, so unconditional logging would flood the event log. Only the
+     * ride start overlay enables it, and each slot logs at most once per distinct layout.
+     */
+    debugLayout?: boolean
 }
 
 export interface ButtonProps {

--- a/src/components/Dialog/Dialog.test.tsx
+++ b/src/components/Dialog/Dialog.test.tsx
@@ -1,7 +1,16 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
-import { ScrollView, Text, View } from 'react-native';
+import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { Dialog } from './Dialog';
+
+const getSlotLabels = (root: any) =>
+    root.findAllByType(TouchableOpacity)
+        .map((n: any) => {
+            const hidden = JSON.stringify(n.props.style).includes('"display":"none"');
+            const texts = n.findAllByType(Text).map((t: any) => t.props.children);
+            return hidden ? null : texts[0];
+        })
+        .filter((l: any) => l !== null && l !== '');
 
 describe('Dialog', () => {
     it('wraps children in a ScrollView by default (scrollable=true)', () => {
@@ -40,15 +49,19 @@ describe('Dialog', () => {
         expect(getByText('my content')).toBeTruthy();
     });
 
-    // FIXES_BACKLOG #52. These guard the footer `key` that works around the RN new-architecture
-    // iOS Modal defect (children added to a mounted subtree are never finalized/laid out until a
-    // later commit). Jest renders to a JS tree and cannot exercise the native mounting path, so
-    // this proves only that the footer remounts when the button set changes — not that the
-    // workaround fixes the device symptom. Real-device iOS validation is the actual evidence.
-    describe('footer remount on button-set change (FIXES_BACKLOG #52)', () => {
+    // FIXES_BACKLOG #52. The footer renders a fixed pool of button slots that are all mounted
+    // from the first render, so a changing button set only updates props on views that already
+    // exist. On iOS, React Native's new architecture does not lay out a view mounted into an
+    // already-presented <Modal>, which left a newly added Start button invisible. Jest renders to
+    // a JS tree and cannot exercise native mounting, so these guard the structure only - the
+    // device is the real evidence.
+    describe('button slots (FIXES_BACKLOG #52)', () => {
+        const cancel = { id: 'cancel', label: 'Cancel', onClick: () => {} };
+        const start = { id: 'start', label: 'Start', primary: true, onClick: () => {} };
+
         it('renders the updated button set when buttons change while open', () => {
             const { getByText, queryByText, rerender } = render(
-                <Dialog title="Starting activity ..." buttons={[{ id: 'cancel', label: 'Cancel', onClick: () => {} }]}>
+                <Dialog title="Starting activity ..." buttons={[cancel]}>
                     <Text>content</Text>
                 </Dialog>
             );
@@ -56,13 +69,7 @@ describe('Dialog', () => {
             expect(queryByText('Start')).toBeNull();
 
             rerender(
-                <Dialog
-                    title="Starting activity ..."
-                    buttons={[
-                        { id: 'start', label: 'Start', primary: true, onClick: () => {} },
-                        { id: 'cancel', label: 'Cancel', onClick: () => {} },
-                    ]}
-                >
+                <Dialog title="Starting activity ..." buttons={[start, cancel]}>
                     <Text>content</Text>
                 </Dialog>
             );
@@ -71,20 +78,16 @@ describe('Dialog', () => {
             expect(getByText('Cancel')).toBeTruthy();
         });
 
-        it('remounts the footer subtree when the button ids change', () => {
-            const footerOf = (root: any) =>
-                root.findAllByType(View).find((v: any) => Array.isArray(v.props.children)
-                    ? false
-                    : v.props.children?.props?.buttons !== undefined);
+        it('keeps the same number of mounted slots as the button set grows', () => {
+            const countSlots = (root: any) =>
+                root.findAllByType(TouchableOpacity).length;
 
             const { UNSAFE_root, rerender } = render(
-                <Dialog title="Starting activity ..." buttons={[{ id: 'cancel', label: 'Cancel', onClick: () => {} }]}>
+                <Dialog title="Starting activity ..." buttons={[cancel]}>
                     <Text>content</Text>
                 </Dialog>
             );
-
-            const before = footerOf(UNSAFE_root);
-            expect(before).toBeTruthy();
+            const before = countSlots(UNSAFE_root);
 
             rerender(
                 <Dialog
@@ -92,17 +95,29 @@ describe('Dialog', () => {
                     buttons={[
                         { id: 'retry', label: 'Retry', onClick: () => {} },
                         { id: 'ignore', label: 'Ignore', primary: true, onClick: () => {} },
-                        { id: 'cancel', label: 'Cancel', onClick: () => {} },
+                        cancel,
                     ]}
                 >
                     <Text>content</Text>
                 </Dialog>
             );
 
-            // A changed key means React discarded the old footer instance rather than reusing it.
-            const after = footerOf(UNSAFE_root);
-            expect(after).toBeTruthy();
-            expect(after).not.toBe(before);
+            // No slot was mounted to make room for the extra buttons - the count is unchanged,
+            // which is the property that keeps the iOS defect unreachable.
+            expect(countSlots(UNSAFE_root)).toBe(before);
+            expect(getSlotLabels(UNSAFE_root)).toEqual(['Retry', 'Ignore', 'Cancel']);
+        });
+
+        it('hides unused slots rather than unmounting them', () => {
+            const { UNSAFE_root } = render(
+                <Dialog title="Starting activity ..." buttons={[cancel]}>
+                    <Text>content</Text>
+                </Dialog>
+            );
+
+            const hidden = UNSAFE_root.findAllByType(TouchableOpacity)
+                .filter((n: any) => JSON.stringify(n.props.style).includes('"display":"none"'));
+            expect(hidden.length).toBeGreaterThan(0);
         });
     });
 });

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -45,6 +45,7 @@ export const Dialog = ({
     visible = true,
     nested = false,
     onOutsideClick,
+    debugLayout,
     slideFrom,
     scrollable = true,
 }: PropsWithChildren<DialogProps>) => {
@@ -133,17 +134,6 @@ export const Dialog = ({
 
     const styles = getStyles({ width, height, minWidth, minHeight, variant, isCompact, stripHeight,nested });
 
-    // FIXES_BACKLOG #52 — workaround for a React Native new-architecture defect on iOS: when a
-    // child view is added to an already-mounted subtree inside a <Modal>, Fabric calls
-    // mountChildComponentView without a following finalizeUpdates, so the new view is never laid
-    // out until some *later* commit forces the pass. The visible effect is a footer that paints
-    // one structural change late: the rider's Start button appeared only once the button set
-    // changed again (or a tap forced a commit), leaving them with Cancel as the only option on a
-    // slow ride start. Initial mount is unaffected, so keying the footer on the button set turns
-    // every change into a fresh subtree mount instead of an insertion into a mounted one.
-    // Remove once RN fixes this upstream — facebook/react-native#49717, #47694, #48245, #51424.
-    const buttonSignature = buttons?.map(b => b.id).join('|') ?? '';
-
     const gradientColors = colors.dialogBackground;
 
     const BackgroundContainer = Platform.OS === 'web' ? View : LinearGradient;
@@ -205,8 +195,8 @@ export const Dialog = ({
                                 )}
 
                                 {buttons?.length ? (
-                                    <View key={buttonSignature} style={styles.footer}>
-                                        <ButtonBar buttons={buttons} />
+                                    <View style={styles.footer}>
+                                        <ButtonBar buttons={buttons} debugLayout={debugLayout} />
                                     </View>
                                 ) : <></>}
                             </BackgroundContainer>
@@ -255,8 +245,8 @@ export const Dialog = ({
                                 )}
 
                                 {buttons?.length ? (
-                                    <View key={buttonSignature} style={styles.footer}>
-                                        <ButtonBar buttons={buttons} />
+                                    <View style={styles.footer}>
+                                        <ButtonBar buttons={buttons} debugLayout={debugLayout} />
                                     </View>
                                 ) : <></>}
 

--- a/src/components/Dialog/types.ts
+++ b/src/components/Dialog/types.ts
@@ -13,6 +13,11 @@ export interface DialogProps {
     onOutsideClick?: () => void;
     visible?: boolean;
     buttons?: ButtonProps[];
+    /**
+     * Opt-in button-layout diagnostics (FIXES_BACKLOG #52). Off by default: Dialog is used by
+     * nearly every screen, so unconditional logging would flood the event log.
+     */
+    debugLayout?: boolean;
     style?: StyleProp<ViewStyle>;
     nested?: boolean;
     titleStyle?: StyleProp<TextStyle>;

--- a/src/components/StartRideDisplay/StartRideDisplay.tsx
+++ b/src/components/StartRideDisplay/StartRideDisplay.tsx
@@ -139,6 +139,7 @@ export const StartRideDisplay = (props: StartRideDisplayProps) => {
                 title="Could not start Sensor(s)"
                 titleStyle={{ color: colors.warning }}
                 variant="info"
+                debugLayout
                 minWidth={minWidth}
                 buttons={[
                     { id: 'retry', label: 'Retry', primary: false, onClick: onRetry! },
@@ -209,6 +210,7 @@ export const StartRideDisplay = (props: StartRideDisplayProps) => {
         <Dialog
             title="Starting activity ..."
             variant="info"
+            debugLayout
             minWidth={minWidth}
             buttons={startingButtons}
         >


### PR DESCRIPTION
Second attempt at `FIXES_BACKLOG.md` item #52. **PR #391 did not fix it** — verified on an iPhone.

## Why #391 failed

#391 keyed the footer on the button set, assuming a fresh subtree mount would be laid out correctly. It isn't: a remount is still a mount, so it hit the same defect.

## What the device evidence actually establishes

| Observation | Implication |
|---|---|
| `useWhyDidYouRender` logs the new `readyToStart` **after** commit | React renders and commits the Start button correctly — not a re-render bug |
| Device rows repaint `Starting ...` → `Started` | Layout runs fine for views that already exist (the string width changes, which *requires* a layout pass) |
| Sensor-error dialog showed `Start` + `Cancel` | The footer paints exactly one structural change late |
| Tapping Cancel briefly reveals Start | A later commit flushes the pending one |
| Android unaffected | Different mounting layer |

Together: **only views mounted into an already-presented iOS `<Modal>` fail to be laid out.** Upstream, still open as facebook/react-native#49717.

## The fix — stop mounting

`ButtonBar` renders a **fixed pool of 3 slots**, all mounted from the first render. A changing button set only updates props on views that already exist — the path proven to work above. `[Start, Cancel]` → `[Retry, Ignore, Cancel]` is now three prop updates and zero mounts.

Two details that matter:
- **Positional keys** (`slot-0/1/2`), deliberately. Keying on the label would remount a slot whenever the set changed, reintroducing exactly the bug being fixed.
- Unused slots are hidden with `display: 'none'` so the active buttons stay centred. This does rely on a layout pass for an existing view — which the device-row evidence supports. If it turns out not to hold, the fallback is `opacity: 0`, at the cost of off-centre spacing.

A bar passed more than `MAX_SLOTS` buttons still renders all of them; it just loses the guarantee for those beyond the initial count. Raise `MAX_SLOTS` if a dialog ever needs more.

## Diagnostics — opt-in, deliberately quiet

`ButtonBar` is used by nearly every dialog, so unconditional logging would flood the event log. `debugLayout` defaults **off**; only the two start-overlay dialogs whose button set changes while open enable it, and each slot logs **at most once per distinct layout** (deduped on label/hidden/size) — a few lines per ride start.

It records `{slot, button, hidden, x, y, width, height}`, which distinguishes:
- **no event, or `width: 0`** → mounted but never laid out (this PR's premise is right)
- **correct size but invisible** → laid out and something else hides it — clipping via the container's `overflow: 'hidden'`, or z-order — which would be a different fix

That fork is still unresolved, and it decides whether this approach can work at all. The logs settle it on the next occurrence without needing another guess.

## Also

Removes #391's footer key and its now-incorrect comment.

## Test plan

- `Dialog.test.tsx` slot tests **verified red** without the fixed pool (temporarily setting `MAX_SLOTS = 0` reproduces the old insert-on-change behaviour; both new tests fail), green with it.
- 109 suites / 734 tests pass, `tsc --noEmit` clean, lint 0 errors.

**Jest renders to a JS tree and cannot exercise native mounting.** These tests guard the structural property only. The iPhone is the only real evidence.

## Validation required before merge

- iOS: start a ride with the HRM off — Start must appear as soon as `readyToStart` flips.
- iOS: reach the sensor-error dialog — must show `Retry`/`Ignore`/`Cancel`, not a stale set.
- Both platforms: a quick pass over other dialogs (device pairing, route details, ride menu) since `ButtonBar` is shared.
- If it still fails, capture the `button layout` log lines — they tell us which branch of the fork we're in.