### PR TITLE
Wire up Activities delete: swipe-to-delete list UI + fix post-ride Delete stub

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "axios": "^1.17.0",
         "events": "^3.3.0",
         "gd-eventlog": "^0.1.27",
-        "incyclist-services": "^1.7.116",
+        "incyclist-services": "^1.7.117",
         "mqtt": "^5.15.2",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
@@ -11830,9 +11830,9 @@
       }
     },
     "node_modules/incyclist-services": {
-      "version": "1.7.116",
-      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.116.tgz",
-      "integrity": "sha512-M5vBoU2Kkvu08VgictCyTkQ1W4YmsBfgmtXOJObTL6Ao6exUi/ebVo+w4XMYriS5Gg7GmC/zGAFV3t+ndlQq2Q==",
+      "version": "1.7.117",
+      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.117.tgz",
+      "integrity": "sha512-fh52RME8davs1MkwhiQCrtby5dZSePbBPY89AsgNSZn6/hn768U2a/DH1zBbsgkJ3sQK56sSca8KkR3Va2CF7Q==",
       "dependencies": {
         "@garmin/fitsdk": "^21.213.0",
         "axios": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "axios": "^1.17.0",
     "events": "^3.3.0",
     "gd-eventlog": "^0.1.27",
-    "incyclist-services": "^1.7.116",
+    "incyclist-services": "^1.7.117",
     "mqtt": "^5.15.2",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",

--- a/src/components/ActivitiesTable/ActivitiesTable.test.tsx
+++ b/src/components/ActivitiesTable/ActivitiesTable.test.tsx
@@ -14,7 +14,7 @@ jest.mock('../Dynamic', () => ({
 }));
 
 jest.mock('../ActivityListItem', () => ({
-    ActivityListItem: () => null,
+    ActivityListItem: jest.fn(() => null),
     ACTIVITY_LIST_ITEM_HEIGHT: 72,
 }));
 
@@ -26,11 +26,24 @@ const MOCK_ACTIVITIES = [
 ] as any;
 
 describe('ActivitiesTable', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     it('renders empty array without crashing', () => {
-        render(<ActivitiesTable activities={[]} onSelect={jest.fn()} />);
+        render(<ActivitiesTable activities={[]} onSelect={jest.fn()} onDelete={jest.fn()} />);
     });
 
     it('renders with one item without crashing', () => {
-        render(<ActivitiesTable activities={MOCK_ACTIVITIES} onSelect={jest.fn()} />);
+        render(<ActivitiesTable activities={MOCK_ACTIVITIES} onSelect={jest.fn()} onDelete={jest.fn()} />);
+    });
+
+    it('passes onDelete through to ActivityListItem', () => {
+        const { ActivityListItem } = require('../ActivityListItem');
+        const onDelete = jest.fn();
+        render(<ActivitiesTable activities={MOCK_ACTIVITIES} onSelect={jest.fn()} onDelete={onDelete} />);
+
+        const [props] = ActivityListItem.mock.calls[0];
+        expect(props).toEqual(expect.objectContaining({ onDelete }));
     });
 });

--- a/src/components/ActivitiesTable/ActivitiesTable.tsx
+++ b/src/components/ActivitiesTable/ActivitiesTable.tsx
@@ -10,7 +10,7 @@ import { colors, textSizes } from '../../theme';
 const LOOKAHEAD = 5;
 const ITEM_HEIGHT = ACTIVITY_LIST_ITEM_HEIGHT + 8; // Height (72) + marginVertical (4 * 2)
 
-export const ActivitiesTable = ({ activities, onSelect }: ActivitiesTableProps) => {
+export const ActivitiesTable = ({ activities, onSelect, onDelete }: ActivitiesTableProps) => {
     const refObserver = useRef<Observer | null>(null);
     const refInitialized = useRef(false);
 
@@ -83,6 +83,7 @@ export const ActivitiesTable = ({ activities, onSelect }: ActivitiesTableProps) 
                         <ActivityListItem
                             activityInfo={activity}
                             onPress={onSelect}
+                            onDelete={onDelete}
                             outsideFold={initialFoldState[index]}
                         />
                     </Dynamic>

--- a/src/components/ActivitiesTable/types.ts
+++ b/src/components/ActivitiesTable/types.ts
@@ -3,4 +3,5 @@ import { ActivityInfoUI } from 'incyclist-services';
 export interface ActivitiesTableProps {
     activities: ActivityInfoUI[];
     onSelect: (id: string) => void;
+    onDelete: (id: string) => void;
 }

--- a/src/components/ActivityListItem/ActivityListItem.test.tsx
+++ b/src/components/ActivityListItem/ActivityListItem.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, fireEvent } from '@testing-library/react-native';
 import { ActivityListItem } from './ActivityListItem';
 
 jest.mock('incyclist-services', () => ({
@@ -36,6 +36,7 @@ const MOCK_FORMATTED = {
         },
     },
     onPress: jest.fn(),
+    onDelete: jest.fn(),
 } as any;
 
 describe('ActivityListItem', () => {
@@ -45,6 +46,15 @@ describe('ActivityListItem', () => {
 
     it('renders outsideFold placeholder without crashing', () => {
         render(<ActivityListItem {...MOCK_FORMATTED} outsideFold={true} />);
+    });
+
+    it('calls onDelete with the activity id when the swipe delete action is pressed', () => {
+        const onDelete = jest.fn();
+        const { getByText } = render(<ActivityListItem {...MOCK_FORMATTED} onDelete={onDelete} />);
+
+        fireEvent.press(getByText('Delete'));
+
+        expect(onDelete).toHaveBeenCalledWith('1');
     });
 
     // FIXES_BACKLOG.md item #54: services used to hand out { value: undefined, unit } for

--- a/src/components/ActivityListItem/ActivityListItem.tsx
+++ b/src/components/ActivityListItem/ActivityListItem.tsx
@@ -8,7 +8,7 @@ import { useLogging } from '../../hooks';
 const detailsCache = new Map<string, ActivityDetails>();
 
 export const ActivityListItem = memo((props: ActivityListItemProps) => {
-    const { activityInfo, onPress, outsideFold = false } = props;
+    const { activityInfo, onPress, onDelete, outsideFold = false } = props;
     const { summary, details: initialDetails } = activityInfo;
     const { id, startTime, rideTime, distance } = summary;
 
@@ -65,6 +65,11 @@ export const ActivityListItem = memo((props: ActivityListItemProps) => {
         onPress(id);
     }, [logEvent, id, displayTitle, onPress]);
 
+    const handleDelete = useCallback(() => {
+        logEvent({message:'item deleted', id, title:displayTitle, eventSource:'user' })
+        onDelete(id);
+    }, [logEvent, id, displayTitle, onDelete]);
+
     const dateStr = formatDateTime(new Date(startTime), '%d.%m.%Y');
     const timeStr = formatDateTime(new Date(startTime), '%H:%M');
 
@@ -108,6 +113,7 @@ export const ActivityListItem = memo((props: ActivityListItemProps) => {
             compact={false}
             outsideFold={outsideFold}
             onPress={handlePress}
+            onDelete={handleDelete}
         />
     );
 });

--- a/src/components/ActivityListItem/ActivityListItemView.test.tsx
+++ b/src/components/ActivityListItem/ActivityListItemView.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, fireEvent } from '@testing-library/react-native';
 import { ActivityListItemView } from './ActivityListItemView';
 import { ActivityListItemViewProps } from './types';
 
@@ -16,6 +16,7 @@ const MOCK_PROPS: ActivityListItemViewProps = {
     compact: false,
     outsideFold: false,
     onPress: () => {},
+    onDelete: () => {},
 };
 
 describe('ActivityListItemView', () => {
@@ -33,5 +34,14 @@ describe('ActivityListItemView', () => {
 
     it('renders when outside fold', () => {
         render(<ActivityListItemView {...MOCK_PROPS} outsideFold={true} />);
+    });
+
+    it('calls onDelete when the swipe delete action is pressed', () => {
+        const onDelete = jest.fn();
+        const { getByText } = render(<ActivityListItemView {...MOCK_PROPS} onDelete={onDelete} />);
+
+        fireEvent.press(getByText('Delete'));
+
+        expect(onDelete).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/components/ActivityListItem/ActivityListItemView.tsx
+++ b/src/components/ActivityListItem/ActivityListItemView.tsx
@@ -1,9 +1,27 @@
 import React, { memo } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, Platform } from 'react-native';
 import { ActivityListItemViewProps, ACTIVITY_LIST_ITEM_HEIGHT } from './types';
 import { ActivityGraphPreview } from '../ActivityGraphPreview';
 import { colors, textSizes } from '../../theme';
 import { Icon } from '../Icon';
+
+// Conditional import to prevent Storybook Vite from crashing — same pattern as RouteItemView.
+// The fallback renders renderRightActions inline (rather than discarding it) so the delete
+// action is still reachable in Storybook/web and in this file's own unit tests, where
+// react-native-gesture-handler's native Swipeable is unavailable.
+let Swipeable: any = View;
+try {
+    if (Platform.OS !== 'web') {
+        Swipeable = require('react-native-gesture-handler').Swipeable;
+    }
+} catch {
+    Swipeable = ({ children, renderRightActions }: any) => (
+        <View>
+            {children}
+            {renderRightActions?.()}
+        </View>
+    );
+}
 
 export const ActivityListItemView = memo((props: ActivityListItemViewProps) => {
     const {
@@ -20,6 +38,7 @@ export const ActivityListItemView = memo((props: ActivityListItemViewProps) => {
         outsideFold,
         ftp,
         onPress,
+        onDelete,
     } = props;
 
     if (outsideFold) {
@@ -32,40 +51,48 @@ export const ActivityListItemView = memo((props: ActivityListItemViewProps) => {
         compact && styles.compactContainer
     ];
 
-    return (
-        <TouchableOpacity style={containerStyle} onPress={onPress} activeOpacity={0.7}>
-            <View style={styles.leftSection}>
-                {hasLogs ? (
-                    <ActivityGraphPreview width={80} height={64} activity={details} ftp={ftp??200} />
-                ) : (
-                    <View style={styles.placeholder} />
-                )}
-            </View>
-
-            <View style={styles.centerSection}>
-                <Text style={styles.title} numberOfLines={1}>
-                    {title}
-                </Text>
-                <Text style={styles.dateTime}>
-                    {dateStr}{'  '}{timeStr}{'  '}{durationStr}
-                </Text>
-            </View>
-
-            <View style={styles.metricsSection}>
-                <View style={styles.metricColumn}>
-                    <Icon name="distance" size={16} color={colors.text} />
-                    <Text style={styles.metricValue}>{distanceValue}</Text>
-                    <Text style={styles.metricUnit}>{distanceUnit}</Text>
-                </View>
-                {elevationValue !== '' && (
-                    <View style={styles.metricColumn}>
-                        <Icon name="elevation" size={16} color={colors.text} />
-                        <Text style={styles.metricValue}>{elevationValue}</Text>
-                        <Text style={styles.metricUnit}>{elevationUnit}</Text>
-                    </View>
-                )}
-            </View>
+    const renderRightActions = () => (
+        <TouchableOpacity style={styles.deleteAction} onPress={onDelete}>
+            <Text style={styles.deleteText}>Delete</Text>
         </TouchableOpacity>
+    );
+
+    return (
+        <Swipeable renderRightActions={renderRightActions}>
+            <TouchableOpacity style={containerStyle} onPress={onPress} activeOpacity={0.7}>
+                <View style={styles.leftSection}>
+                    {hasLogs ? (
+                        <ActivityGraphPreview width={80} height={64} activity={details} ftp={ftp??200} />
+                    ) : (
+                        <View style={styles.placeholder} />
+                    )}
+                </View>
+
+                <View style={styles.centerSection}>
+                    <Text style={styles.title} numberOfLines={1}>
+                        {title}
+                    </Text>
+                    <Text style={styles.dateTime}>
+                        {dateStr}{'  '}{timeStr}{'  '}{durationStr}
+                    </Text>
+                </View>
+
+                <View style={styles.metricsSection}>
+                    <View style={styles.metricColumn}>
+                        <Icon name="distance" size={16} color={colors.text} />
+                        <Text style={styles.metricValue}>{distanceValue}</Text>
+                        <Text style={styles.metricUnit}>{distanceUnit}</Text>
+                    </View>
+                    {elevationValue !== '' && (
+                        <View style={styles.metricColumn}>
+                            <Icon name="elevation" size={16} color={colors.text} />
+                            <Text style={styles.metricValue}>{elevationValue}</Text>
+                            <Text style={styles.metricUnit}>{elevationUnit}</Text>
+                        </View>
+                    )}
+                </View>
+            </TouchableOpacity>
+        </Swipeable>
     );
 });
 
@@ -148,5 +175,18 @@ const styles = StyleSheet.create({
         color: colors.text,
         fontSize: textSizes.smallText,
         textAlign: 'center',
+    },
+    deleteAction: {
+        backgroundColor: colors.error,
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: 80,
+        height: ACTIVITY_LIST_ITEM_HEIGHT,
+        marginVertical: 4,
+        borderRadius: 8,
+    },
+    deleteText: {
+        color: '#FFFFFF',
+        fontWeight: 'bold',
     },
 });

--- a/src/components/ActivityListItem/types.ts
+++ b/src/components/ActivityListItem/types.ts
@@ -3,6 +3,7 @@ import { ActivityInfoUI, ActivityDetails } from 'incyclist-services';
 export interface ActivityListItemProps {
     activityInfo: ActivityInfoUI;
     onPress: (id: string) => void;
+    onDelete: (id: string) => void;
     outsideFold?: boolean;
 }
 
@@ -20,6 +21,7 @@ export interface ActivityListItemViewProps {
     outsideFold: boolean;
     ftp?:number
     onPress: () => void;
+    onDelete: () => void;
 }
 
 export const ACTIVITY_LIST_ITEM_HEIGHT = 72;

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialog.test.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialog.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { useActivityRide } from 'incyclist-services';
+import { ActivitySummaryDialog } from './ActivitySummaryDialog';
+
+jest.mock('incyclist-services', () => ({
+    useActivityRide: jest.fn(),
+}));
+
+jest.mock('react-native-share', () => ({ default: { open: jest.fn() } }));
+jest.mock('react-native-mmkv', () => ({ createMMKV: jest.fn() }));
+jest.mock('react-native-fs', () => ({
+    CachesDirectoryPath: '/cache',
+    copyFile: jest.fn(),
+    writeFile: jest.fn(),
+}));
+
+jest.mock('../../hooks', () => ({
+    useLogging: () => ({ logEvent: jest.fn(), logError: jest.fn() }),
+}));
+
+jest.mock('./ActivitySummaryDialogView', () => {
+    const { TouchableOpacity, Text } = require('react-native');
+    return {
+        ActivitySummaryDialogView: ({ onDeleteConfirm }: any) => (
+            <TouchableOpacity onPress={onDeleteConfirm}>
+                <Text>ConfirmDelete</Text>
+            </TouchableOpacity>
+        ),
+    };
+});
+
+const mockUseActivityRide = useActivityRide as jest.Mock;
+
+describe('ActivitySummaryDialog', () => {
+    const onClose = jest.fn();
+    const onExit = jest.fn();
+
+    const baseDisplayProps = {
+        activity: { id: '1' },
+        showMap: false,
+        showSave: true,
+        showContinue: true,
+    };
+
+    beforeEach(() => {
+        onClose.mockClear();
+        onExit.mockClear();
+    });
+
+    // Mirrors the actual mobile flow: "End Ride" already autosaved the activity by the time this
+    // dialog mounts, so the ride is 'paused' rather than 'completed' - this is the branch of
+    // ActivityRideService.delete() that waits for the 'completed' event before removing the saved
+    // record. From this component's point of view that just means delete() is a slow-resolving
+    // promise; the test asserts the call is awaited regardless.
+    it('calls service.delete(), awaits it, and only exits after it resolves', async () => {
+        let resolveDelete: () => void;
+        const deletePromise = new Promise<void>(resolve => { resolveDelete = resolve; });
+        const deleteMock = jest.fn(() => deletePromise);
+
+        mockUseActivityRide.mockReturnValue({
+            getActivitySummaryDisplayProperties: () => baseDisplayProps,
+            save: jest.fn(),
+            delete: deleteMock,
+        });
+
+        const { getByText } = render(<ActivitySummaryDialog onClose={onClose} onExit={onExit} />);
+
+        fireEvent.press(getByText('ConfirmDelete'));
+
+        expect(deleteMock).toHaveBeenCalledTimes(1);
+        // onExit() must not fire until the delete promise actually resolves
+        expect(onExit).not.toHaveBeenCalled();
+
+        resolveDelete!();
+        await waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
+    });
+
+    it('logs the error and does not call onExit() when service.delete() rejects', async () => {
+        const deleteMock = jest.fn(() => Promise.reject(new Error('boom')));
+
+        mockUseActivityRide.mockReturnValue({
+            getActivitySummaryDisplayProperties: () => baseDisplayProps,
+            save: jest.fn(),
+            delete: deleteMock,
+        });
+
+        const { getByText } = render(<ActivitySummaryDialog onClose={onClose} onExit={onExit} />);
+
+        fireEvent.press(getByText('ConfirmDelete'));
+
+        await waitFor(() => expect(deleteMock).toHaveBeenCalledTimes(1));
+        expect(onExit).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/ActivitySummaryDialog/ActivitySummaryDialog.tsx
+++ b/src/components/ActivitySummaryDialog/ActivitySummaryDialog.tsx
@@ -52,12 +52,16 @@ export const ActivitySummaryDialog = ({ onClose, onExit }: ActivitySummaryDialog
         setShowDeleteConfirm(true);
     }, []);
 
-    const handleDeleteConfirm = useCallback(() => {
+    const handleDeleteConfirm = useCallback(async () => {
         logEvent({ message: 'delete confirmed' });
         setShowDeleteConfirm(false);
-        // activityRide.delete() will be wired in follow-up
-        onExit();
-    }, [onExit, logEvent]);
+        try {
+            await service.delete();
+            onExit();
+        } catch (err: any) {
+            logError(err as Error, 'handleDeleteConfirm');
+        }
+    }, [service, onExit, logEvent, logError]);
 
     const handleDeleteCancel = useCallback(() => {
         setShowDeleteConfirm(false);

--- a/src/pages/ActivitiesPage/ActivitiesPage.test.tsx
+++ b/src/pages/ActivitiesPage/ActivitiesPage.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, fireEvent } from '@testing-library/react-native';
 import { ActivitiesPage } from './ActivitiesPage';
 
 jest.mock('../../services', () => ({
@@ -10,17 +10,22 @@ jest.mock('../../components/ActivityDetailsDialog', () => ({
     ActivityDetailsDialog: () => null,
 }));
 
+const mockOnDeleteActivity = jest.fn().mockResolvedValue(true);
+
 jest.mock('incyclist-services', () => ({
     getActivitiesPageService: () => ({
         openPage: () => null,
         closePage: () => {},
         getPageDisplayProps: () => ({
-            loading: true,
-            activities: [],
+            loading: false,
+            activities: [
+                { summary: { id: 'activity-42', title: 'Activity', startTime: Date.now(), rideTime: 100, distance: 1000 } },
+            ],
             detailActivityId: undefined
         }),
         onOpenActivity: () => {},
         onCloseActivity: () => {},
+        onDeleteActivity: (id: string) => mockOnDeleteActivity(id),
     }),
     // Needed by useScheduledWorkoutPrompt (session 5.7), which every content page - including
     // ActivitiesPage - now calls.
@@ -33,11 +38,15 @@ jest.mock('incyclist-services', () => ({
 }));
 
 jest.mock('../../components', () => {
-    const { View, Text } = require('react-native');
+    const { View, Text, TouchableOpacity } = require('react-native');
     return {
         MainBackground: ({ children }: any) => children,
         NavigationBar: () => null,
-        ActivitiesTable: () => null,
+        ActivitiesTable: ({ onDelete }: any) => (
+            <TouchableOpacity onPress={() => onDelete('activity-42')}>
+                <Text>DeleteActivity</Text>
+            </TouchableOpacity>
+        ),
         ErrorBoundary: ({ children }: any) => children,
         ScheduledWorkoutPromptModal: () => null,
         ListPageShell: ({ title, headerLeft, headerRight, belowHeader, children }: any) => (
@@ -55,11 +64,19 @@ jest.mock('../../components', () => {
 describe('ActivitiesPage', () => {
     it('renders without crashing when observer is null', () => {
         const { toJSON } = render(
-            <ActivitiesPage 
-                
-                
+            <ActivitiesPage
+
+
             />
         );
         expect(toJSON()).toBeDefined();
+    });
+
+    it('calls the page service delete method when an activity is deleted', () => {
+        const { getByText } = render(<ActivitiesPage />);
+
+        fireEvent.press(getByText('DeleteActivity'));
+
+        expect(mockOnDeleteActivity).toHaveBeenCalledWith('activity-42');
     });
 });

--- a/src/pages/ActivitiesPage/ActivitiesPage.tsx
+++ b/src/pages/ActivitiesPage/ActivitiesPage.tsx
@@ -86,6 +86,10 @@ export const ActivitiesPage = () => {
         service.onCloseActivity();
     }, [service]);
 
+    const onDeleteActivity = useCallback((id: string) => {
+        service.onDeleteActivity(id).catch((err: any) => logError(err, 'onDeleteActivity'));
+    }, [service, logError]);
+
     const onNavigate = useCallback((item: TNavigationItem) => {
         navigate(item);
     }, []);
@@ -95,9 +99,10 @@ export const ActivitiesPage = () => {
 
     return (
         <ErrorBoundary>
-            <ActivitiesPageView 
+            <ActivitiesPageView
                 props={props}
                 onSelectActivity={onSelectActivity}
+                onDeleteActivity={onDeleteActivity}
                 onNavigate={onNavigate}
             />
             {props.detailActivityId && (

--- a/src/pages/ActivitiesPage/ActivitiesPageView.test.tsx
+++ b/src/pages/ActivitiesPage/ActivitiesPageView.test.tsx
@@ -36,8 +36,9 @@ describe('ActivitiesPageView', () => {
         const { toJSON } = render(
             <ActivitiesPageView 
                 props={props} 
-                onSelectActivity={jest.fn()} 
-                onNavigate={jest.fn()} 
+                onSelectActivity={jest.fn()}
+                onDeleteActivity={jest.fn()}
+                onNavigate={jest.fn()}
             />
         );
         expect(toJSON()).toBeDefined();
@@ -48,8 +49,9 @@ describe('ActivitiesPageView', () => {
         const { getByText } = render(
             <ActivitiesPageView 
                 props={props} 
-                onSelectActivity={jest.fn()} 
-                onNavigate={jest.fn()} 
+                onSelectActivity={jest.fn()}
+                onDeleteActivity={jest.fn()}
+                onNavigate={jest.fn()}
             />
         );
         expect(getByText('No activities found')).toBeDefined();
@@ -68,8 +70,9 @@ describe('ActivitiesPageView', () => {
         const { toJSON } = render(
             <ActivitiesPageView 
                 props={props as any} 
-                onSelectActivity={jest.fn()} 
-                onNavigate={jest.fn()} 
+                onSelectActivity={jest.fn()}
+                onDeleteActivity={jest.fn()}
+                onNavigate={jest.fn()}
             />
         );
         expect(toJSON()).toBeDefined();

--- a/src/pages/ActivitiesPage/ActivitiesPageView.tsx
+++ b/src/pages/ActivitiesPage/ActivitiesPageView.tsx
@@ -7,10 +7,11 @@ import { colors, textSizes } from '../../theme';
 export interface ActivitiesPageViewProps {
     props: ActivitiesPageDisplayProps | null;
     onSelectActivity: (id: string) => void;
+    onDeleteActivity: (id: string) => void;
     onNavigate: (item: TNavigationItem) => void;
 }
 
-export const ActivitiesPageView = ({ props, onSelectActivity, onNavigate }: ActivitiesPageViewProps) => {
+export const ActivitiesPageView = ({ props, onSelectActivity, onDeleteActivity, onNavigate }: ActivitiesPageViewProps) => {
     const { height } = useWindowDimensions();
     const compact = height < 420;
     const activities = props?.activities ?? [];
@@ -34,7 +35,7 @@ export const ActivitiesPageView = ({ props, onSelectActivity, onNavigate }: Acti
                 </View>
             }
             { !isLoading && activities.length >0 &&
-                <ActivitiesTable activities={activities} onSelect={onSelectActivity} />
+                <ActivitiesTable activities={activities} onSelect={onSelectActivity} onDelete={onDeleteActivity} />
             }
         </ListPageShell>
     );


### PR DESCRIPTION
## Summary

Two independent gaps that both come down to the same thing: activity deletion was never fully wired up on mobile, even though the underlying domain delete already works (the web UI uses it today).

**1. Activities list has no delete UI at all.** Routes and Workouts both support swipe-to-delete on their list rows; Activities had no equivalent anywhere in its chain (`ActivitiesTable`, `ActivityListItem`, `ActivitiesPage`).

**2. The post-ride "Delete" button was an unfinished stub.** After a ride ends, the Save/Delete dialog's delete-confirm handler just closed the dialog - it never called the domain delete method. Since the ride service autosaves on every ride-state transition (including immediately on "End Ride"), the activity is already persisted by the time this dialog shows, so "Delete" needs to actively undo that save, and previously did nothing, so a "deleted" activity would reappear in the list.

## What changed

**Swipe-to-delete on the Activities list:**
- Added a `Swipeable` "Delete" action to `ActivityListItemView`, mirroring the existing `RouteItemView` pattern (including a web/Storybook fallback that still renders the revealed action, since a plain discard-and-render-children fallback would silently hide the delete button outside native RN).
- Threaded an `onDelete(id)` callback from `ActivitiesPage` down through `ActivitiesPageView` -> `ActivitiesTable` -> `ActivityListItem`, calling a new page-service method (`onDeleteActivity`, added in a companion `incyclist-services` change).
- Deletes immediately on tap, no confirmation dialog - matching the existing Routes/Workouts behavior for consistency.

**Post-ride Delete:**
- `ActivitySummaryDialog`'s delete-confirm handler now awaits the ride service's `delete()` before exiting, and logs (without exiting) if it throws.
- Covered the actual mobile timing: delete is triggered right after "End Ride", while ride state is still `paused` rather than `completed` - the branch of `delete()` that waits for the `completed` event before removing the saved record.

## Dependency note

The swipe-to-delete UI calls `ActivitiesPageService.onDeleteActivity()`, added in a companion `incyclist-services` PR. Until that's published and this repo's `incyclist-services` version is bumped, `npx tsc --noEmit` will show a missing-property error for that one call site - verified clean by building the companion `services` branch locally and type-checking against it.

## Test plan

- [x] `npx jest` - full suite passes (952 tests)
- [x] `npm run lint` - clean (pre-existing warnings only, unrelated to this change)
- [x] `npx tsc --noEmit` - clean against the companion `services` branch's build output (see dependency note above)
- [x] New tests: swipe delete action wiring (`ActivityListItemView`, `ActivityListItem`, `ActivitiesTable`, `ActivitiesPage`) and post-ride delete (`ActivitySummaryDialog`, including the delete-while-paused timing and the delete-rejects path)