### PR TITLE
Add phone chevron affordance + expand/collapse panel for previous rides

### DIFF
--- a/src/components/PrevRides/PrevRidesCornerPanel.stories.tsx
+++ b/src/components/PrevRides/PrevRidesCornerPanel.stories.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { View, Text, Image, StyleSheet } from 'react-native';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { PrevRidesCornerPanel } from './PrevRidesCornerPanel';
+import { MOCK_ROWS, MOCK_ROW_CHASER, MOCK_ROW_CURRENT } from './PrevRidesRow.mock';
+import { PrevRidesSlotRect } from './types';
+import { computeRideOverlayLayout } from '../../hooks/render/useRideOverlayLayout';
+import { colors, textSizes } from '../../theme';
+
+/**
+ * The phone-only chevron affordance + expand/collapse panel for the previous-rides corner slot.
+ * Pure view, no `incyclist-services` dependency: `active`/`rows`/`slotRect` are plain props, and
+ * `onExpandPrevRides`/`onCollapsePrevRides`/`onVisibleRowsChange` are component-level callbacks a
+ * later session wires up to the real page service (`RidePageService.setPrevRidesVisibleRows()` is
+ * not yet published from `incyclist-services`, so that reporting stops at this callback here).
+ *
+ * The condensed slot's own single-line content ("3rd · +0:08 to 2nd") is not owned by this
+ * component — these stories render it as `children` purely so the chevron/panel have a realistic
+ * backdrop to sit against, mirroring the "own condensed content vs. interaction layer" split the
+ * component itself makes.
+ *
+ * `slotRect` is taken directly from `computeRideOverlayLayout()`'s own compact-fallback
+ * `.elevation` rect at each frame's size — the same geometry the existing elevation/workout
+ * corner slot already renders at — rather than reproducing those constants here.
+ */
+const meta: Meta<typeof PrevRidesCornerPanel> = {
+    title: 'Components/PrevRides/PrevRidesCornerPanel',
+    component: PrevRidesCornerPanel,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PrevRidesCornerPanel>;
+
+const FALLBACK_SLOT_DEFAULT = (screenWidth: number, screenHeight: number): PrevRidesSlotRect => ({
+    top: 0,
+    right: 0,
+    width: screenWidth * 0.2,
+    height: screenHeight * 0.12,
+});
+
+const fallbackSlot = (screenWidth: number, screenHeight: number): PrevRidesSlotRect => {
+    const layout = computeRideOverlayLayout({ screenWidth, screenHeight, screenLayout: 'compact', mapVisible: false });
+    return layout.elevation ?? FALLBACK_SLOT_DEFAULT(screenWidth, screenHeight);
+};
+
+const CondensedLine = () => (
+    <View style={styles.condensedLine}>
+        <Text style={styles.condensedHeader}>PREV RIDES</Text>
+        <Text style={styles.condensedText} numberOfLines={1}>
+            3rd · +0:08 to 2nd
+        </Text>
+    </View>
+);
+
+const PhoneFrame = ({ width, height, children }: { width: number; height: number; children: React.ReactNode }) => (
+    <View style={[styles.frame, { width, height }]}>
+        <Image source={{ uri: '/screenshot.jpg' }} style={StyleSheet.absoluteFill} resizeMode="cover" />
+        {children}
+    </View>
+);
+
+// --- Reference frame: 844×390 ---
+
+export const CollapsedCondensed: Story = {
+    render: () => (
+        <PhoneFrame width={844} height={390}>
+            <PrevRidesCornerPanel active={true} slotRect={fallbackSlot(844, 390)} screenHeight={390} rows={MOCK_ROWS}>
+                <CondensedLine />
+            </PrevRidesCornerPanel>
+        </PhoneFrame>
+    ),
+};
+
+/** Same frame, `active: false` — the cornerWidget cycle is on `'elevation'`/`'workout'`, so no
+ *  chevron renders at all (it's a separate tap target only ever shown while the cycle is on
+ *  `'prevRides'`). */
+export const CollapsedNotActive: Story = {
+    render: () => (
+        <PhoneFrame width={844} height={390}>
+            <PrevRidesCornerPanel active={false} slotRect={fallbackSlot(844, 390)} screenHeight={390} rows={MOCK_ROWS}>
+                <CondensedLine />
+            </PrevRidesCornerPanel>
+        </PhoneFrame>
+    ),
+};
+
+export const Expanded: Story = {
+    render: () => (
+        <PhoneFrame width={844} height={390}>
+            <PrevRidesCornerPanel
+                active={true}
+                defaultExpanded={true}
+                slotRect={fallbackSlot(844, 390)}
+                screenHeight={390}
+                rows={MOCK_ROWS}
+            >
+                <CondensedLine />
+            </PrevRidesCornerPanel>
+        </PhoneFrame>
+    ),
+};
+
+/** A short field (current + one other rider) — the panel sizes to the data it has, it doesn't pad
+ *  out empty rows to fill the budget. */
+export const ExpandedShortField: Story = {
+    render: () => (
+        <PhoneFrame width={844} height={390}>
+            <PrevRidesCornerPanel
+                active={true}
+                defaultExpanded={true}
+                slotRect={fallbackSlot(844, 390)}
+                screenHeight={390}
+                rows={[MOCK_ROW_CHASER, MOCK_ROW_CURRENT]}
+            >
+                <CondensedLine />
+            </PrevRidesCornerPanel>
+        </PhoneFrame>
+    ),
+};
+
+// --- Tighter frame: confirms the panel clamps rather than overflowing into the bottom bar ---
+
+const TIGHT_WIDTH = 700;
+const TIGHT_HEIGHT = 300;
+
+export const ExpandedTightFrameClamps: Story = {
+    render: () => (
+        <PhoneFrame width={TIGHT_WIDTH} height={TIGHT_HEIGHT}>
+            <PrevRidesCornerPanel
+                active={true}
+                defaultExpanded={true}
+                slotRect={fallbackSlot(TIGHT_WIDTH, TIGHT_HEIGHT)}
+                screenHeight={TIGHT_HEIGHT}
+                rows={MOCK_ROWS}
+            >
+                <CondensedLine />
+            </PrevRidesCornerPanel>
+        </PhoneFrame>
+    ),
+};
+
+const styles = StyleSheet.create({
+    frame: {
+        alignSelf: 'flex-start',
+        overflow: 'hidden',
+        borderWidth: 1,
+        borderColor: 'rgba(255,255,255,0.25)',
+        backgroundColor: colors.background,
+    },
+    condensedLine: {
+        flex: 1,
+        justifyContent: 'center',
+        paddingHorizontal: 6,
+    },
+    condensedHeader: {
+        color: colors.text,
+        fontSize: textSizes.microText,
+        fontWeight: '700',
+        opacity: 0.7,
+    },
+    condensedText: {
+        color: colors.text,
+        fontSize: textSizes.tinyText,
+        fontWeight: '700',
+    },
+});

--- a/src/components/PrevRides/PrevRidesCornerPanel.test.tsx
+++ b/src/components/PrevRides/PrevRidesCornerPanel.test.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, fireEvent } from '@testing-library/react-native';
+import { PrevRidesCornerPanel } from './PrevRidesCornerPanel';
+import { MOCK_ROWS } from './PrevRidesRow.mock';
+import { PrevRidesSlotRect } from './types';
+
+const REFERENCE_SLOT: PrevRidesSlotRect = { top: 41, right: 0, width: 169, height: 47 };
+const REFERENCE_SCREEN_HEIGHT = 390;
+
+describe('PrevRidesCornerPanel', () => {
+    it('renders the given condensed content (children) regardless of active state', () => {
+        const { getByText } = render(
+            <PrevRidesCornerPanel active={false} slotRect={REFERENCE_SLOT} screenHeight={REFERENCE_SCREEN_HEIGHT} rows={MOCK_ROWS}>
+                <Text>3rd · +0:08 to 2nd</Text>
+            </PrevRidesCornerPanel>
+        );
+
+        expect(getByText('3rd · +0:08 to 2nd')).toBeTruthy();
+    });
+
+    it('does not render the chevron when the slot is not showing prevRides', () => {
+        const { queryByTestId } = render(
+            <PrevRidesCornerPanel active={false} slotRect={REFERENCE_SLOT} screenHeight={REFERENCE_SCREEN_HEIGHT} rows={MOCK_ROWS} />
+        );
+
+        expect(queryByTestId('prev-rides-expand-chevron')).toBeNull();
+    });
+
+    it('renders the chevron, collapsed by default, when active', () => {
+        const { getByTestId, queryByTestId } = render(
+            <PrevRidesCornerPanel active={true} slotRect={REFERENCE_SLOT} screenHeight={REFERENCE_SCREEN_HEIGHT} rows={MOCK_ROWS} />
+        );
+
+        expect(getByTestId('prev-rides-expand-chevron')).toBeTruthy();
+        expect(queryByTestId('prev-rides-expanded-panel')).toBeNull();
+    });
+
+    it('opens the panel and calls onExpandPrevRides when the chevron is tapped', () => {
+        const onExpandPrevRides = jest.fn();
+        const { getByTestId } = render(
+            <PrevRidesCornerPanel
+                active={true}
+                slotRect={REFERENCE_SLOT}
+                screenHeight={REFERENCE_SCREEN_HEIGHT}
+                rows={MOCK_ROWS}
+                onExpandPrevRides={onExpandPrevRides}
+            />
+        );
+
+        fireEvent.press(getByTestId('prev-rides-expand-chevron'));
+
+        expect(getByTestId('prev-rides-expanded-panel')).toBeTruthy();
+        expect(onExpandPrevRides).toHaveBeenCalledTimes(1);
+    });
+
+    it('collapses and calls onCollapsePrevRides when the chevron is tapped again', () => {
+        const onCollapsePrevRides = jest.fn();
+        const { getByTestId, queryByTestId } = render(
+            <PrevRidesCornerPanel
+                active={true}
+                slotRect={REFERENCE_SLOT}
+                screenHeight={REFERENCE_SCREEN_HEIGHT}
+                rows={MOCK_ROWS}
+                defaultExpanded={true}
+                onCollapsePrevRides={onCollapsePrevRides}
+            />
+        );
+
+        fireEvent.press(getByTestId('prev-rides-expand-chevron'));
+
+        expect(queryByTestId('prev-rides-expanded-panel')).toBeNull();
+        expect(onCollapsePrevRides).toHaveBeenCalledTimes(1);
+    });
+
+    it('collapses and calls onCollapsePrevRides when tapping outside the panel', () => {
+        const onCollapsePrevRides = jest.fn();
+        const { getByTestId, queryByTestId } = render(
+            <PrevRidesCornerPanel
+                active={true}
+                slotRect={REFERENCE_SLOT}
+                screenHeight={REFERENCE_SCREEN_HEIGHT}
+                rows={MOCK_ROWS}
+                defaultExpanded={true}
+                onCollapsePrevRides={onCollapsePrevRides}
+            />
+        );
+
+        fireEvent.press(getByTestId('prev-rides-panel-backdrop'));
+
+        expect(queryByTestId('prev-rides-expanded-panel')).toBeNull();
+        expect(onCollapsePrevRides).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render a backdrop while collapsed', () => {
+        const { queryByTestId } = render(
+            <PrevRidesCornerPanel active={true} slotRect={REFERENCE_SLOT} screenHeight={REFERENCE_SCREEN_HEIGHT} rows={MOCK_ROWS} />
+        );
+
+        expect(queryByTestId('prev-rides-panel-backdrop')).toBeNull();
+    });
+
+    it('force-collapses and reports onCollapsePrevRides when the cycle moves away from prevRides while expanded', () => {
+        const onCollapsePrevRides = jest.fn();
+        const { rerender, queryByTestId } = render(
+            <PrevRidesCornerPanel
+                active={true}
+                slotRect={REFERENCE_SLOT}
+                screenHeight={REFERENCE_SCREEN_HEIGHT}
+                rows={MOCK_ROWS}
+                defaultExpanded={true}
+                onCollapsePrevRides={onCollapsePrevRides}
+            />
+        );
+
+        expect(queryByTestId('prev-rides-expanded-panel')).toBeTruthy();
+
+        rerender(
+            <PrevRidesCornerPanel
+                active={false}
+                slotRect={REFERENCE_SLOT}
+                screenHeight={REFERENCE_SCREEN_HEIGHT}
+                rows={MOCK_ROWS}
+                onCollapsePrevRides={onCollapsePrevRides}
+            />
+        );
+
+        expect(queryByTestId('prev-rides-expanded-panel')).toBeNull();
+        expect(onCollapsePrevRides).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates the panel visible-row report via onVisibleRowsChange', () => {
+        const onVisibleRowsChange = jest.fn();
+        const { getByTestId } = render(
+            <PrevRidesCornerPanel
+                active={true}
+                slotRect={REFERENCE_SLOT}
+                screenHeight={REFERENCE_SCREEN_HEIGHT}
+                rows={MOCK_ROWS}
+                onVisibleRowsChange={onVisibleRowsChange}
+            />
+        );
+
+        fireEvent.press(getByTestId('prev-rides-expand-chevron'));
+
+        expect(onVisibleRowsChange).toHaveBeenCalled();
+    });
+});

--- a/src/components/PrevRides/PrevRidesCornerPanel.tsx
+++ b/src/components/PrevRides/PrevRidesCornerPanel.tsx
@@ -1,0 +1,136 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { View, Pressable, StyleSheet } from 'react-native';
+import { PrevRidesExpandChevron } from './PrevRidesExpandChevron';
+import { PrevRidesExpandedPanel } from './PrevRidesExpandedPanel';
+import { PrevRidesRowProps, PrevRidesSlotRect } from './types';
+
+export interface PrevRidesCornerPanelProps {
+    /**
+     * Only render the chevron/panel affordance when the corner slot's active `cornerWidget`
+     * cycle state is `'prevRides'` — `false` for every other state (`'elevation'`/`'workout'`).
+     * Also force-collapses the panel if it happens to be open when the cycle moves away.
+     */
+    active: boolean;
+    /**
+     * The corner slot's own geometry — the same rect the elevation/workout corner widget already
+     * occupies. This component only overlays the chevron/panel on top of it; the slot's own
+     * condensed content (e.g. the "current position + gap to nearest rival" line) is owned by
+     * the caller and rendered as `children`, underneath the chevron.
+     */
+    slotRect: PrevRidesSlotRect;
+    screenHeight: number;
+    /** The full, already-sorted `select()` result for the expanded panel. */
+    rows: PrevRidesRowProps[];
+    /** Uncontrolled by default (`false`) — set to start already expanded (e.g. in Storybook). */
+    defaultExpanded?: boolean;
+    /** Called when the chevron opens the panel — component-level callback; the real
+     *  `RidePageService` wiring is session 3.1's job. */
+    onExpandPrevRides?: () => void;
+    /** Called when the panel closes, whichever of the three ways that happens: re-tapping the
+     *  chevron, tapping outside the panel, or the corner slot cycling away from `'prevRides'`. */
+    onCollapsePrevRides?: () => void;
+    /** Stand-in for `RidePageService.setPrevRidesVisibleRows()` — see `PrevRidesExpandedPanel`. */
+    onVisibleRowsChange?: (visibleRows: number) => void;
+    /** The condensed slot's own content — not owned by this component. */
+    children?: React.ReactNode;
+}
+
+/**
+ * Phone-only interaction layer for the previous-rides corner slot: the chevron affordance plus
+ * the expand/collapse panel it opens. Purely presentational — no `incyclist-services` dependency.
+ * Dismissal follows `RideMenu`'s own pattern (a full-screen underlay behind the panel, tapped to
+ * close) rather than a timer: the panel stays open until the chevron is tapped again or the
+ * rider taps anywhere outside it.
+ */
+export const PrevRidesCornerPanel = (props: PrevRidesCornerPanelProps) => {
+    const {
+        active,
+        slotRect,
+        screenHeight,
+        rows,
+        defaultExpanded = false,
+        onExpandPrevRides,
+        onCollapsePrevRides,
+        onVisibleRowsChange,
+        children,
+    } = props;
+    const [expanded, setExpanded] = useState(defaultExpanded);
+
+    const collapse = useCallback(() => {
+        setExpanded(false);
+        onCollapsePrevRides?.();
+    }, [onCollapsePrevRides]);
+
+    const toggle = useCallback(() => {
+        setExpanded((wasExpanded) => {
+            if (wasExpanded) {
+                onCollapsePrevRides?.();
+            } else {
+                onExpandPrevRides?.();
+            }
+            return !wasExpanded;
+        });
+    }, [onExpandPrevRides, onCollapsePrevRides]);
+
+    // The panel can only ever be shown while the slot itself is showing prevRides — if the
+    // cornerWidget cycle moves on (to elevation/workout) while the panel happens to be open,
+    // force it closed rather than leaving an orphaned panel anchored to a slot that no longer
+    // shows prevRides content.
+    useEffect(() => {
+        if (!active && expanded) {
+            collapse();
+        }
+    }, [active, expanded, collapse]);
+
+    const panelVisible = active && expanded;
+
+    return (
+        <>
+            {panelVisible && (
+                <Pressable
+                    testID="prev-rides-panel-backdrop"
+                    style={[StyleSheet.absoluteFill, styles.backdrop]}
+                    onPress={collapse}
+                    accessibilityLabel="Dismiss previous rides panel"
+                />
+            )}
+
+            <View
+                testID="prev-rides-corner-slot"
+                style={[
+                    styles.slot,
+                    {
+                        top: slotRect.top,
+                        left: slotRect.left,
+                        right: slotRect.right,
+                        width: slotRect.width,
+                        height: slotRect.height,
+                    },
+                ]}
+            >
+                {children}
+                {active && <PrevRidesExpandChevron expanded={expanded} onPress={toggle} />}
+            </View>
+
+            {panelVisible && (
+                <PrevRidesExpandedPanel
+                    rows={rows}
+                    anchor={slotRect}
+                    screenHeight={screenHeight}
+                    onVisibleRowsChange={onVisibleRowsChange}
+                />
+            )}
+        </>
+    );
+};
+
+const styles = StyleSheet.create({
+    slot: {
+        position: 'absolute',
+        zIndex: 10,
+    },
+    backdrop: {
+        zIndex: 9,
+        backgroundColor: 'transparent',
+    },
+});

--- a/src/components/PrevRides/PrevRidesExpandChevron.test.tsx
+++ b/src/components/PrevRides/PrevRidesExpandChevron.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { PrevRidesExpandChevron } from './PrevRidesExpandChevron';
+
+describe('PrevRidesExpandChevron', () => {
+    it('renders a chevron pointing down when collapsed', () => {
+        const { getByLabelText } = render(<PrevRidesExpandChevron expanded={false} onPress={jest.fn()} />);
+        expect(getByLabelText('Expand previous rides')).toBeTruthy();
+    });
+
+    it('renders a chevron pointing up when expanded', () => {
+        const { getByLabelText } = render(<PrevRidesExpandChevron expanded={true} onPress={jest.fn()} />);
+        expect(getByLabelText('Collapse previous rides')).toBeTruthy();
+    });
+
+    it('calls onPress when tapped', () => {
+        const onPress = jest.fn();
+        const { getByTestId } = render(<PrevRidesExpandChevron expanded={false} onPress={onPress} />);
+
+        fireEvent.press(getByTestId('prev-rides-expand-chevron'));
+
+        expect(onPress).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/components/PrevRides/PrevRidesExpandChevron.tsx
+++ b/src/components/PrevRides/PrevRidesExpandChevron.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Pressable, StyleSheet } from 'react-native';
+import { Icon } from '../Icon';
+import { colors } from '../../theme';
+
+export interface PrevRidesExpandChevronProps {
+    expanded: boolean;
+    onPress: () => void;
+}
+
+/**
+ * The phone corner slot's expand/collapse affordance. A small, separate `Pressable` from the
+ * slot's own cycle-tap handler (elevation ↔ workout ↔ prevRides) — the caller overlays this on
+ * top of the condensed slot, and tapping it must never also advance that cycle, just as tapping
+ * the rest of the slot must never open the panel.
+ *
+ * Reuses the existing `chevron-down`/`chevron-up` glyphs (`Icon`'s `IconName` union already has
+ * both) rather than adding a new icon — same collapsed-points-down / expanded-points-up
+ * convention already used by `WorkoutsTable`'s section toggle and `RouteImportDialog`'s
+ * `CompleteView` error disclosure.
+ */
+export const PrevRidesExpandChevron = ({ expanded, onPress }: PrevRidesExpandChevronProps) => (
+    <Pressable
+        testID="prev-rides-expand-chevron"
+        onPress={onPress}
+        hitSlop={8}
+        style={styles.chevron}
+        accessibilityRole="button"
+        accessibilityLabel={expanded ? 'Collapse previous rides' : 'Expand previous rides'}
+    >
+        <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={14} color={colors.text} />
+    </Pressable>
+);
+
+const styles = StyleSheet.create({
+    chevron: {
+        position: 'absolute',
+        right: 2,
+        bottom: 2,
+        width: 18,
+        height: 18,
+        borderRadius: 9,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'rgba(0,0,0,0.55)',
+        zIndex: 12,
+    },
+});

--- a/src/components/PrevRides/PrevRidesExpandedPanel.test.tsx
+++ b/src/components/PrevRides/PrevRidesExpandedPanel.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { PrevRidesExpandedPanel } from './PrevRidesExpandedPanel';
+import { MOCK_ROWS } from './PrevRidesRow.mock';
+import { PrevRidesSlotRect } from './types';
+
+// Reference frame's condensed corner slot (design doc §2.6/§6.3): ~169×47dp at the bottom-right.
+const REFERENCE_SLOT: PrevRidesSlotRect = { top: 41, right: 0, width: 169, height: 47 };
+const REFERENCE_SCREEN_HEIGHT = 390; // 844×390
+
+describe('PrevRidesExpandedPanel', () => {
+    it('renders a header and one row per rider up to its computed budget', () => {
+        const { getByText, queryAllByTestId } = render(
+            <PrevRidesExpandedPanel rows={MOCK_ROWS} anchor={REFERENCE_SLOT} screenHeight={REFERENCE_SCREEN_HEIGHT} />
+        );
+
+        expect(getByText('Previous Rides')).toBeTruthy();
+        // All 5 mock rows fit comfortably in the ~257dp freed band at the reference frame.
+        expect(queryAllByTestId('prev-rides-row')).toHaveLength(MOCK_ROWS.length);
+    });
+
+    it('renders only compact-tier fields on each row (no avatar/speed/power/heartrate)', () => {
+        const { getByText, queryByText } = render(
+            <PrevRidesExpandedPanel rows={MOCK_ROWS} anchor={REFERENCE_SLOT} screenHeight={REFERENCE_SCREEN_HEIGHT} />
+        );
+
+        expect(getByText('12.05.2026')).toBeTruthy(); // MOCK_ROW_LEADER's label
+        expect(queryByText('32.4 km/h')).toBeNull(); // tablet-only speed stat
+    });
+
+    it('clamps to the rows that fit rather than overflowing on a tight frame', () => {
+        const tightSlot: PrevRidesSlotRect = { top: 20, right: 0, width: 169, height: 47 };
+        const { queryAllByTestId } = render(
+            <PrevRidesExpandedPanel rows={MOCK_ROWS} anchor={tightSlot} screenHeight={200} />
+        );
+
+        // earFreeBand = 200 - 24 - 67 - 16 = 93 -> floor((93-22)/24) = 2 rows.
+        expect(queryAllByTestId('prev-rides-row')).toHaveLength(2);
+    });
+
+    it('never shows fewer than one row even when the free band is negative', () => {
+        const tinySlot: PrevRidesSlotRect = { top: 100, right: 0, width: 169, height: 47 };
+        const { queryAllByTestId } = render(
+            <PrevRidesExpandedPanel rows={MOCK_ROWS} anchor={tinySlot} screenHeight={180} />
+        );
+
+        expect(queryAllByTestId('prev-rides-row')).toHaveLength(1);
+    });
+
+    it('reports the computed visible-row budget via onVisibleRowsChange', () => {
+        const onVisibleRowsChange = jest.fn();
+        render(
+            <PrevRidesExpandedPanel
+                rows={MOCK_ROWS}
+                anchor={REFERENCE_SLOT}
+                screenHeight={REFERENCE_SCREEN_HEIGHT}
+                onVisibleRowsChange={onVisibleRowsChange}
+            />
+        );
+
+        // earFreeBand = 390 - 46.8 - 88 - 16 = 239.2 -> floor((239.2-22)/24) = 9, clamped to 10 max (unaffected here).
+        expect(onVisibleRowsChange).toHaveBeenCalledWith(9);
+    });
+
+    it('renders no rows beyond the data it was given even when the budget allows more', () => {
+        const { queryAllByTestId } = render(
+            <PrevRidesExpandedPanel rows={[MOCK_ROWS[0]]} anchor={REFERENCE_SLOT} screenHeight={REFERENCE_SCREEN_HEIGHT} />
+        );
+
+        expect(queryAllByTestId('prev-rides-row')).toHaveLength(1);
+    });
+});

--- a/src/components/PrevRides/PrevRidesExpandedPanel.tsx
+++ b/src/components/PrevRides/PrevRidesExpandedPanel.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useMemo } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { PrevRidesRow } from './PrevRidesRow';
+import { PrevRidesRowProps, PrevRidesSlotRect } from './types';
+import { colors, textSizes } from '../../theme';
+import { SLOT_GAP, BOTTOM_BAR_RATIO } from '../../hooks/render/useRideOverlayLayout';
+
+/**
+ * Mirrors the reserved-slot prototype's ghost sizing (`RideOverlayPrototype.stories.tsx`) — the
+ * same 24/22 dp budget the tablet ear already uses. Not currently exported from
+ * `useRideOverlayLayout.ts`, so pinned here at the identical values rather than imported.
+ */
+const PHASE3_ROW_HEIGHT = 24;
+const PHASE3_HEADER_HEIGHT = 22;
+const MIN_VISIBLE_ROWS = 1;
+const MAX_VISIBLE_ROWS = 10;
+
+const clamp = (value: number, min: number, max: number): number => Math.min(Math.max(value, min), max);
+
+export interface PrevRidesExpandedPanelProps {
+    /** The full, already-sorted `select()` result — this component only trims it to what fits. */
+    rows: PrevRidesRowProps[];
+    /** The corner slot's own rect — the panel grows downward from its bottom edge. */
+    anchor: PrevRidesSlotRect;
+    screenHeight: number;
+    /**
+     * Reports how many rows the panel's own height budget can show. Stands in for
+     * `RidePageService.setPrevRidesVisibleRows()`, which the currently pinned `incyclist-services`
+     * version does not export yet — wiring this to the real service call is session 3.1's job.
+     */
+    onVisibleRowsChange?: (visibleRows: number) => void;
+}
+
+/**
+ * Phone-only expanded previous-rides panel: anchored to the corner slot's position, growing
+ * downward into the freed band between the slot's bottom edge and the top of the bottom
+ * elevation strip — the same `earFreeBand`/`visibleRows` computation the tablet ear already uses,
+ * just anchored at the slot's own bottom edge instead of the elevation widget's.
+ */
+export const PrevRidesExpandedPanel = ({ rows, anchor, screenHeight, onVisibleRowsChange }: PrevRidesExpandedPanelProps) => {
+    const anchorBottom = anchor.top + anchor.height;
+    const earFreeBand = screenHeight - BOTTOM_BAR_RATIO * screenHeight - anchorBottom - 2 * SLOT_GAP;
+    const visibleRows = clamp(
+        Math.floor((earFreeBand - PHASE3_HEADER_HEIGHT) / PHASE3_ROW_HEIGHT),
+        MIN_VISIBLE_ROWS,
+        MAX_VISIBLE_ROWS
+    );
+
+    useEffect(() => {
+        onVisibleRowsChange?.(visibleRows);
+    }, [visibleRows, onVisibleRowsChange]);
+
+    const visibleRowData = useMemo(() => rows.slice(0, visibleRows), [rows, visibleRows]);
+    const panelHeight = PHASE3_HEADER_HEIGHT + visibleRowData.length * PHASE3_ROW_HEIGHT;
+
+    return (
+        <View
+            testID="prev-rides-expanded-panel"
+            style={[
+                styles.panel,
+                {
+                    top: anchorBottom + SLOT_GAP,
+                    left: anchor.left,
+                    right: anchor.right,
+                    width: anchor.width,
+                    height: panelHeight,
+                },
+            ]}
+        >
+            <Text style={styles.header}>Previous Rides</Text>
+            {visibleRowData.map((row, index) => (
+                <PrevRidesRow key={`${row.position}-${index}`} {...row} layout="compact" />
+            ))}
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    panel: {
+        position: 'absolute',
+        backgroundColor: 'rgba(0,0,0,0.75)',
+        borderRadius: 4,
+        paddingHorizontal: 4,
+        overflow: 'hidden',
+        zIndex: 11,
+        elevation: 11,
+    },
+    header: {
+        height: PHASE3_HEADER_HEIGHT,
+        lineHeight: PHASE3_HEADER_HEIGHT,
+        color: colors.text,
+        fontSize: textSizes.tinyText,
+        fontWeight: '700',
+        opacity: 0.8,
+    },
+});

--- a/src/components/PrevRides/index.ts
+++ b/src/components/PrevRides/index.ts
@@ -1,3 +1,6 @@
 export * from './PrevRidesRow';
 export * from './PrevRiderAvatar';
+export * from './PrevRidesExpandChevron';
+export * from './PrevRidesExpandedPanel';
+export * from './PrevRidesCornerPanel';
 export * from './types';

--- a/src/components/PrevRides/types.ts
+++ b/src/components/PrevRides/types.ts
@@ -35,3 +35,16 @@ export interface PrevRidesRowComponentProps extends PrevRidesRowProps {
      *  rows computes it once and every row stays a plain, easily-tested pure component. */
     layout: ScreenLayout;
 }
+
+/**
+ * The phone corner slot's own geometry (top/left-or-right/width/height) — mirrors
+ * `useRideOverlayLayout()`'s `Rect` shape without importing it, since this component tree only
+ * ever needs a plain rect, not the hook's full layout-decision machinery.
+ */
+export interface PrevRidesSlotRect {
+    top: number;
+    left?: number;
+    right?: number;
+    width: number;
+    height: number;
+}


### PR DESCRIPTION
## Summary

- Phone-only interaction layer for the previous-rides corner slot: a small chevron overlay (a separate tap target from the slot's own elevation/workout/prevRides cycle toggle) and the expand/collapse panel it opens.
- The panel anchors to the corner slot's position and grows downward into the freed band between the slot's bottom edge and the top of the bottom elevation strip, rendering `PrevRidesRow` (compact tier) up to whatever height budget it computes.
- Dismisses on re-tapping the chevron or tapping anywhere outside the panel. No auto-dismiss timer.
- Purely presentational — no `incyclist-services` dependency. `onExpandPrevRides`/`onCollapsePrevRides` and a visible-row-count callback are plain component props; the currently pinned `incyclist-services` version doesn't yet publish the corresponding page-service method or types, so real service wiring is left for a later session.

## What changed

- `src/components/PrevRides/PrevRidesExpandChevron.tsx` — the small chevron `Pressable`, reusing the existing `chevron-down`/`chevron-up` icons (no new icon added).
- `src/components/PrevRides/PrevRidesExpandedPanel.tsx` — the expanded panel: computes how many rows fit in the freed band below the corner slot (mirroring the tablet ear's own row-budget formula, just anchored at the slot's bottom edge) and renders that many `PrevRidesRow` instances, clamped to the data available.
- `src/components/PrevRides/PrevRidesCornerPanel.tsx` — composing wrapper: owns the local expanded/collapsed state, renders the chevron overlay and a tap-outside-to-dismiss backdrop, and forwards `onExpandPrevRides`/`onCollapsePrevRides`/visible-row-count callbacks.
- `src/components/PrevRides/types.ts` — added `PrevRidesSlotRect`, a plain rect type mirroring the corner-slot geometry shape.
- `src/components/PrevRides/index.ts` — exports the new components.
- Stories: collapsed (condensed) state, collapsed with the affordance hidden (not the active cycle state), expanded state at the reference 844×390 frame, a short-field variant, and a tighter frame confirming the panel clamps rather than overflowing.

## Test plan

- [x] `npm test` — all suites pass except one pre-existing, unrelated failure in `FreeMapView.android.test.tsx` (confirmed present on this branch before these changes, via `git stash`).
- [x] `npm run lint` — 0 errors (pre-existing warnings elsewhere in the repo, none touching these files).
- [x] `npx tsc --noEmit` — clean.
- [x] New unit tests cover: chevron icon/label swap and press handling, panel row-budget/clamping math across multiple frame sizes and `onVisibleRowsChange` reporting, and the composing wrapper's active/expand/collapse/backdrop/force-collapse behavior.
- [ ] Visual review in Storybook (left for the reviewer, per the request to keep this PR in draft until reviewed there).