### PR TITLE
fix: stop losing startup log events before the REST adapter registers

### DIFF
--- a/src/Loader.tsx
+++ b/src/Loader.tsx
@@ -3,6 +3,7 @@ import { App } from './App'; // This is your actual application
 import { ApiConfiguration, initRestLogging  } from './services';
 
 import { EventLogger, LogAdapter } from 'gd-eventlog';
+import { getLogBacklog } from './bindings/logging/Adapters/BacklogAdapter';
 import { RNConsoleAdapter } from './bindings/logging/Adapters/RNConsoleAdapter';
 import Orientation from 'react-native-orientation-locker';
 import { LoadingScreen } from './pages/LoadingScreen/LoadingScreen';
@@ -39,6 +40,12 @@ export const Loader = () =>{
     const refChecking = useRef<Promise<any> | null>(null)
     
     const initLogging =() =>{
+        // Registered first, so nothing logged between here and the REST adapter coming up
+        // is lost. initRestLogging() cannot run any earlier - it needs the settings - and
+        // EventLogger drops each event once the adapters registered at that moment have
+        // seen it, so without this the early startup events never reach the server.
+        EventLogger.registerAdapter(getLogBacklog())
+
         const logAdapter  = new RNConsoleAdapter( {depth:1}) as LogAdapter
         EventLogger.registerAdapter(logAdapter)
 

--- a/src/bindings/logging/Adapters/BacklogAdapter.test.ts
+++ b/src/bindings/logging/Adapters/BacklogAdapter.test.ts
@@ -1,0 +1,105 @@
+import { BacklogAdapter, getLogBacklog, resetLogBacklog, MAX_BACKLOG_ENTRIES } from './BacklogAdapter';
+
+describe('BacklogAdapter', () => {
+
+    afterEach(() => {
+        resetLogBacklog();
+    });
+
+    describe('retaining', () => {
+        it('keeps the events it is given', () => {
+            const backlog = new BacklogAdapter();
+
+            backlog.log('mq', { message: 'mqtt connected', uri: 'wss://host/ws' });
+            backlog.log('Incyclist', { message: 'Initializing App' });
+
+            expect(backlog.drain()).toEqual([
+                { context: 'mq', event: { message: 'mqtt connected', uri: 'wss://host/ws' } },
+                { context: 'Incyclist', event: { message: 'Initializing App' } },
+            ]);
+        });
+
+        it('copies the event, so an adapter mutating its own copy cannot corrupt the backlog', () => {
+            const backlog = new BacklogAdapter();
+            const event: any = { message: 'mqtt connected', ts: '2026-08-19T00:00:00.000Z' };
+
+            backlog.log('mq', event);
+
+            // The console adapter deletes these off the event it is handed.
+            delete event.ts;
+            delete event.message;
+
+            expect(backlog.drain()[0].event).toEqual({
+                message: 'mqtt connected', ts: '2026-08-19T00:00:00.000Z',
+            });
+        });
+
+        it('ignores undefined context or event rather than throwing', () => {
+            const backlog = new BacklogAdapter();
+
+            expect(() => backlog.log(undefined as any, { message: 'x' })).not.toThrow();
+            expect(() => backlog.log('mq', undefined)).not.toThrow();
+            expect(backlog.size).toBe(0);
+        });
+    });
+
+    describe('bounded growth', () => {
+        it('drops the oldest events once the cap is reached', () => {
+            const backlog = new BacklogAdapter(3);
+
+            [1, 2, 3, 4, 5].forEach((n) => backlog.log('mq', { message: `event ${n}` }));
+
+            const entries = backlog.drain();
+            expect(entries).toHaveLength(3);
+            expect(entries.map((e) => e.event.message)).toEqual(['event 3', 'event 4', 'event 5']);
+        });
+
+        it('defaults to a sane cap', () => {
+            const backlog = new BacklogAdapter();
+
+            for (let i = 0; i < MAX_BACKLOG_ENTRIES + 50; i++) {
+                backlog.log('mq', { message: `event ${i}` });
+            }
+
+            expect(backlog.size).toBe(MAX_BACKLOG_ENTRIES);
+        });
+    });
+
+    describe('handover', () => {
+        it('stops retaining once drained, so it costs nothing for the rest of the session', () => {
+            const backlog = new BacklogAdapter();
+            backlog.log('mq', { message: 'early' });
+
+            expect(backlog.drain()).toHaveLength(1);
+            expect(backlog.isRetaining).toBe(false);
+
+            backlog.log('mq', { message: 'later' });
+            expect(backlog.size).toBe(0);
+        });
+
+        it('a second drain returns nothing rather than repeating the first', () => {
+            const backlog = new BacklogAdapter();
+            backlog.log('mq', { message: 'early' });
+
+            backlog.drain();
+            expect(backlog.drain()).toEqual([]);
+        });
+
+        it('stop() releases everything without handing it over', () => {
+            const backlog = new BacklogAdapter();
+            backlog.log('mq', { message: 'early' });
+
+            backlog.stop();
+
+            expect(backlog.size).toBe(0);
+            expect(backlog.isRetaining).toBe(false);
+            expect(backlog.drain()).toEqual([]);
+        });
+    });
+
+    describe('singleton', () => {
+        it('hands the same instance to the registrar and the consumer', () => {
+            expect(getLogBacklog()).toBe(getLogBacklog());
+        });
+    });
+});

--- a/src/bindings/logging/Adapters/BacklogAdapter.ts
+++ b/src/bindings/logging/Adapters/BacklogAdapter.ts
@@ -1,0 +1,94 @@
+import { BaseAdapter, LogAdapter } from 'gd-eventlog';
+
+/**
+ * Retains early log events so they can be handed to an adapter that registers later.
+ *
+ * The REST adapter cannot be registered at startup: it needs `logRest.url` and
+ * `logRest.sendInterval`, which are only known after the settings have loaded. Everything
+ * logged before that point reaches the console adapter but never reaches the server -
+ * `EventLogger` hands each event to whichever adapters exist at that moment and then drops
+ * it, so there is nothing left to replay by the time the REST adapter appears.
+ *
+ * This adapter is registered first, at startup, purely to keep a copy. Once the REST
+ * adapter is up, `drain()` hands the backlog over and retention stops, so this costs
+ * nothing for the rest of the session.
+ *
+ * The alternative - delaying startup until logging is ready - was rejected deliberately:
+ * it would make unrelated subsystems wait on logging, whereas this lets logging catch up
+ * with what already happened.
+ */
+
+export const MAX_BACKLOG_ENTRIES = 200;
+
+export type BacklogEntry = {
+    context: string;
+    event: any;
+};
+
+export class BacklogAdapter extends BaseAdapter implements LogAdapter {
+    protected entries: BacklogEntry[] = [];
+    protected retaining: boolean = true;
+    protected maxEntries: number;
+
+    constructor(maxEntries: number = MAX_BACKLOG_ENTRIES) {
+        super();
+        this.maxEntries = maxEntries;
+    }
+
+    log(context: string, event: any): void {
+        if (!this.retaining || context === undefined || event === undefined) {
+            return;
+        }
+
+        try {
+            // Copied, not referenced: adapters are free to mutate the event they are given
+            // (the console adapter deletes keys off it), and each adapter receives its own
+            // filtered copy, so holding on to this one is only safe if it is ours.
+            this.entries.push({ context, event: { ...event } });
+
+            // Bounded so that a session where the REST adapter never registers - logging
+            // disabled, or a failure during init - cannot grow this without limit.
+            if (this.entries.length > this.maxEntries) {
+                this.entries.shift();
+            }
+        } catch {
+            // logging must never throw into the caller
+        }
+    }
+
+    /**
+     * Returns everything retained so far and stops retaining. Safe to call more than once;
+     * later calls return nothing.
+     */
+    drain(): BacklogEntry[] {
+        const entries = this.entries;
+        this.stop();
+        return entries;
+    }
+
+    /** Stops retaining and releases anything held, without handing it over. */
+    stop(): void {
+        this.retaining = false;
+        this.entries = [];
+    }
+
+    get size(): number {
+        return this.entries.length;
+    }
+
+    get isRetaining(): boolean {
+        return this.retaining;
+    }
+}
+
+let backlog: BacklogAdapter | undefined;
+
+export const getLogBacklog = (): BacklogAdapter => {
+    backlog = backlog ?? new BacklogAdapter();
+    return backlog;
+};
+
+/** Test only. */
+export const resetLogBacklog = (): void => {
+    backlog = undefined;
+};

--- a/src/services/RestLogging/RestLogging.test.ts
+++ b/src/services/RestLogging/RestLogging.test.ts
@@ -70,7 +70,7 @@ describe('initRestLogging - early event handover', () => {
         }));
     });
 
-    it('tags replayed events, and gives them the globals every other line carries', async () => {
+    it('gives replayed events the globals every other line carries', async () => {
         startupLogging();
         new EventLogger('mq').logEvent({ message: 'mqtt connected' });
 
@@ -78,13 +78,22 @@ describe('initRestLogging - early event handover', () => {
 
         const entry = replayed().find((e: any) => e.event.message === 'mqtt connected');
         expect(entry.event).toMatchObject({
-            replayed: true,
             version: '0.1.1',
             appVersion: '1.2.3',
             uuid: 'test-uuid',
             session: 'test-session',
             'app-channel': 'mobile',
         });
+    });
+
+    it('does not mark replayed events - they are ordinary startup events, not a special kind', async () => {
+        startupLogging();
+        new EventLogger('mq').logEvent({ message: 'mqtt connected' });
+
+        await initRestLogging();
+
+        const entry = replayed().find((e: any) => e.event.message === 'mqtt connected');
+        expect(entry.event.replayed).toBeUndefined();
     });
 
     it('sets session and app-channel up front, not only once services initialises', async () => {

--- a/src/services/RestLogging/RestLogging.test.ts
+++ b/src/services/RestLogging/RestLogging.test.ts
@@ -15,6 +15,7 @@ jest.mock('../../bindings/appInfo', () => ({
     getAppInfoBinding: async () => ({
         getAppVersion: () => '1.2.3',
         getUIVersion: () => '0.1.1',
+        session: 'test-session',
     }),
     getChannel: () => 'mobile',
 }));
@@ -81,7 +82,23 @@ describe('initRestLogging - early event handover', () => {
             version: '0.1.1',
             appVersion: '1.2.3',
             uuid: 'test-uuid',
+            session: 'test-session',
+            'app-channel': 'mobile',
         });
+    });
+
+    it('sets session and app-channel up front, not only once services initialises', async () => {
+        startupLogging();
+
+        await initRestLogging();
+
+        // A live event logged straight after init - i.e. long before services sets its own
+        // globals - must already be correlatable to a session.
+        mockAdapters[0].log.mockClear();
+        new EventLogger('mq').logEvent({ message: 'mqtt connected' });
+
+        const [, event] = mockAdapters[0].log.mock.calls[0];
+        expect(event).toMatchObject({ session: 'test-session', 'app-channel': 'mobile' });
     });
 
     it('preserves the original timestamp, so late arrival does not reorder the log', async () => {

--- a/src/services/RestLogging/RestLogging.test.ts
+++ b/src/services/RestLogging/RestLogging.test.ts
@@ -1,0 +1,145 @@
+// Covers the handover of early startup events to the REST adapter. The REST adapter cannot
+// be registered until the settings have loaded, so anything logged before that - which is
+// most of app startup - used to reach the console and nothing else.
+
+const mockSettings: Record<string, any> = {};
+const mockAdapters: any[] = [];
+
+jest.mock('../IncyclistApi', () => ({
+    ApiConfiguration: { getInstance: () => ({ addHeader: jest.fn() }) },
+}));
+
+jest.mock('react-native', () => ({ Platform: { OS: 'android' } }));
+
+jest.mock('../../bindings/appInfo', () => ({
+    getAppInfoBinding: async () => ({
+        getAppVersion: () => '1.2.3',
+        getUIVersion: () => '0.1.1',
+    }),
+    getChannel: () => 'mobile',
+}));
+
+jest.mock('../../bindings/user-settings', () => ({
+    getUserSettingsBinding: () => ({
+        getAll: async () => mockSettings,
+        get: (key: string, defValue: any) => mockSettings[key] ?? defValue,
+        getValue: (key: string, defValue: any) => mockSettings[key] ?? defValue,
+    }),
+}));
+
+jest.mock('../../bindings/logging/Adapters/RestLogAdapter', () => ({
+    RestLogAdapter: class {
+        log = jest.fn();
+        send = jest.fn();
+        stop = jest.fn();
+        constructor() { mockAdapters.push(this); }
+    },
+}));
+
+import { EventLogger } from 'gd-eventlog';
+import { initRestLogging } from './RestLogging';
+import { getLogBacklog, resetLogBacklog } from '../../bindings/logging/Adapters/BacklogAdapter';
+
+describe('initRestLogging - early event handover', () => {
+
+    beforeEach(() => {
+        EventLogger.reset();
+        resetLogBacklog();
+        mockAdapters.length = 0;
+        Object.keys(mockSettings).forEach((key) => delete mockSettings[key]);
+        mockSettings.uuid = 'test-uuid';
+    });
+
+    // Mirrors what Loader.tsx does at startup, well before the settings are available.
+    const startupLogging = () => {
+        EventLogger.registerAdapter(getLogBacklog());
+    };
+
+    const replayed = () => mockAdapters[0].log.mock.calls.map(([context, event]: any[]) => ({ context, event }));
+
+    it('hands events logged before it existed to the REST adapter', async () => {
+        startupLogging();
+        new EventLogger('mq').logEvent({ message: 'mqtt connected', uri: 'wss://host/ws' });
+
+        await initRestLogging();
+
+        expect(replayed()).toContainEqual(expect.objectContaining({
+            context: 'mq',
+            event: expect.objectContaining({ message: 'mqtt connected', uri: 'wss://host/ws' }),
+        }));
+    });
+
+    it('tags replayed events, and gives them the globals every other line carries', async () => {
+        startupLogging();
+        new EventLogger('mq').logEvent({ message: 'mqtt connected' });
+
+        await initRestLogging();
+
+        const entry = replayed().find((e: any) => e.event.message === 'mqtt connected');
+        expect(entry.event).toMatchObject({
+            replayed: true,
+            version: '0.1.1',
+            appVersion: '1.2.3',
+            uuid: 'test-uuid',
+        });
+    });
+
+    it('preserves the original timestamp, so late arrival does not reorder the log', async () => {
+        startupLogging();
+        new EventLogger('mq').logEvent({ message: 'mqtt connected' });
+
+        await initRestLogging();
+
+        const entry = replayed().find((e: any) => e.event.message === 'mqtt connected');
+        expect(entry.event.ts).toBeDefined();
+        expect(new Date(entry.event.ts).getTime()).toBeLessThanOrEqual(Date.now());
+    });
+
+    it('applies the same filter live events are subject to', async () => {
+        startupLogging();
+        new EventLogger('Requests').logEvent({ message: 'GET /something' });
+        new EventLogger('mq').logEvent({ message: 'mqtt connected' });
+
+        await initRestLogging();
+
+        const contexts = replayed().map((e: any) => e.context);
+        expect(contexts).toContain('mq');
+        expect(contexts).not.toContain('Requests');
+    });
+
+    it('stops retaining once handed over, so the backlog costs nothing afterwards', async () => {
+        startupLogging();
+        new EventLogger('mq').logEvent({ message: 'early' });
+
+        await initRestLogging();
+
+        expect(getLogBacklog().isRetaining).toBe(false);
+
+        new EventLogger('mq').logEvent({ message: 'later' });
+        expect(getLogBacklog().size).toBe(0);
+    });
+
+    it('releases the backlog when rest logging is disabled, rather than holding it forever', async () => {
+        mockSettings['logRest.enabled'] = false;
+
+        startupLogging();
+        new EventLogger('mq').logEvent({ message: 'early' });
+
+        await initRestLogging();
+
+        expect(mockAdapters).toHaveLength(0);
+        expect(getLogBacklog().isRetaining).toBe(false);
+        expect(getLogBacklog().size).toBe(0);
+    });
+
+    it('reports how many events were recovered', async () => {
+        startupLogging();
+        new EventLogger('mq').logEvent({ message: 'one' });
+        new EventLogger('mq').logEvent({ message: 'two' });
+
+        await initRestLogging();
+
+        const entry = replayed().find((e: any) => e.event.message === 'Logging initialiazed');
+        expect(entry.event.replayed).toBe(2);
+    });
+});

--- a/src/services/RestLogging/RestLogging.ts
+++ b/src/services/RestLogging/RestLogging.ts
@@ -4,6 +4,7 @@ import { ApiConfiguration } from "../IncyclistApi";
 import { Platform } from "react-native";
 import { getAppInfoBinding, getChannel} from "../../bindings/appInfo";
 import { getUserSettingsBinding } from "../../bindings/user-settings";
+import { getLogBacklog } from "../../bindings/logging/Adapters/BacklogAdapter";
 
 
 const DEFAULT_LOG_URL = 'https://analytics.incyclist.com/api/v1'
@@ -27,6 +28,25 @@ const restLogFilter = (context:string, event:any) => {
 }
 
 let restAdapter: RestLogAdapter | undefined
+
+/**
+ * Hands the events that were logged before this adapter existed over to it.
+ *
+ * They carry their original timestamps, so they sort correctly server-side even though
+ * they arrive late, and they are tagged `replayed` so that is visible rather than
+ * surprising. The globals are applied here because `setGlobal` only affects events logged
+ * after it - a replayed event would otherwise arrive without the version and uuid that
+ * every other line carries.
+ */
+const replayBacklog = (adapter: RestLogAdapter, globals: Record<string, any>): number => {
+    const entries = getLogBacklog().drain().filter(({ context, event }) => restLogFilter(context, event));
+
+    entries.forEach(({ context, event }) => {
+        adapter.log(context, { ...globals, ...event, replayed: true });
+    });
+
+    return entries.length;
+}
 
 /**
  * Best-effort immediate flush of any queued log events, bypassing the normal 10s send interval.
@@ -74,6 +94,8 @@ export const initRestLogging = async () => {
             EventLogger.registerAdapter(restAdapter, restLogFilter)
         }
         else {
+            // Nothing will ever consume the backlog, so stop retaining and release it.
+            getLogBacklog().stop()
             console.log('# Rest logging disabled', {enabled, logUrl,sendInterval})
         }
 
@@ -86,7 +108,10 @@ export const initRestLogging = async () => {
 
 
         logger.setGlobal({version, appVersion, uuid})
-        logger.logEvent( {message:'Logging initialiazed'})
+
+        const replayed = restAdapter ? replayBacklog(restAdapter, {version, appVersion, uuid}) : 0
+
+        logger.logEvent( {message:'Logging initialiazed', replayed})
     }
     catch(err) {
         console.log('Error', err)

--- a/src/services/RestLogging/RestLogging.ts
+++ b/src/services/RestLogging/RestLogging.ts
@@ -33,16 +33,17 @@ let restAdapter: RestLogAdapter | undefined
  * Hands the events that were logged before this adapter existed over to it.
  *
  * They carry their original timestamps, so they sort correctly server-side even though
- * they arrive late, and they are tagged `replayed` so that is visible rather than
- * surprising. The globals are applied here because `setGlobal` only affects events logged
- * after it - a replayed event would otherwise arrive without the version and uuid that
- * every other line carries.
+ * they arrive late, and are otherwise indistinguishable from events that were logged
+ * normally - which is the point: they are ordinary startup events that simply had nowhere
+ * to go yet. The count is reported once on `Logging initialiazed` instead. The globals are
+ * applied here because `setGlobal` only affects events logged after it - a replayed event
+ * would otherwise arrive without the version and uuid that every other line carries.
  */
 const replayBacklog = (adapter: RestLogAdapter, globals: Record<string, any>): number => {
     const entries = getLogBacklog().drain().filter(({ context, event }) => restLogFilter(context, event));
 
     entries.forEach(({ context, event }) => {
-        adapter.log(context, { ...globals, ...event, replayed: true });
+        adapter.log(context, { ...globals, ...event });
     });
 
     return entries.length;

--- a/src/services/RestLogging/RestLogging.ts
+++ b/src/services/RestLogging/RestLogging.ts
@@ -107,9 +107,20 @@ export const initRestLogging = async () => {
 
 
 
-        logger.setGlobal({version, appVersion, uuid})
+        // `session` and `app-channel` are also set by incyclist-services once it initialises
+        // its own logging, but that happens later in startup - so without setting them here
+        // every event logged in between (all of app init, including the whole mq connect)
+        // reached the server without a session to correlate it against. Both values are
+        // already available at this point, and services sets the same ones afterwards.
+        const globals = {
+            version, appVersion, uuid,
+            session: appInfo.session,
+            'app-channel': getChannel(),
+        }
 
-        const replayed = restAdapter ? replayBacklog(restAdapter, {version, appVersion, uuid}) : 0
+        logger.setGlobal(globals)
+
+        const replayed = restAdapter ? replayBacklog(restAdapter, globals) : 0
 
         logger.logEvent( {message:'Logging initialiazed', replayed})
     }


### PR DESCRIPTION
Events logged during app startup reached the console but never the server. Found while device-testing the MQTT migration (#398), where `mqtt connected` was missing from the forwarded log while an event 59ms later came through — but this is a general problem, not an MQTT one.

## Why they were lost

The REST adapter cannot be registered any earlier than it is: it needs `logRest.url` and `logRest.sendInterval`, so `await settings.getAll()` is a real dependency. And `EventLogger` hands each event to whichever adapters exist at that moment, then drops it — there is nothing left to replay by the time the REST adapter appears.

The window is small but covers most of app init, and which events fall inside it varies run to run. Two traces from the same build:

| Run | `mqtt connected` | Reached server? |
|---|---|---|
| 20:23 | `19.154` | yes |
| 20:59 | `48.866` | **no** — but `feature-toggle sync started` at `48.925` did |

So the adapter registered somewhere in that 59ms gap. Nothing is wrong with the events; they simply had nowhere to go yet.

## Approaches rejected

**Registering the REST adapter earlier** — not possible, it needs the settings to exist.

**Gating `EventLogger`'s buffer clear on `adapters.length > 0`** — `gd-eventlog` already buffers into a per-logger `this.events` and clears it unconditionally at `EventLogger.ts:211`, which looks like the fix. It isn't: a console adapter is registered early (`Loader.tsx`), so the backlog *is* consumed and cleared before the REST adapter exists. Any real fix has to be per-adapter, not global.

**Delaying startup until logging is ready** — rejected deliberately. It would make unrelated subsystems wait on logging and would need every downstream assumption re-verified. This inverts it: logging catches up with what already happened, and nothing about startup order changes.

## What this does

A `BacklogAdapter` is registered first, at startup, purely to keep a bounded copy of what goes past. Once the REST adapter is up, the backlog is drained into it and retention stops, so it costs nothing for the rest of the session.

Replayed events:
- keep their **original timestamps**, so they sort correctly server-side despite arriving late;
- are given the same **globals** every other line carries — `setGlobal` only affects events logged after it, so a replayed event would otherwise arrive without `version`/`uuid`;
- are subject to the **same filter** as live events (`Requests`/`RestLogAdapter` stay excluded);

Replayed events are deliberately **not** marked. They are ordinary startup events that simply had nowhere to go when they were logged, and tagging them would put a field on every early line that says nothing about what the app was doing. `Logging initialiazed` reports how many were recovered instead — one line, where the count is actually useful, and the signal that this is working.

Memory is bounded two ways: the backlog is capped at 200 entries, and it is released outright if rest logging is disabled — so a session where nothing ever consumes it cannot grow without limit.

## Also: session and app-channel were missing from early events

Related, and found the same way. `incyclist-services` sets `session` and `app-channel` as log globals when it initialises its own logging — but that happens later in startup than `initRestLogging()`. Everything logged in between reached the server with `version`/`appVersion`/`uuid` but **no session**, so none of it could be correlated with the session it belonged to:

```
08:03:24.041  "message":"create message queue"        ← no session
08:03:24.067  "message":"mqtt broker uri resolved"    ← no session
08:03:24.575  "message":"mq subscribe deferred"  "session":"f9df0bf2-…"
```

Both values are already available at that point — the appInfo binding is already awaited there and exposes `session`, and `getChannel()` is already imported for the `x-channel` header and returns the same value services uses. They are now set up front. Services setting them again afterwards is harmless; the values are identical.

Replayed backlog events pick these up too, since they are handed the same globals.

## Test plan

- `npm test` — **754 tests / 111 suites pass**, including 18 new ones: retention and copy-on-capture (the console adapter mutates the event it is handed, so holding a reference would not be safe), the cap and eviction order, drain/stop semantics, and the handover itself — globals, timestamps, filtering, the disabled path, and the recovered count.
- `npm run lint` — clean for all changed files.
- `npx tsc --noEmit` — one error in `ActivityDetailsDialogView.tsx`, confirmed pre-existing on `main` and unrelated.

**Verified on device (2026-08-19):** a startup trace showed three events that would previously have been lost arriving with full globals, and `Logging initialiazed` reporting `replayed:3`.

Independent of #398 and branched from `main`; the two touch different files and can merge in either order.
