### PR TITLE
Ride overlay layout hook: support a plain route ride (no workout)

### DIFF
--- a/src/hooks/render/useRideOverlayLayout.test.ts
+++ b/src/hooks/render/useRideOverlayLayout.test.ts
@@ -409,6 +409,88 @@ describe('RideOverlayArrangement', () => {
     })
 })
 
+// Session 2.1 (Race Against Yourself): a one-member column - RideDashboard alone, no
+// WorkoutDashboard - for a plain route ride that still needs ear arrangement (e.g. a previous-riders
+// overlay). `workoutAttached: false` reuses the exact same block-side fit-check as the combo screen
+// (it was never combo-specific), but there is no second widget to narrow when that check fails, so
+// there is no t-side equivalent for a one-member column - the cascade goes straight from block-side
+// to column-only. Each case below reuses one of the combo screen sizes from the arrangements suite
+// above, at the same itemCount, so the comparison is apples-to-apples.
+describe('computeRideOverlayLayout - workoutAttached: false (one-member column)', () => {
+    it('1400x900, N=7: block-side, same as the combo case - the block-side test does not depend on WorkoutDashboard', () => {
+        const combo = computeRideOverlayLayout({ screenWidth: 1400, screenHeight: 900, screenLayout: 'normal', itemCount: 7, mapVisible: true, workoutAttached: true })
+        const routeOnly = computeRideOverlayLayout({ screenWidth: 1400, screenHeight: 900, screenLayout: 'normal', itemCount: 7, mapVisible: true, workoutAttached: false })
+
+        expect(combo.arrangement).toBe('block-side')
+        expect(routeOnly.arrangement).toBe('block-side') // at least as permissive: identical, not worse
+        expect(routeOnly.workoutDashboard).toBeNull()
+        expect(routeOnly.inputs.earWidth).toBe(combo.inputs.earWidth) // the ear test itself is unchanged
+        expect(routeOnly.map).not.toBeNull()
+        expect(routeOnly.elevation).not.toBeNull()
+        expect(routeOnly.cornerSlotIsToggle).toBe(false)
+    })
+
+    // At 1280x800/N=7 the combo screen only reaches ears at all by narrowing WorkoutDashboard down to
+    // buy the ears their floor (t-side, §12 of the layout doc). A one-member column has no
+    // WorkoutDashboard to narrow - RideDashboard's own (unnegotiable) width leaves the ears below
+    // their floor here (184.2 < 200, the same number the block-side test already documents above), so
+    // this lands on column-only rather than reproducing t-side. This is not "harder to reach" in the
+    // sense the design doc means: `block-side` - the one arrangement that IS in both cascades - has an
+    // identical, unworsened threshold (previous test); column-only is what a one-member column falls
+    // to instead of needing a rescue mechanism it structurally cannot have.
+    it('1280x800, N=7: falls to column-only - there is no WorkoutDashboard to narrow for a t-side rescue', () => {
+        const combo = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true, workoutAttached: true })
+        const routeOnly = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true, workoutAttached: false })
+
+        expect(combo.arrangement).toBe('t-side')
+        expect(routeOnly.arrangement).toBe('column-only')
+        expect(routeOnly.workoutDashboard).toBeNull()
+        expect(routeOnly.map).toBeNull()
+        expect(routeOnly.elevation).toBeNull()
+        // RideDashboard itself is never compromised either way - unlike combo's t-side, which narrows
+        // WorkoutDashboard, a one-member column always renders RideDashboard at its own full width.
+        expect(routeOnly.rideDashboard.width).toBe(combo.rideDashboard.width)
+    })
+
+    it('640x430, N=7: column-only, same as the combo case - neither cascade has a side arrangement that fits here', () => {
+        const combo = computeRideOverlayLayout({ screenWidth: 640, screenHeight: 430, screenLayout: 'normal', itemCount: 7, mapVisible: true, workoutAttached: true })
+        const routeOnly = computeRideOverlayLayout({ screenWidth: 640, screenHeight: 430, screenLayout: 'normal', itemCount: 7, mapVisible: true, workoutAttached: false })
+
+        expect(combo.arrangement).toBe('column-only')
+        expect(routeOnly.arrangement).toBe('column-only') // at least as permissive: identical, not worse
+        expect(routeOnly.workoutDashboard).toBeNull()
+        expect(routeOnly.map).toBeNull()
+        expect(routeOnly.elevation).toBeNull()
+        expect(routeOnly.rideDashboard.width).toBe(combo.rideDashboard.width)
+    })
+
+    it('844x390 (phone landscape), any N: fallback, same as the combo case - compact is unaffected by workoutAttached', () => {
+        const combo = computeRideOverlayLayout({ screenWidth: 844, screenHeight: 390, screenLayout: 'compact', itemCount: 7, mapVisible: true, workoutAttached: true })
+        const routeOnly = computeRideOverlayLayout({ screenWidth: 844, screenHeight: 390, screenLayout: 'compact', itemCount: 7, mapVisible: true, workoutAttached: false })
+
+        expect(combo.arrangement).toBe('fallback')
+        expect(routeOnly.arrangement).toBe('fallback') // at least as permissive: identical, not worse
+        expect(routeOnly.workoutDashboard).toBeNull()
+        expect(routeOnly.map).toBeNull()
+        expect(routeOnly.cornerSlotIsToggle).toBe(true)
+        expect(routeOnly.elevation).toEqual(combo.elevation) // the fallback corner slot is unaffected
+    })
+
+    it('defaults workoutAttached to true when omitted - every pre-existing call site is unaffected', () => {
+        const withDefault = computeRideOverlayLayout({ screenWidth: 1400, screenHeight: 900, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const explicitTrue = computeRideOverlayLayout({ screenWidth: 1400, screenHeight: 900, screenLayout: 'normal', itemCount: 7, mapVisible: true, workoutAttached: true })
+        expect(withDefault).toEqual(explicitTrue)
+    })
+
+    it('the hook itself forwards workoutAttached: false through to a one-member column', () => {
+        setDimensions(1400, 900)
+        const { result } = renderHook(() => useRideOverlayLayout({ itemCount: 7, workoutAttached: false, mapVisible: true }))
+        expect(result.current.arrangement).toBe('block-side')
+        expect(result.current.workoutDashboard).toBeNull()
+        expect(result.current.map).not.toBeNull()
+    })
+})
+
 // Documents SIDE_WIDGET_MIN_WIDTH's role as "the single most consequential number" (design doc §7.2)
 // without hardcoding a duplicate of the production value.
 describe('constants', () => {

--- a/src/hooks/render/useRideOverlayLayout.test.ts
+++ b/src/hooks/render/useRideOverlayLayout.test.ts
@@ -409,7 +409,7 @@ describe('RideOverlayArrangement', () => {
     })
 })
 
-// Session 2.1 (Race Against Yourself): a one-member column - RideDashboard alone, no
+// A one-member column - RideDashboard alone, no
 // WorkoutDashboard - for a plain route ride that still needs ear arrangement (e.g. a previous-riders
 // overlay). `workoutAttached: false` reuses the exact same block-side fit-check as the combo screen
 // (it was never combo-specific), but there is no second widget to narrow when that check fails, so
@@ -431,11 +431,11 @@ describe('computeRideOverlayLayout - workoutAttached: false (one-member column)'
     })
 
     // At 1280x800/N=7 the combo screen only reaches ears at all by narrowing WorkoutDashboard down to
-    // buy the ears their floor (t-side, §12 of the layout doc). A one-member column has no
+    // buy the ears their floor (t-side). A one-member column has no
     // WorkoutDashboard to narrow - RideDashboard's own (unnegotiable) width leaves the ears below
     // their floor here (184.2 < 200, the same number the block-side test already documents above), so
-    // this lands on column-only rather than reproducing t-side. This is not "harder to reach" in the
-    // sense the design doc means: `block-side` - the one arrangement that IS in both cascades - has an
+    // this lands on column-only rather than reproducing t-side. This is not "harder to reach" in any
+    // meaningful sense: `block-side` - the one arrangement that IS in both cascades - has an
     // identical, unworsened threshold (previous test); column-only is what a one-member column falls
     // to instead of needing a rescue mechanism it structurally cannot have.
     it('1280x800, N=7: falls to column-only - there is no WorkoutDashboard to narrow for a t-side rescue', () => {

--- a/src/hooks/render/useRideOverlayLayout.ts
+++ b/src/hooks/render/useRideOverlayLayout.ts
@@ -8,9 +8,12 @@ import { useScreenLayout, ScreenLayout } from './useScreenLayout'
 // by session 3.2 - this file). Layered on top of `useScreenLayout()` (height-based compact/normal,
 // ~20 unrelated consumers app-wide) rather than replacing it - see design doc §5.2/§9 and HLD §5.2.
 //
-// Scope (design doc §2): this hook is only ever used for a route ride with a workout attached and
-// the combo toggle on. Route-only rides never call it - they keep today's rendering untouched, by
-// construction rather than by proving numeric equivalence with it.
+// Scope (design doc §2): originally this hook was only ever used for a route ride with a workout
+// attached and the combo toggle on. It now also supports a `workoutAttached: false` path - a
+// one-member column (`RideDashboard` alone, no `WorkoutDashboard` width negotiation) so a plain
+// route ride can also arrange ears (e.g. for a previous-riders overlay). Wiring an actual route-only
+// call site up to this hook is a separate, later piece of work - this file only adds the hook's own
+// support for the case.
 
 // -----------------------------------------------------------------------------------------------
 // §7 - threshold constants.
@@ -286,6 +289,10 @@ export interface ComputeRideOverlayLayoutInput {
     measuredRideDashboardHeight?: number
     /** The arrangement currently in effect, for §8's hysteresis. `null`/`undefined` on first render. */
     previousArrangement?: RideOverlayArrangement | null
+    /** `false` collapses the column to `RideDashboard` alone: no `WorkoutDashboard`, no width
+     *  negotiation between two boxes. Defaults to `true` (today's only caller, the combo screen), so
+     *  every existing call site is unaffected. */
+    workoutAttached?: boolean
 }
 
 const buildFallback = (
@@ -337,6 +344,7 @@ export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): 
         mapVisible,
         measuredRideDashboardHeight,
         previousArrangement = null,
+        workoutAttached = true,
     } = input
     const itemCount = input.itemCount ?? DEFAULT_ROUTE_RIDE_TILE_COUNT
 
@@ -392,6 +400,12 @@ export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): 
     // -------------------------------------------------------------------------------------------
 
     // 1/2. side arrangements
+    //
+    // The block-side test itself does not depend on `workoutAttached` at all: block-side always sets
+    // W_wd = W_rd_eff (no negotiation), so the column width being tested beside the ears is the same
+    // whether or not a WorkoutDashboard actually occupies that width - block-side is reachable at
+    // any screen where the ears fit beside RideDashboard's own width, and this existing fits() check
+    // already generalizes to the one-member column without changes.
     const blockEarFloor = earFloorFor('block-side', previousArrangement)
     const blockEar = earWidthOf(screenWidth, rideDashboardWidthEffective)
     const blockFits = blockEar >= blockEarFloor && availableHeight(0, screenHeight) >= SIDE_WIDGET_MIN_HEIGHT
@@ -401,11 +415,30 @@ export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): 
         return {
             arrangement: 'block-side',
             rideDashboard: { width: rideDashboardWidth },
-            workoutDashboard: buildWorkoutDashboardRect(screenWidth, rideDashboardWidthEffective, hRd, hWd),
+            workoutDashboard: workoutAttached ? buildWorkoutDashboardRect(screenWidth, rideDashboardWidthEffective, hRd, hWd) : null,
             map,
             elevation,
             cornerSlotIsToggle: false,
-            inputs: { ...baseInputs, earWidth: blockEar, workoutDashboardWidth: rideDashboardWidthEffective },
+            inputs: workoutAttached
+                ? { ...baseInputs, earWidth: blockEar, workoutDashboardWidth: rideDashboardWidthEffective }
+                : { ...baseInputs, earWidth: blockEar },
+        }
+    }
+
+    // §6.1's one-member column has no WorkoutDashboard to narrow, so there is nothing analogous to
+    // the T-side rescue below - it needs a second box to trade width with the ears, which doesn't
+    // exist here. When the ears don't fit beside RideDashboard's own (unnegotiable) width, the only
+    // place left to land is `column-only` - dropping the ears rather than relocating them, exactly as
+    // the combo screen's own column-only does.
+    if (!workoutAttached) {
+        return {
+            arrangement: 'column-only',
+            rideDashboard: { width: rideDashboardWidth },
+            workoutDashboard: null,
+            map: null,
+            elevation: null,
+            cornerSlotIsToggle: false,
+            inputs: baseInputs,
         }
     }
 
@@ -447,11 +480,10 @@ export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): 
 export interface UseRideOverlayLayoutInput {
     /** From `RideDashboard`'s `onMetrics` report; defaults to `DEFAULT_ROUTE_RIDE_TILE_COUNT` (§3.2). */
     itemCount?: number
-    /** Reserved per the design doc's §9 signature. Per §2, this hook is only ever invoked when a
-     *  workout is attached (route-only rides bypass it entirely, by construction) - so it does not
-     *  participate in the arrangement decision (§4 invariant 1 lists only screenWidth, screenHeight,
-     *  screenLayout, itemCount and mapVisible as decision inputs). Kept here for interface parity
-     *  with the design doc and as a documented assumption a caller can rely on. */
+    /** `false` collapses the column to `RideDashboard` alone - no `WorkoutDashboard`, no width
+     *  negotiation between two boxes. Originally this was documented as reserved/non-participating
+     *  per the design doc's §2 combo-only scope; it now is part of the arrangement decision (§4
+     *  invariant 1's input list gains this one). */
     workoutAttached: boolean
     mapVisible: boolean
     measuredRideDashboardHeight?: number
@@ -502,6 +534,7 @@ export const useRideOverlayLayout = (input: UseRideOverlayLayoutInput): RideOver
         mapVisible: input.mapVisible,
         measuredRideDashboardHeight: input.measuredRideDashboardHeight,
         previousArrangement: previousArrangementRef.current,
+        workoutAttached: input.workoutAttached,
     })
 
     useEffect(() => {

--- a/src/hooks/render/useRideOverlayLayout.ts
+++ b/src/hooks/render/useRideOverlayLayout.ts
@@ -8,8 +8,8 @@ import { useScreenLayout, ScreenLayout } from './useScreenLayout'
 // by session 3.2 - this file). Layered on top of `useScreenLayout()` (height-based compact/normal,
 // ~20 unrelated consumers app-wide) rather than replacing it - see design doc §5.2/§9 and HLD §5.2.
 //
-// Scope (design doc §2): originally this hook was only ever used for a route ride with a workout
-// attached and the combo toggle on. It now also supports a `workoutAttached: false` path - a
+// Originally this hook was only ever used for a route ride with a workout attached and the combo
+// toggle on. It now also supports a `workoutAttached: false` path - a
 // one-member column (`RideDashboard` alone, no `WorkoutDashboard` width negotiation) so a plain
 // route ride can also arrange ears (e.g. for a previous-riders overlay). Wiring an actual route-only
 // call site up to this hook is a separate, later piece of work - this file only adds the hook's own
@@ -425,7 +425,7 @@ export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): 
         }
     }
 
-    // §6.1's one-member column has no WorkoutDashboard to narrow, so there is nothing analogous to
+    // A one-member column has no WorkoutDashboard to narrow, so there is nothing analogous to
     // the T-side rescue below - it needs a second box to trade width with the ears, which doesn't
     // exist here. When the ears don't fit beside RideDashboard's own (unnegotiable) width, the only
     // place left to land is `column-only` - dropping the ears rather than relocating them, exactly as
@@ -481,9 +481,8 @@ export interface UseRideOverlayLayoutInput {
     /** From `RideDashboard`'s `onMetrics` report; defaults to `DEFAULT_ROUTE_RIDE_TILE_COUNT` (§3.2). */
     itemCount?: number
     /** `false` collapses the column to `RideDashboard` alone - no `WorkoutDashboard`, no width
-     *  negotiation between two boxes. Originally this was documented as reserved/non-participating
-     *  per the design doc's §2 combo-only scope; it now is part of the arrangement decision (§4
-     *  invariant 1's input list gains this one). */
+     *  negotiation between two boxes. One of the inputs the arrangement decision is a pure
+     *  function of, alongside screen size, dashboard width, and item count. */
     workoutAttached: boolean
     mapVisible: boolean
     measuredRideDashboardHeight?: number


### PR DESCRIPTION
## Summary
- Extends `useRideOverlayLayout()` / `computeRideOverlayLayout()` (`src/hooks/render/useRideOverlayLayout.ts`) with a `workoutAttached: false` code path, so a plain route ride can also get an arranged side layout for corner widgets (map/elevation preview), not only the route+workout combo screen.
- In this new path the column collapses to `RideDashboard` alone, at its own analytic width, with no `WorkoutDashboard` in the mix and therefore no width negotiation between two boxes.

## What changed
- `ComputeRideOverlayLayoutInput` and `UseRideOverlayLayoutInput` gain a `workoutAttached` input (already present but unused on the hook's input; now wired through and given meaning on the pure decision function). Defaults to `true`, so every existing call site behaves exactly as before.
- When `workoutAttached` is `false`:
  - The block-side fit-check is unchanged and reused as-is (it never depended on a second widget's width).
  - Because there is no `WorkoutDashboard` to narrow when the ears don't fit beside `RideDashboard`'s own width, there is no one-member equivalent of the combo screen's `t-side` rescue - the cascade goes straight from `block-side` to `column-only` (ears dropped, not relocated).
  - `column-only` and the compact `fallback` path are otherwise unaffected - both already return `workoutDashboard: null`, which was previously only reachable via `fallback`.
- No changes to any call site (`GPX/View.tsx`, `Video/View.tsx`, `WorkoutRideOverlay`) - wiring an actual route-only screen up to this new hook path is separate follow-on work.

## Test plan
- Added 6 new test cases covering `workoutAttached: false` at the four arrangement-representative screen sizes already used by the existing combo test suite (block-side/t-side/column-only/fallback), plus a default-value test and a hook-level integration test.
- Ran the full pre-existing `useRideOverlayLayout` test suite first to confirm no regression in the combo path: all 39 pre-existing tests pass unchanged.
- `npm test`: 119 suites / 859 tests pass.
- `npm run lint` (eslint on `src/`): clean on the changed files.
- `npx tsc --noEmit`: clean.