### PR TITLE
fix: emit mq payloads as standalone arrays, not views into the packet buffer

### DIFF
--- a/src/bindings/mq/index.test.ts
+++ b/src/bindings/mq/index.test.ts
@@ -407,6 +407,32 @@ describe('MessageQueue', () => {
             expect(client.subscribe).not.toHaveBeenCalled();
         });
 
+        // Regression guard: mqtt-packet slices the stream buffer, so the payload MQTT.js
+        // delivers is a view whose `.buffer` is the whole packet. Services reads it via
+        // `Buffer.from(message.buffer)`, which then yields the entire backing store instead
+        // of the message - seen in production as a feature toggle rejected as a "malformed
+        // payload" when its bytes were in fact perfectly valid.
+        test('emits a payload that owns its buffer, not a view into the packet', async () => {
+            const promise = mq.connect();
+            const client = mockInstances[0];
+            succeed(client);
+            await promise;
+
+            const received: Uint8Array[] = [];
+            mq.on('mq-message', (_topic: string, payload: Uint8Array) => received.push(payload));
+
+            // How a real payload arrives: the JSON sitting at an offset inside a larger packet.
+            const packet = Buffer.from('....HEADER....{"value":true}', 'utf-8');
+            client.emit('message', 'topic/in', packet.subarray(14));
+
+            const payload = received[0];
+            expect(payload.byteOffset).toBe(0);
+            expect(payload.byteLength).toBe(payload.buffer.byteLength);
+
+            // The exact pattern the services-side handlers use must now yield the message.
+            expect(Buffer.from(payload.buffer).toString()).toBe('{"value":true}');
+        });
+
         test('forwards incoming messages as mq-message events', async () => {
             const promise = mq.connect();
             const client = mockInstances[0];
@@ -421,7 +447,10 @@ describe('MessageQueue', () => {
 
             expect(received).toHaveLength(1);
             expect(received[0][0]).toBe('topic/in');
-            expect(received[0][1].toString()).toBe('hello');
+            // Decoded the way consumers do it. The payload is a Uint8Array, which is all the
+            // binding interface promises - asserting Buffer's own toString() here would pin a
+            // detail of whichever client library happens to be underneath.
+            expect(Buffer.from(received[0][1].buffer).toString()).toBe('hello');
         });
     });
 

--- a/src/bindings/mq/index.ts
+++ b/src/bindings/mq/index.ts
@@ -494,7 +494,23 @@ export class MessageQueue extends EventEmitter {
 
     private onMessage(topic: string, message: Uint8Array) {
         try {
-            this.emit('mq-message', topic, message);
+            // Emitted as a standalone array, never as the view MQTT.js hands us.
+            //
+            // mqtt-packet builds the payload by slicing the stream buffer, so what it
+            // delivers is a *view*: `byteOffset` is non-zero and `message.buffer` is the
+            // whole packet - in practice the entire backing store - rather than these bytes.
+            // A consumer reading `.buffer` therefore sees far more than the message.
+            //
+            // Every other binding delivers a standalone array: the native module this
+            // replaced did, and desktop's does because Electron IPC copies on the way
+            // through. Mobile was the only one handing out a view, which silently broke
+            // payload parsing in services - both the feature-toggle and active-rides
+            // handlers do `Buffer.from(message.buffer)` - so it is normalised here rather
+            // than every consumer having to defend against it.
+            //
+            // `new Uint8Array(view)` copies element-wise, giving an array that owns its
+            // buffer at offset 0. Payloads are small JSON documents, so the copy is cheap.
+            this.emit('mq-message', topic, new Uint8Array(message));
         } catch (err: any) {
             this.logger.logEvent({ message: 'error', fn: 'onMessage', error: err.message });
         }


### PR DESCRIPTION
A feature toggle published to a device was rejected as a malformed payload — even though the bytes were exactly `{"value":true}`:

```
message:feature-toggle sync: ignoring malformed payload,
topic:incyclist/features/IOS-DEV/TOGGLE_TEST,
payload:{0:123,1:34,2:118,3:97,4:108,5:117,6:101,7:34,8:58,9:116,10:114,11:117,12:101,13:125}
```

Those 14 bytes decode to `{"value":true}`. The data arrived intact; reading it was the problem.

## Cause

`mqtt-packet` builds a payload by slicing the stream buffer (`parser.js:323`), so what MQTT.js delivers is a **view**: `byteOffset` is non-zero and `message.buffer` is the whole packet, not the message.

Both services-side handlers — `appstate/toggle-sync.ts:159` and `activities/active-rides/mq.ts:149` — read the payload as:

```ts
str = Buffer.from(message.buffer).toString()
```

`Buffer.from(arrayBuffer)` wraps the *entire* buffer, ignoring `byteOffset`/`byteLength`. Reproduced locally: for a 14-byte payload at offset 14, that call returned the whole 8KB backing store including unrelated memory. `JSON.parse` then failed and the toggle was discarded.

## Why it is fixed in the binding, not in services

That services code is unchanged and worked before, because **every other binding hands over a standalone array**: the native module this replaced did, and desktop's does because Electron IPC copies on the way through. Mobile was the only one exposing a view into a larger buffer.

Normalising here also fixes both consumers at once and needs no `services` release.

## The fix

```ts
this.emit('mq-message', topic, new Uint8Array(message));
```

`new Uint8Array(view)` copies element-wise into an array that owns its buffer at offset 0. Payloads are small JSON documents, so the copy is cheap.

`Buffer.from(message)` would **not** work: Node pools small Buffer allocations, so the copy would itself sit at a non-zero offset in a shared pool — correct on device, where the `buffer` polyfill does not pool, but wrong under test. `new Uint8Array` is deterministic on both.

## Scope

**Active rides would have hit this too** — `active-rides/mq.ts` has the identical line. It was listed as unverified in `TESTING_BACKLOG` #58 precisely because no multi-user ride had been run over the new transport; this is what that would have found.

## Test plan

- `npm test` — **794 tests / 111 suites pass**, including a new regression guard that feeds the binding a payload at a non-zero offset inside a larger packet and asserts the emitted array owns its buffer, then asserts the consumers' exact `Buffer.from(payload.buffer).toString()` pattern yields the message.
- One existing assertion was relaxed: it checked `payload.toString()` returned `'hello'`, which pinned Buffer semantics the `Uint8Array` interface never promised. It now decodes the way consumers actually do.
- `npx tsc --noEmit` — clean. `npm run lint` — 0 errors.

**Not verified:** not yet on a device. The check is to publish a feature toggle and confirm `feature-toggle sync: applied toggle` instead of `ignoring malformed payload`.
