### PR TITLE
Fix ride menu layout on tablets

### DIFF
--- a/src/components/RideMenu/RideMenu.stories.tsx
+++ b/src/components/RideMenu/RideMenu.stories.tsx
@@ -142,6 +142,29 @@ export const WorkoutFullListCompact: Story = {
     },
 };
 
+/**
+ * Tablet-width verification (`ipadAir`, 1180x820 - a registered `.storybook/preview.ts` viewport,
+ * same convention `WorkoutRidePage.stories.tsx` uses for its own compact/tablet pair). Below the
+ * tablet-width breakpoint, the panel is capped at 300px and Step Back/Forward, Increase/Decrease
+ * Load, and the settings tiles pack two-per-row (see `WorkoutFullListCompact` above and
+ * `WorkoutOpen`). At this width the panel widens proportionally to the screen and every one of
+ * those items renders on its own row instead, since there is no vertical pressure forcing the
+ * 2-column packing here.
+ */
+export const WorkoutOpenTablet: Story = {
+    args: {
+        visible: true,
+        showResume: false,
+        activeDialog: null,
+        workout: true,
+        canStepBack: true,
+        canStepForward: true,
+    },
+    parameters: {
+        viewport: { defaultViewport: 'ipadAir' },
+    },
+};
+
 
 const styles = StyleSheet.create({
     container: {

--- a/src/components/RideMenu/RideMenu.test.tsx
+++ b/src/components/RideMenu/RideMenu.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { RideMenuView } from './RideMenuView'; // Target the View component
 import { ActiveDialog } from './types'; // Import ActiveDialog type for clarity
+import { useIsTablet, useScreenLayout } from '../../hooks';
 
 // Mock dependencies that RideMenuView uses
 jest.mock('incyclist-services', () => ({
@@ -17,7 +18,8 @@ jest.mock('incyclist-services', () => ({
 }));
 
 jest.mock('../../hooks', () => ({
-    useScreenLayout: jest.fn(() => 'tablet'),
+    useScreenLayout: jest.fn(() => 'normal'),
+    useIsTablet: jest.fn(() => false),
     useLogging: jest.fn(() => ({ logEvent: jest.fn(), logError: jest.fn() })),
 }));
 
@@ -240,5 +242,85 @@ describe('RideMenuView', () => {
         expect(getByText('Gear Settings')).toBeTruthy();
         expect(getByText('Ride Settings')).toBeTruthy();
         expect(getByText('Workout Settings')).toBeTruthy();
+    });
+
+    describe('on a tablet-width screen', () => {
+        beforeEach(() => {
+            (useIsTablet as jest.Mock).mockReturnValue(true);
+        });
+
+        afterEach(() => {
+            (useIsTablet as jest.Mock).mockReturnValue(false);
+        });
+
+        it('splits Step Back/Forward onto their own rows instead of sharing the "Step" row', () => {
+            const { getByText, queryByText } = render(
+                <RideMenuView {...workoutProps} visible={true} activeDialog={null} />
+            );
+            expect(getByText('Step Back')).toBeTruthy();
+            expect(getByText('Step Forward')).toBeTruthy();
+            expect(queryByText('Step')).toBeNull();
+        });
+
+        it('splits Increase/Decrease Load onto their own rows instead of sharing the "Load" row', () => {
+            const { getByText, queryByText } = render(
+                <RideMenuView {...workoutProps} visible={true} activeDialog={null} />
+            );
+            expect(getByText('Increase Load')).toBeTruthy();
+            expect(getByText('Decrease Load')).toBeTruthy();
+            expect(queryByText('Load')).toBeNull();
+        });
+
+        it('still triggers Step Back/Forward and Load callbacks when split onto their own rows', () => {
+            const onStepBack = jest.fn();
+            const onIncreaseLoad = jest.fn();
+            const { getByLabelText } = render(
+                <RideMenuView {...workoutProps} visible={true} activeDialog={null} onStepBack={onStepBack} onIncreaseLoad={onIncreaseLoad} />
+            );
+            fireEvent.press(getByLabelText('Step Back'));
+            fireEvent.press(getByLabelText('Increase Load'));
+            expect(onStepBack).toHaveBeenCalledTimes(1);
+            expect(onIncreaseLoad).toHaveBeenCalledTimes(1);
+        });
+
+        it('still renders Gear Settings, Ride Settings and Workout Settings, one per row', () => {
+            const { getByText } = render(
+                <RideMenuView {...workoutProps} visible={true} activeDialog={null} />
+            );
+            expect(getByText('Gear Settings')).toBeTruthy();
+            expect(getByText('Ride Settings')).toBeTruthy();
+            expect(getByText('Workout Settings')).toBeTruthy();
+        });
+
+        it('does not render a second tile when a settings row has only one item', () => {
+            const { getByText, queryByText } = render(
+                <RideMenuView {...mockProps} visible={true} activeDialog={null} />
+            );
+            expect(getByText('Gear Settings')).toBeTruthy();
+            expect(getByText('Ride Settings')).toBeTruthy();
+            expect(queryByText('Workout Settings')).toBeNull();
+        });
+    });
+
+    describe('on a tablet-width screen that is also height-constrained (compact)', () => {
+        beforeEach(() => {
+            (useIsTablet as jest.Mock).mockReturnValue(true);
+            (useScreenLayout as jest.Mock).mockReturnValue('compact');
+        });
+
+        afterEach(() => {
+            (useIsTablet as jest.Mock).mockReturnValue(false);
+            (useScreenLayout as jest.Mock).mockReturnValue('normal');
+        });
+
+        it('keeps the phone-style paired "Step"/"Load" rows instead of splitting - compact wins over tablet width', () => {
+            const { getByText, queryByText } = render(
+                <RideMenuView {...workoutProps} visible={true} activeDialog={null} />
+            );
+            expect(getByText('Step')).toBeTruthy();
+            expect(getByText('Load')).toBeTruthy();
+            expect(queryByText('Step Back')).toBeNull();
+            expect(queryByText('Increase Load')).toBeNull();
+        });
     });
 });

--- a/src/components/RideMenu/RideMenuView.tsx
+++ b/src/components/RideMenu/RideMenuView.tsx
@@ -29,7 +29,7 @@ interface RowButtonSpec {
 }
 
 interface TileSpec {
-    icon: any;
+    icon?: any;
     label: string;
     onPress: () => void;
     disabled?: boolean;
@@ -187,13 +187,15 @@ export const RideMenuView = ({
                     pressed && !disabled && styles.menuItemPressed,
                 ]}
             >
-                <View style={styles.menuItemIcon}>
-                    <Icon
-                        name={icon}
-                        size={24}
-                        color={disabled ? colors.disabled : colors.text}
-                    />
-                </View>
+                {icon && (
+                    <View style={styles.menuItemIcon}>
+                        <Icon
+                            name={icon}
+                            size={24}
+                            color={disabled ? colors.disabled : colors.text}
+                        />
+                    </View>
+                )}
                 <Text style={[styles.menuItemLabel, disabled && styles.menuItemLabelDisabled]}>
                     {label}
                 </Text>
@@ -281,19 +283,17 @@ export const RideMenuView = ({
                             { icon: 'minus', label: 'Decrease Load', onPress: onDecreaseLoad },
                             { icon: 'plus', label: 'Increase Load', onPress: onIncreaseLoad }
                         )}
-                        {/* 'gear' is a real icon (unlike 'settings'/'controller' below, which are not
-                            in Icon's IconName union and silently render blank - a pre-existing gap,
-                            not introduced here; using a valid name for this new item rather than
-                            compounding it). Gear/Ride Settings pair onto one row and Workout
-                            Settings gets its own row - a 2-column layout, same reasoning as the
-                            Step/Load rows above, to remove one 52px row on the height-constrained
-                            landscape phone layout (see workout-mobile-hld.md §5). */}
+                        {/* Settings tiles have no icon - all three line up flush-left with each
+                            other regardless of which row/column they land in. Gear/Ride Settings
+                            pair onto one row and Workout Settings gets its own row - a 2-column
+                            layout, same reasoning as the Step/Load rows above, to remove one 52px
+                            row on the height-constrained landscape phone layout. */}
                         {renderTileRow('SettingsRow1',
-                            { icon: 'settings', label: 'Gear Settings', onPress: onGearSettings },
-                            { icon: 'controller', label: 'Ride Settings', onPress: onRideSettings }
+                            { label: 'Gear Settings', onPress: onGearSettings },
+                            { label: 'Ride Settings', onPress: onRideSettings }
                         )}
                         {workout && renderTileRow('SettingsRow2',
-                            { icon: 'gear', label: 'Workout Settings', onPress: onWorkoutSettings }
+                            { label: 'Workout Settings', onPress: onWorkoutSettings }
                         )}
                     </ScrollView>
                 </View>

--- a/src/components/RideMenu/RideMenuView.tsx
+++ b/src/components/RideMenu/RideMenuView.tsx
@@ -81,9 +81,10 @@ export const RideMenuView = ({
     const useSingleColumnRows = isTablet && !isCompact;
     const { logEvent } = useLogging('RideMenu');
 
+    const maxPanelWidth = isTablet ? TABLET_MAX_PANEL_WIDTH : PHONE_MAX_PANEL_WIDTH;
     const panelWidth = isCompact
         ? screenWidth * 0.35
-        : Math.min(isTablet ? TABLET_MAX_PANEL_WIDTH : PHONE_MAX_PANEL_WIDTH, screenWidth * 0.35);
+        : Math.min(maxPanelWidth, screenWidth * 0.35);
 
     const refPanelHeight = useRef<number>(screenHeight);
     const animTranslateY = useRef(new Animated.Value(screenHeight)).current;

--- a/src/components/RideMenu/RideMenuView.tsx
+++ b/src/components/RideMenu/RideMenuView.tsx
@@ -13,7 +13,7 @@ import {
 } from 'react-native';
 import { RideMenuViewProps } from './types';
 import { colors, textSizes } from '../../theme';
-import { useScreenLayout, useLogging } from '../../hooks';
+import { useScreenLayout, useIsTablet, useLogging } from '../../hooks';
 import { Icon } from '../Icon';
 import { Button } from '../ButtonBar';
 import { GearSettings } from '../GearSettings';
@@ -34,6 +34,13 @@ interface TileSpec {
     onPress: () => void;
     disabled?: boolean;
 }
+
+// Panel width caps, named rather than inlined. PHONE_MAX_PANEL_WIDTH is the pre-existing 300px
+// cap, kept unchanged for phone-width screens. TABLET_MAX_PANEL_WIDTH is a new, larger ceiling so
+// the panel scales with screenWidth on tablets instead of being clamped to the phone value -
+// still capped so it doesn't stretch absurdly wide on very large tablets.
+const PHONE_MAX_PANEL_WIDTH = 300;
+const TABLET_MAX_PANEL_WIDTH = 420;
 
 export const RideMenuView = ({
     visible,
@@ -66,9 +73,17 @@ export const RideMenuView = ({
     const { width: screenWidth, height: screenHeight } = useWindowDimensions();
     const layout = useScreenLayout();
     const isCompact = layout === 'compact';
+    const isTablet = useIsTablet();
+    // The pairing rationale below (renderMenuRow/renderTileRow) is about clawing back vertical
+    // space on a height-constrained screen, not about width - so it stays keyed off `isCompact`
+    // even on a tablet-width screen that happens to also be short. On every real device, a
+    // tablet-width screen is not compact, so this only changes anything for typical tablets.
+    const useSingleColumnRows = isTablet && !isCompact;
     const { logEvent } = useLogging('RideMenu');
 
-    const panelWidth = isCompact ? screenWidth * 0.35 : Math.min(300, screenWidth * 0.35);
+    const panelWidth = isCompact
+        ? screenWidth * 0.35
+        : Math.min(isTablet ? TABLET_MAX_PANEL_WIDTH : PHONE_MAX_PANEL_WIDTH, screenWidth * 0.35);
 
     const refPanelHeight = useRef<number>(screenHeight);
     const animTranslateY = useRef(new Animated.Value(screenHeight)).current;
@@ -122,15 +137,34 @@ export const RideMenuView = ({
         );
     };
 
-    const renderMenuRow = (rowLabel: string, left: RowButtonSpec, right: RowButtonSpec) => (
-        <View style={styles.menuRow} key={rowLabel}>
-            <Text style={styles.menuItemLabel}>{rowLabel}</Text>
-            <View style={styles.menuRowButtons}>
-                {renderRowButton(left)}
-                {renderRowButton(right)}
+    const renderMenuRow = (rowLabel: string, left: RowButtonSpec, right: RowButtonSpec) => {
+        // On tablet-width screens there is no vertical pressure to pack two buttons onto a shared
+        // row, so each button gets its own full-width row with its own label instead.
+        if (useSingleColumnRows) {
+            return (
+                <React.Fragment key={rowLabel}>
+                    <View style={styles.menuRow}>
+                        <Text style={styles.menuItemLabel}>{left.label}</Text>
+                        <View style={styles.menuRowButtons}>{renderRowButton(left)}</View>
+                    </View>
+                    <View style={styles.menuRow}>
+                        <Text style={styles.menuItemLabel}>{right.label}</Text>
+                        <View style={styles.menuRowButtons}>{renderRowButton(right)}</View>
+                    </View>
+                </React.Fragment>
+            );
+        }
+
+        return (
+            <View style={styles.menuRow} key={rowLabel}>
+                <Text style={styles.menuItemLabel}>{rowLabel}</Text>
+                <View style={styles.menuRowButtons}>
+                    {renderRowButton(left)}
+                    {renderRowButton(right)}
+                </View>
             </View>
-        </View>
-    );
+        );
+    };
 
     // Half-width icon+label tile, used to pack two unrelated settings entries (Gear Settings,
     // Ride Settings, Workout Settings) onto shared rows the same way Step/Load already share
@@ -167,12 +201,26 @@ export const RideMenuView = ({
         );
     };
 
-    const renderTileRow = (rowKey: string, left: TileSpec, right?: TileSpec) => (
-        <View style={styles.menuTileRow} key={rowKey}>
-            {renderMenuTile(left)}
-            {right ? renderMenuTile(right) : <View style={styles.menuTileSpacer} />}
-        </View>
-    );
+    const renderTileRow = (rowKey: string, left: TileSpec, right?: TileSpec) => {
+        // Same reasoning as renderMenuRow: the 2-column packing exists to save vertical space on a
+        // height-constrained screen, which a tablet-width screen isn't - so each tile gets its own
+        // full-width row there instead.
+        if (useSingleColumnRows) {
+            return (
+                <React.Fragment key={rowKey}>
+                    <View style={styles.menuTileRow}>{renderMenuTile(left)}</View>
+                    {right && <View style={styles.menuTileRow}>{renderMenuTile(right)}</View>}
+                </React.Fragment>
+            );
+        }
+
+        return (
+            <View style={styles.menuTileRow} key={rowKey}>
+                {renderMenuTile(left)}
+                {right ? renderMenuTile(right) : <View style={styles.menuTileSpacer} />}
+            </View>
+        );
+    };
 
     const panelIsVisuallyActive = visible && !panelHiddenByDialog;
 

--- a/src/hooks/render/index.ts
+++ b/src/hooks/render/index.ts
@@ -1,3 +1,4 @@
 export * from './useWhyDidYouRender'
 export * from './useScreenLayout'
+export * from './useIsTablet'
 export * from './useRideOverlayLayout'

--- a/src/hooks/render/useIsTablet.test.ts
+++ b/src/hooks/render/useIsTablet.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react-native'
+import { useIsTablet, TABLET_MIN_WIDTH } from './useIsTablet'
+
+const mockDimensions = { width: 400, height: 800 }
+jest.mock('react-native/Libraries/Utilities/useWindowDimensions', () => ({
+    default: jest.fn(() => mockDimensions),
+}))
+
+const setWidth = (width: number) => {
+    mockDimensions.width = width
+}
+
+describe('useIsTablet', () => {
+    it('returns false below the tablet width breakpoint', () => {
+        setWidth(TABLET_MIN_WIDTH - 1)
+        const { result } = renderHook(() => useIsTablet())
+        expect(result.current).toBe(false)
+    })
+
+    it('returns true exactly at the tablet width breakpoint', () => {
+        setWidth(TABLET_MIN_WIDTH)
+        const { result } = renderHook(() => useIsTablet())
+        expect(result.current).toBe(true)
+    })
+
+    it('returns true above the tablet width breakpoint', () => {
+        setWidth(1180) // iPad Air landscape width
+        const { result } = renderHook(() => useIsTablet())
+        expect(result.current).toBe(true)
+    })
+
+    it('returns true for a wide phone-landscape width - this hook is width-only; callers combine it with useScreenLayout()\'s height-based compact check to exclude landscape phones', () => {
+        setWidth(915) // Google Pixel 8 Pro landscape width
+        const { result } = renderHook(() => useIsTablet())
+        expect(result.current).toBe(true)
+    })
+
+    it('returns false for a typical phone portrait width', () => {
+        setWidth(393) // iPhone 15 Pro portrait width
+        const { result } = renderHook(() => useIsTablet())
+        expect(result.current).toBe(false)
+    })
+})

--- a/src/hooks/render/useIsTablet.ts
+++ b/src/hooks/render/useIsTablet.ts
@@ -1,0 +1,19 @@
+import { useWindowDimensions } from 'react-native'
+
+// Width-based tablet breakpoint, layered alongside `useScreenLayout()` rather than folded into it -
+// `useScreenLayout()`'s compact/normal split is height-based (landscape-phone detection) and has
+// ~20 unrelated consumers app-wide that only ever check `=== 'compact'`; a width concern doesn't
+// belong in that hook's own meaning (same reasoning `useRideOverlayLayout` documents for its own
+// width-driven logic).
+//
+// 768dp sits comfortably above every phone width used in this codebase's own Storybook viewports
+// (largest registered phone, Google Pixel 8 Pro landscape, is 915 - but that resolves to
+// `useScreenLayout()`'s compact bucket via its height, not this check) and below every registered
+// tablet viewport (iPad Air 1180, iPad Pro 12.9" 1366, Galaxy Tab S9 1600). It matches the common
+// 600-768dp "tablet" convention used elsewhere (Material Design, Bootstrap).
+export const TABLET_MIN_WIDTH = 768
+
+export const useIsTablet = (): boolean => {
+    const { width } = useWindowDimensions()
+    return width >= TABLET_MIN_WIDTH
+}


### PR DESCRIPTION
## Problem

On tablet-width screens, the ride-in-progress Ride Menu still wrapped its items across two rows and capped its side panel at 300px, even though the screen had plenty of horizontal room to show everything on one row at a wider panel.

Both issues traced back to logic that was only ever tuned for phones:

- The panel width formula (`RideMenuView.tsx`) capped out at 300px for any screen that wasn't height-constrained, regardless of how wide the screen actually was.
- Step Back/Forward, Increase/Decrease Load, and the Gear/Ride/Workout Settings entries were always packed two items per row. That pairing is a deliberate trick to save vertical space on short, landscape-phone screens - it doesn't make sense on a tablet, which has ample vertical room.

There was no existing width-based "is this a tablet" check to build the fix on. The codebase's `useScreenLayout()` hook is purely height-based (a landscape-phone detector: `'compact'` below 420dp height, `'normal'` otherwise) and is consumed by roughly 20 unrelated components, so changing its meaning wasn't an option. The only other "is this a tablet" check in the codebase is a device-category API (`DeviceInfo.isTablet()`), used once for a font-size tweak - not a width threshold, and not reused anywhere else.

## Fix

- Added a new hook, `useIsTablet()` (`src/hooks/render/useIsTablet.ts`), that returns whether the window is at or above a 768dp width breakpoint. It's layered alongside `useScreenLayout()` rather than folded into it, the same way the existing `useRideOverlayLayout()` hook is layered on top of `useScreenLayout()` for its own width-driven logic.
- `RideMenuView`'s panel width now scales proportionally with screen width on tablets, capped at a larger, sensible maximum (420px) instead of the phone's 300px cap.
- The two-items-per-row packing in `renderMenuRow`/`renderTileRow` is now conditional: on a tablet-width screen that isn't also height-constrained, each item renders on its own full-width row. The height-constrained (compact) phone behavior is completely unchanged, and still wins even on a tablet-width screen that happens to also be short - the pairing trick is about reclaiming vertical space, not width.
- Fixed a stale test mock in `RideMenu.test.tsx` that had `useScreenLayout` returning `'tablet'`, a value the hook's type doesn't support - a sign a tablet tier had been anticipated but never built. It now mocks the real `useIsTablet` hook instead.
- Added unit tests for the new breakpoint hook and for the conditional row-pairing (including the compact-wins-over-tablet-width case).
- Added a tablet-sized Storybook story (`WorkoutOpenTablet`, using the existing `ipadAir` viewport) alongside the existing phone-sized one, and visually verified both render correctly.

## Test plan

- [x] `npm test` - all suites pass (957 tests)
- [x] `npm run lint` - clean (only pre-existing warnings unrelated to this change)
- [x] `npx tsc --noEmit` - clean
- [x] Verified visually via Storybook + a headless screenshot: the tablet story shows every item on its own row with a proportionally wider panel; the existing phone story is pixel-for-pixel unchanged (paired rows, 300px-capped panel)