### PR TITLE
fix: accept the 'loading' upload status, unbreaking tsc on every PR

### DIFF
--- a/src/components/UploadPill/UploadPill.test.tsx
+++ b/src/components/UploadPill/UploadPill.test.tsx
@@ -23,6 +23,11 @@ const MOCK_UNKNOWN: UploadPillProps = {
     type: 'strava', text: 'Strava', status: 'unknown',
     onSynchronize: jest.fn(), onOpen: jest.fn(),
 };
+// incyclist-services emits this for an upload whose state is still being determined.
+const MOCK_LOADING: UploadPillProps = {
+    type: 'strava', text: 'Strava', status: 'loading',
+    onSynchronize: jest.fn(), onOpen: jest.fn(),
+};
 const MOCK_SYNCING: UploadPillProps = {
     type: 'strava', text: 'Strava', status: 'unknown',
     synchronizing: true, onSynchronize: jest.fn(), onOpen: jest.fn(),
@@ -43,5 +48,12 @@ describe('UploadPill', () => {
 
     it('renders synchronizing state without crashing', () => {
         render(<UploadPill {...MOCK_SYNCING} />);
+    });
+
+    // Regression guard: services added 'loading' to ActivityUploadStatus and this type was
+    // not widened to match, which broke `tsc` on every PR. The value was already arriving
+    // here at runtime, so this pins that it is an accepted status.
+    it('renders loading state without crashing', () => {
+        render(<UploadPill {...MOCK_LOADING} />);
     });
 });

--- a/src/components/UploadPill/types.ts
+++ b/src/components/UploadPill/types.ts
@@ -1,4 +1,7 @@
-export type UploadPillStatus = 'success' | 'failed' | 'unknown'
+// Mirrors `ActivityUploadStatus` in incyclist-services, which gained 'loading' in 1.7.x.
+// The value already reaches this component at runtime and already renders through the
+// same branch as 'unknown' - only the type was out of date, which broke `tsc` on every PR.
+export type UploadPillStatus = 'success' | 'failed' | 'unknown' | 'loading'
 
 export interface UploadPillProps {
     type: string


### PR DESCRIPTION
`tsc --noEmit` fails on `main` and therefore on every open PR:

```
src/components/ActivityDetailsDialog/ActivityDetailsDialogView.tsx(225,25): error TS2322:
  Type 'ActivityUploadStatus' is not assignable to type 'UploadPillStatus'.
  Type '"loading"' is not assignable to type 'UploadPillStatus'.
```

## Cause

`incyclist-services` defines `ActivityUploadStatus` as `'success' | 'failed' | 'unknown' | 'loading'`. Mobile's `UploadPillStatus` was never widened to match, so `ActivityDetailsDialogView` cannot pass a value straight through to `UploadPill`.

The break came in with the `incyclist-services` 1.7.109 bump. It went unnoticed because **the `verify` workflow only runs on pull requests** — main's own runs are all `skipped` — so the first thing to check main's type health was the next PR to open.

## Why this is a type correction, not a behaviour change

`UploadPill` only branches on `'success'` and `'failed'`:

```js
const backgroundColor = status === 'success'
    ? colors.success
    : (status === 'failed' ? colors.error : colors.disabled);
```

So `'loading'` already arrives at runtime today and already renders through the same path as `'unknown'`. Nothing about what the user sees changes here — the type was simply describing the component inaccurately, and `tsc` was right to complain.

Whether `'loading'` *should* look different — a spinner, or non-tappable, the way the existing `synchronizing` prop behaves — is a UX decision, and is deliberately **not** made in this PR. Bundling it would mean shipping an unrequested visual change inside a build fix.

## Test plan

- `npx tsc --noEmit` — **completely clean**, no errors at all (previously this one).
- `npm test` — 737 tests / 109 suites pass, including a new `UploadPill` case pinning `'loading'` as an accepted status so this cannot silently regress.
- `npm run lint` — 0 errors (24 pre-existing warnings, untouched).

## Note

Branched from `main` and independent of #398 and #399. It should merge **first** — until it does, neither of those can go green, since they inherit this failure from main.

Worth considering separately: running `verify` on pushes to `main`, not just on PRs. A type break sitting undetected in main until someone opens an unrelated PR is how this reached three branches at once.
