### PR TITLE
fix: stop deferring to npm's injected EDITOR default

### DIFF
--- a/scripts/release-android.js
+++ b/scripts/release-android.js
@@ -230,7 +230,11 @@ function draftWithClaude(baseRef, appVersion) {
 }
 
 function editInEditor(initialContent) {
-    const editor = process.env.EDITOR || process.env.VISUAL || 'nano';
+    // EDITOR is deliberately not consulted here: npm injects its own default (typically 'vi')
+    // into every `npm run` child process whenever EDITOR isn't already set in the parent shell,
+    // so checking it can't distinguish "you actually want vi" from "npm filled it in behind
+    // your back". VISUAL isn't touched by npm, so it's still honored if you set it.
+    const editor = process.env.VISUAL || 'nano';
     const tmpFile = path.join(os.tmpdir(), `incyclist-whatsnew-${Date.now()}.txt`);
     fs.writeFileSync(tmpFile, initialContent);
     try {


### PR DESCRIPTION
## Summary
- `scripts/release-android.js`'s editor selection (`process.env.EDITOR || process.env.VISUAL || 'nano'`) always resolved to `vi` in practice, even for people who never set `EDITOR` themselves.
- Root cause: npm injects `EDITOR=vi` into every `npm run` child process whenever `EDITOR` isn't already set in the parent shell — confirmed empirically (a bare `node -e ...` shows `EDITOR` unset; the identical check run via `npm run` shows `EDITOR=vi`).
- `VISUAL` isn't touched by npm, so it's still honored as an explicit override; `EDITOR` is no longer consulted at all.

## What changed
- `scripts/release-android.js` — editor resolution now `process.env.VISUAL || 'nano'`

## Test plan
- [x] `npm test` — 131 suites / 964 tests pass
- [x] `eslint scripts/release-android.js` clean
- [x] Verified via a temporary npm script that `EDITOR` is `vi` under `npm run` even with the parent shell's `EDITOR` unset, and that the fix resolves to `nano` in that same environment