### PR TITLE
fix: resolve SonarCloud open RELIABILITY issues

### DIFF
--- a/src/bindings/ble/binding.ts
+++ b/src/bindings/ble/binding.ts
@@ -27,7 +27,10 @@ export class BleBindingRN extends EventEmitter implements BleBinding {
     private permissionsService: PermissionService
 
     public static getInstance(): BleBindingRN {
-        this.instance = this.instance ?? new BleBindingRN()
+        if (!this.instance) {
+            this.instance = new BleBindingRN()
+            this.instance.initializeAuthorization()
+        }
         return this.instance
     }
 
@@ -51,8 +54,6 @@ export class BleBindingRN extends EventEmitter implements BleBinding {
         if (Platform.OS==='android') {
             this.setAuthorized(false)
         }
-        this.initializeAuthorization()
-       
     }
 
     start() {

--- a/src/bindings/ble/peripheral.ts
+++ b/src/bindings/ble/peripheral.ts
@@ -192,7 +192,7 @@ export class BlePeripheralRN
         }
 
         // 1. Convert the Hex Company ID (Big Endian String "0059") into an Integer
-        const companyIdInt = parseInt(companyIdHex, 16);
+        const companyIdInt = Number.parseInt(companyIdHex, 16);
 
         // 2. Extract the Little Endian bytes for the Company ID
         const companyIdByte1 = companyIdInt & 0xFF;        // Low byte (0x59)
@@ -239,7 +239,7 @@ export class BlePeripheralRN
     private normalizeUuid(uuid: string): string {
         return uuid
             .toLowerCase()
-            .replace(/-/g, '')
-    }    
+            .replaceAll('-', '')
+    }
 
 }

--- a/src/bindings/ble/utils.ts
+++ b/src/bindings/ble/utils.ts
@@ -28,7 +28,7 @@ export const parseUUID = (str:string):string => {
         return uuid
     }
     else if (uuid.length===36) {
-        return uuid.replace(/-/g,'')
+        return uuid.replaceAll('-','')
 
     }
     throw new Error(`Invalid UUID: ${uuid}`)

--- a/src/bindings/direct-connect/net/binding.ts
+++ b/src/bindings/direct-connect/net/binding.ts
@@ -23,7 +23,7 @@ class RNSocket extends EventEmitter implements Socket  {
     }
 
     destroy() {
-        this.socket?.destroy
+        this.socket?.destroy()
         delete this.socket
     }
 

--- a/src/bindings/secret/index.ts
+++ b/src/bindings/secret/index.ts
@@ -22,6 +22,8 @@ const isWithinTTL = (fetchedAt: string): boolean => {
     return (Date.now() - time) < (TTL_DAYS * 24 * 60 * 60 * 1000);
 };
 
+const DEFAULT_INIT_OPTIONS: { timeout: number } = { timeout: 5000 };
+
 
 
 export const initSecrets = async ( opts: { timeout: number }) => {
@@ -66,7 +68,7 @@ class SecretBinding {
         return this.currentStatus;       
     }
 
-    async init(opts: { timeout: number } = { timeout: 5000 }): Promise<void> {
+    async init(opts: { timeout: number } = DEFAULT_INIT_OPTIONS): Promise<void> {
         await this.initSecrets(opts);
         this.initPromise = null
     }

--- a/src/bindings/user-settings/index.ts
+++ b/src/bindings/user-settings/index.ts
@@ -143,7 +143,7 @@ class UserSettingsImplementation implements IUserSettingsBinding {
         const appDir = getAppInfo().appDir;
         const fileName = `${appDir}/settings.json`;
 
-        if (this.savePromise) {
+        if (this.savePromise !== null) {
             await this.savePromise;
         }
 

--- a/src/components/ActivityGraph/utils.ts
+++ b/src/components/ActivityGraph/utils.ts
@@ -9,8 +9,8 @@ import {
 
 export const getZoneColor = (power: number, ftp?: number | string): string => {
     try {
-        const parsedFtp = typeof ftp === 'string' ? parseFloat(ftp) : ftp;
-        if (!parsedFtp || isNaN(parsedFtp) || parsedFtp === 0) {
+        const parsedFtp = typeof ftp === 'string' ? Number.parseFloat(ftp) : ftp;
+        if (!parsedFtp || Number.isNaN(parsedFtp) || parsedFtp === 0) {
             return '#7f7f7f';
         }
         const pctFtp = (power / parsedFtp) * 100;
@@ -62,7 +62,7 @@ export const getAvailableMetrics = (logs: ActivityLogRecord[]): ActivityMetric[]
         const metrics: ActivityMetric[] = ['power', 'heartrate', 'speed', 'cadence'];
         return metrics.filter(m => logs.some(log => {
             const val = log[m];
-            return val !== undefined && val !== null && !isNaN(val);
+            return val !== undefined && val !== null && !Number.isNaN(val);
         }));
     } catch (err: any) {
         console.log('# getAvailableMetrics error', err.message);
@@ -100,7 +100,7 @@ export const computeElevationPoints = (
         if (w <= 0 || logs.length === 0) return null;
 
         const xField = xMode === 'distance' ? 'distance' : 'time';
-        const hasElevation = logs.some(log => log.elevation !== undefined && log.elevation !== null && !isNaN(log.elevation));
+        const hasElevation = logs.some(log => log.elevation !== undefined && log.elevation !== null && !Number.isNaN(log.elevation));
         if (!hasElevation) return null;
 
         const xMin = 0;
@@ -119,7 +119,7 @@ export const computeElevationPoints = (
             if (bIdx >= w) bIdx = w - 1;
             if (bIdx < 0) bIdx = 0;
 
-            if (y !== undefined && y !== null && !isNaN(y)) {
+            if (y !== undefined && y !== null && !Number.isNaN(y)) {
                 buckets[bIdx].sumY += y;
                 buckets[bIdx].cntY++;
             }
@@ -180,7 +180,7 @@ export const computeActivitySeries = (
 
             metrics.forEach(m => {
                 const val = log[m];
-                if (val !== undefined && val !== null && !isNaN(val)) {
+                if (val !== undefined && val !== null && !Number.isNaN(val)) {
                     buckets[bIdx].sums[m] = (buckets[bIdx].sums[m] || 0) + val;
                     buckets[bIdx].cnts[m] = (buckets[bIdx].cnts[m] || 0) + 1;
                 }

--- a/src/components/ActivityListItem/ActivityListItem.tsx
+++ b/src/components/ActivityListItem/ActivityListItem.tsx
@@ -93,7 +93,7 @@ export const ActivityListItem = memo((props: ActivityListItemProps) => {
     if (isFormattedNumber(elevation)) {
         elevationValue = Math.round(elevation.value).toString();
         elevationUnit = elevation.unit;
-    } else if (typeof elevation === 'number' && !isNaN(elevation)) {
+    } else if (typeof elevation === 'number' && !Number.isNaN(elevation)) {
         elevationValue = Math.round(elevation).toString();
         elevationUnit = 'm';
     }

--- a/src/components/EditNumber/EditNumber.tsx
+++ b/src/components/EditNumber/EditNumber.tsx
@@ -56,9 +56,9 @@ export const EditNumber = ({
             return;
         }
 
-        const numericValue = parseFloat(internalValue);
+        const numericValue = Number.parseFloat(internalValue);
 
-        if (isNaN(numericValue)) {
+        if (Number.isNaN(numericValue)) {
             // Reject non-numeric input silently (leave text for correction)
             return;
         }
@@ -120,7 +120,7 @@ export const EditNumber = ({
                     keyboardType="numeric"
                     editable={!disabled}
                 />
-                {unit && <Text style={styles.unit}>{unit}</Text>}
+                {!!unit && <Text style={styles.unit}>{unit}</Text>}
             </View>
             {error && (
                 <Text style={[styles.errorText, errorStyle]}>

--- a/src/components/ElevationGraph/utils.ts
+++ b/src/components/ElevationGraph/utils.ts
@@ -63,11 +63,11 @@ const enrichPoints = (original: RoutePoint[], dpp: number): RoutePoint[] => {
                 }
 
                 // Guard: slope may be undefined or NaN — default to 0
-                const slope = isFinite(prev.slope ?? NaN) ? (prev.slope ?? 0) : 0;
+                const slope = Number.isFinite(prev.slope ?? Number.NaN) ? (prev.slope ?? 0) : 0;
                 newPoint.elevation = slope * (newPoint.routeDistance - prev.routeDistance) / 100 + prev.elevation;
 
                 // Guard: if elevation went NaN (e.g. prev.elevation was NaN), inherit parent
-                if (!isFinite(newPoint.elevation)) {
+                if (!Number.isFinite(newPoint.elevation)) {
                     newPoint.elevation = prev.elevation;
                 }
 
@@ -115,7 +115,7 @@ export const domainToPixel = (
     pixelMax: number
 ): number => {
     // Guard: any NaN/Infinity input returns pixelMin to avoid SVG path corruption
-    if (!isFinite(value) || !isFinite(domainMin) || !isFinite(domainMax)) return pixelMin;
+    if (!Number.isFinite(value) || !Number.isFinite(domainMin) || !Number.isFinite(domainMax)) return pixelMin;
     if (domainMax === domainMin) return pixelMin;
     return pixelMin + ((value - domainMin) / (domainMax - domainMin)) * (pixelMax - pixelMin);
 };
@@ -202,7 +202,7 @@ export const computeGraphPoints = (
                 const y = p.elevation * yScale.value;
 
                 // Guard: skip any point with non-finite coordinates — these corrupt SVG paths
-                if (!isFinite(x) || !isFinite(y)) continue;
+                if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
 
                 graphPoints.push({
                     x,

--- a/src/components/FilterPanel/FilterPanel.tsx
+++ b/src/components/FilterPanel/FilterPanel.tsx
@@ -55,8 +55,8 @@ const FilterInput = ({
         const cleaned = text.replace(/[^0-9.]/g, '');
         setLocalValue(cleaned);
         if (cleaned !== '') {
-            const val = parseFloat(cleaned);
-            setError(isNaN(val) || val < 0 || (max !== undefined && val > max));
+            const val = Number.parseFloat(cleaned);
+            setError(Number.isNaN(val) || val < 0 || (max !== undefined && val > max));
         } else {
             setError(false);
         }
@@ -67,8 +67,8 @@ const FilterInput = ({
         if (cleaned === '') {
             onValueChange(undefined);
         } else {
-            const val = parseFloat(cleaned);
-            if (!isNaN(val) && val >= 0 && (max === undefined || val <= max)) {
+            const val = Number.parseFloat(cleaned);
+            if (!Number.isNaN(val) && val >= 0 && (max === undefined || val <= max)) {
                 onValueChange(val);
                 logEvent({ 
                     message: 'text entered', 

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
@@ -97,7 +97,7 @@ export const RouteDetailsDialog = ({ routeId, onStart }: RouteDetailsDialogProps
                 routeId,
                 title,
                 status: 'downloading',
-                pct: parseFloat(pct),                
+                pct: Number.parseFloat(pct),
             })
         };
         const onDone = () => {

--- a/src/components/RouteDetailsDialog/RouteDetailsView.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.tsx
@@ -294,7 +294,7 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
                 <Text style={styles.infoBarText}>
                     {routeType} • {totalDistance.value}{totalDistance.unit} • {totalElevation.value}{totalElevation.unit}
                 </Text>
-                {canNotStartReason && <Text style={styles.errorText}>{canNotStartReason}</Text>}
+                {!!canNotStartReason && <Text style={styles.errorText}>{canNotStartReason}</Text>}
             </View>
         );
 
@@ -358,7 +358,7 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
             </View>
             <View style={styles.settingsArea}>
                 {renderForm()}
-                {canNotStartReason && <Text style={styles.fullErrorText}>{canNotStartReason}</Text>}
+                {!!canNotStartReason && <Text style={styles.fullErrorText}>{canNotStartReason}</Text>}
             </View>
             <DownloadModalView
                 visible={!!showDownloadModal}

--- a/src/pages/LoadingScreen/LoadingScreen.tsx
+++ b/src/pages/LoadingScreen/LoadingScreen.tsx
@@ -25,9 +25,9 @@ export const LoadingScreen = ( {appVersion, bundleVersion, statusMessage}:Loadin
                 style={styles.logo} 
                 resizeMode="contain"
                 />
-                {appVersion && <Text style={styles.versionText}>App Version {appVersion}</Text>}
-                {bundleVersion && <Text style={styles.versionText}>UI Version {bundleVersion}</Text>}
-                {statusMessage && <Text style={styles.versionText}>{statusMessage}</Text>}
+                {!!appVersion && <Text style={styles.versionText}>App Version {appVersion}</Text>}
+                {!!bundleVersion && <Text style={styles.versionText}>UI Version {bundleVersion}</Text>}
+                {!!statusMessage && <Text style={styles.versionText}>{statusMessage}</Text>}
                 <ActivityIndicator size="large" color="#007AFF" />
             </View>
         </SafeAreaView>

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -3,6 +3,6 @@ export const getFlagEmoji = (countryCode?: string): string => {
     const codePoints = countryCode
         .toUpperCase()
         .split('')
-        .map(char => 127397 + char.charCodeAt(0));
+        .map(char => 127397 + (char.codePointAt(0) ?? 0));
     return String.fromCodePoint(...codePoints);
 };


### PR DESCRIPTION
## Summary
Resolves all 36 currently open SonarCloud RELIABILITY-impact issues for this project.

## What changed

**Real bugs (BUG type):**
- `src/bindings/ble/binding.ts`: `BleBindingRN`'s constructor fired an unawaited async `initializeAuthorization()` call (S7059, CRITICAL). Moved it to `getInstance()`, the only place the class is ever constructed, so it still runs exactly once right after construction, just no longer *inside* the constructor.
- `src/bindings/direct-connect/net/binding.ts`: `RNSocket.destroy()` referenced `this.socket.destroy` without calling it — the underlying socket was never actually destroyed (S905). Added the missing `()`.
- `src/bindings/user-settings/index.ts`: `if (this.savePromise)` checked a `Promise<void> | null` for truthiness — a Promise object is always truthy, so this only ever meant "is it not null." Made that explicit with `!== null` (S6544, no behavior change).
- `src/pages/LoadingScreen/LoadingScreen.tsx`, `src/components/EditNumber/EditNumber.tsx`, `src/components/RouteDetailsDialog/RouteDetailsView.tsx`: several `{value && <Text>...}` JSX expressions on optional string props could leak an empty string into the render tree instead of a clean boolean (S6439, MAJOR). Wrapped each in `!!`.

**Code smells (CODE_SMELL type, still RELIABILITY-tagged):**
- `src/bindings/secret/index.ts`: hoisted an object-literal default parameter (`{ timeout: 5000 }`) into a shared `DEFAULT_INIT_OPTIONS` constant (S7737). `opts` is read-only in every call path, so sharing the reference is safe.
- Replaced bare `isNaN`/`parseInt`/`parseFloat`/`isFinite`/`NaN` with their `Number.*` equivalents (more predictable coercion), `String#replace(/x/g)` with `String#replaceAll()`, and `charCodeAt()` with `codePointAt()`, across `ActivityGraph/utils.ts`, `ElevationGraph/utils.ts`, `FilterPanel.tsx`, `EditNumber.tsx`, `ActivityListItem.tsx`, `RouteDetailsDialog.tsx`, `bindings/ble/utils.ts`, `bindings/ble/peripheral.ts` and `utils/flags.ts`.

No behavioral changes intended anywhere except the two real bugs (`RNSocket.destroy()` and the `BleBindingRN` constructor).

## Test plan
- [x] `npx tsc --noEmit` — no new errors (pre-existing unrelated errors on other files untouched by this PR)
- [x] `npx eslint` on all touched files — no errors
- [x] Full `npx jest` suite — 131 suites / 964 tests pass
- [ ] Manual BLE smoke test on a device (authorization prompt still appears correctly after app start), since the `BleBindingRN` constructor change is the one with real behavioral surface