### PR TITLE
fix: allow full (100%) production rollout on Google Play

### DIFF
--- a/.github/workflows/upload-google-play.yml
+++ b/.github/workflows/upload-google-play.yml
@@ -75,9 +75,17 @@ jobs:
           case "${{ github.event.inputs.track }}" in
             production)
               echo "play_track=production" >> "$GITHUB_OUTPUT"
-              echo "status=inProgress" >> "$GITHUB_OUTPUT"
-              FRACTION=$(awk "BEGIN { printf \"%.2f\", ${{ github.event.inputs.rollout }}/100 }")
-              echo "user_fraction=$FRACTION" >> "$GITHUB_OUTPUT"
+              if [ "${{ github.event.inputs.rollout }}" = "100" ]; then
+                # The Play Developer API requires 0 < userFraction < 1, so a full
+                # rollout must be a "completed" release with no userFraction at all
+                # rather than an "inProgress" release staged at fraction 1.0.
+                echo "status=completed" >> "$GITHUB_OUTPUT"
+                echo "user_fraction=" >> "$GITHUB_OUTPUT"
+              else
+                echo "status=inProgress" >> "$GITHUB_OUTPUT"
+                FRACTION=$(awk "BEGIN { printf \"%.2f\", ${{ github.event.inputs.rollout }}/100 }")
+                echo "user_fraction=$FRACTION" >> "$GITHUB_OUTPUT"
+              fi
               ;;
             open_testing)
               echo "play_track=beta" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Fixes the `upload-google-play` workflow failing when a 100% staged rollout is requested for a production release.

## What changed
- `Resolve release parameters` now treats a rollout of `100` as a full ("completed") release with no `userFraction`, instead of an "inProgress" release staged at `userFraction=1.0`.
- The Play Developer API requires `userFraction` to be strictly between 0 and 1; a value of `1.0` is rejected, which is why the workflow previously failed on a 100% input.
- Any rollout value below 100 keeps the existing staged-rollout behavior.

## Test plan
- [ ] Trigger the workflow manually with `track=production`, `rollout=100` and confirm it uploads as a completed release without error.
- [ ] Trigger the workflow manually with `track=production`, `rollout=10` (or another value < 100) and confirm the staged rollout path still works as before.