### PR TITLE
Fix Ride Again always routing through Devices screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "axios": "^1.17.0",
         "events": "^3.3.0",
         "gd-eventlog": "^0.1.27",
-        "incyclist-services": "^1.7.116",
+        "incyclist-services": "^1.7.117",
         "mqtt": "^5.15.2",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
@@ -11830,9 +11830,9 @@
       }
     },
     "node_modules/incyclist-services": {
-      "version": "1.7.116",
-      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.116.tgz",
-      "integrity": "sha512-M5vBoU2Kkvu08VgictCyTkQ1W4YmsBfgmtXOJObTL6Ao6exUi/ebVo+w4XMYriS5Gg7GmC/zGAFV3t+ndlQq2Q==",
+      "version": "1.7.117",
+      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.117.tgz",
+      "integrity": "sha512-fh52RME8davs1MkwhiQCrtby5dZSePbBPY89AsgNSZn6/hn768U2a/DH1zBbsgkJ3sQK56sSca8KkR3Va2CF7Q==",
       "dependencies": {
         "@garmin/fitsdk": "^21.213.0",
         "axios": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "axios": "^1.17.0",
     "events": "^3.3.0",
     "gd-eventlog": "^0.1.27",
-    "incyclist-services": "^1.7.116",
+    "incyclist-services": "^1.7.117",
     "mqtt": "^5.15.2",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",

--- a/src/pages/ActivitiesPage/ActivitiesPage.rideAgain.test.tsx
+++ b/src/pages/ActivitiesPage/ActivitiesPage.rideAgain.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { ActivitiesPage } from './ActivitiesPage';
+
+const mockOnRideAgain = jest.fn();
+const mockRoute = { id: 'route-1', title: 'Route 1' };
+
+jest.mock('../../services', () => ({
+    navigate: jest.fn(),
+}));
+
+jest.mock('incyclist-services', () => ({
+    getActivitiesPageService: () => ({
+        openPage: () => null,
+        closePage: () => {},
+        getPageDisplayProps: () => ({
+            loading: false,
+            activities: [],
+            detailActivityId: 'activity-1',
+        }),
+        onOpenActivity: () => {},
+        onCloseActivity: () => {},
+        onRideAgain: mockOnRideAgain,
+    }),
+    useAppState: () => ({ getState: jest.fn(), setState: jest.fn() }),
+    useWorkoutCalendar: () => ({
+        getScheduledToday: jest.fn(),
+        on: jest.fn(),
+        off: jest.fn(),
+    }),
+}));
+
+jest.mock('../../components', () => {
+    const { View, Text } = require('react-native');
+    return {
+        MainBackground: ({ children }: any) => children,
+        NavigationBar: () => null,
+        ActivitiesTable: () => null,
+        ErrorBoundary: ({ children }: any) => children,
+        ScheduledWorkoutPromptModal: () => null,
+        ListPageShell: ({ title, headerLeft, headerRight, belowHeader, children }: any) => (
+            <View>
+                <Text>{title}</Text>
+                {headerLeft}
+                {headerRight}
+                {belowHeader}
+                {children}
+            </View>
+        ),
+        // Stands in for the real dialog: fires onRideAgain with a resolved route as soon as it
+        // mounts, so the test can assert what ActivitiesPage does with it.
+        ActivityDetailsDialog: (props: any) => {
+            props.onRideAgain(mockRoute);
+            return null;
+        },
+    };
+});
+
+describe('ActivitiesPage - Ride Again', () => {
+    beforeEach(() => {
+        mockOnRideAgain.mockClear();
+    });
+
+    it('routes Ride Again through the page service with the resolved route, not a hardcoded navigate', () => {
+        const { navigate } = require('../../services');
+
+        render(<ActivitiesPage />);
+
+        expect(mockOnRideAgain).toHaveBeenCalledWith(mockRoute);
+        expect(navigate).not.toHaveBeenCalledWith('pairingStart');
+    });
+});

--- a/src/pages/ActivitiesPage/ActivitiesPage.tsx
+++ b/src/pages/ActivitiesPage/ActivitiesPage.tsx
@@ -90,7 +90,7 @@ export const ActivitiesPage = () => {
         navigate(item);
     }, []);
     
-    const handleRideAgain = useCallback(() => navigate('pairingStart'), []);
+    const handleRideAgain = useCallback((route: any) => service.onRideAgain(route), [service]);
 
 
     return (


### PR DESCRIPTION
## Summary

From the Activities list, "Ride Again" on a past activity always routed the user through the Devices/pairing screen, regardless of whether devices were already connected — unlike the Routes/Workouts "Start Ride" flow, which skips that screen when devices are ready.

The Ride Again handler in `ActivitiesPage.tsx` discarded the resolved route and hardcoded `navigate('pairingStart')` instead of making a real decision based on device state.

## What changed

- `ActivitiesPage`'s Ride Again handler now calls the new `ActivitiesPageService.onRideAgain(route)` (from `incyclist-services`) with the route resolved by `ActivityListService.rideAgain()`, instead of ignoring it and hardcoding the pairing screen.
- The page service checks device pairing readiness and navigates straight to the ride or to pairing accordingly — the same behavior Routes/Workouts already have.

This PR depends on the companion `incyclist-services` change that adds `ActivitiesPageService.onRideAgain()`.

## Test plan

- [x] `npm test` — all unit tests pass, including a new test asserting the Ride Again handler calls the page service with the resolved route instead of a hardcoded navigate
- [x] `npm run lint` — clean (no new warnings/errors)
- [x] `npx tsc --noEmit` — clean