### PR TITLE
fix: whatsnew-en-US must be a flat file, not a subdirectory

### DIFF
--- a/.github/workflows/upload-google-play.yml
+++ b/.github/workflows/upload-google-play.yml
@@ -125,8 +125,12 @@ jobs:
         id: release_notes
         if: github.event.inputs.releaseTag != ''
         run: |
-          mkdir -p whatsnew/whatsnew-en-US
-          git tag -l --format='%(contents)' "${{ github.event.inputs.releaseTag }}" > whatsnew/whatsnew-en-US/whatsnew
+          # r0adkll/upload-google-play expects whatsNewDirectory to contain flat FILES named
+          # whatsnew-<LOCALE> directly (not a subdirectory per locale) — a nested layout here
+          # made the action try to read whatsnew-en-US as a file and crash with EISDIR since it
+          # found a directory instead.
+          mkdir -p whatsnew
+          git tag -l --format='%(contents)' "${{ github.event.inputs.releaseTag }}" > whatsnew/whatsnew-en-US
           echo "has_notes=true" >> "$GITHUB_OUTPUT"
 
       - name: Upload to Google Play (staged rollout)


### PR DESCRIPTION
## Summary
The real `upload-google-play` run failed after successfully uploading the AAB:

```
Successfully uploaded 1 artifacts
##[error]EISDIR: illegal operation on a directory, read
```
(https://github.com/incyclist/mobile/actions/runs/33001119082/job/98282934395)

Root cause: `r0adkll/upload-google-play`'s `whatsNewDirectory` handling (verified against its actual source, `src/whatsnew.ts`) does `fs.readdirSync(whatsNewDir)` and then `readFile()` directly on each `whatsnew-<locale>` entry — those must be **files**, not per-locale subdirectories. The "Prepare release notes" step was writing to `whatsnew/whatsnew-en-US/whatsnew` (a directory containing a file), so the action's `readFile()` on `whatsnew/whatsnew-en-US` hit a directory instead of a file.

Since the AAB upload happens before the What's New step in the action's internal flow, this means the run left an uncommitted edit in Google Play Console — worth checking/discarding there since nothing was actually published live.

## What changed
- `.github/workflows/upload-google-play.yml` — "Prepare release notes" now writes directly to `whatsnew/whatsnew-en-US` instead of `whatsnew/whatsnew-en-US/whatsnew`

## Test plan
- [x] YAML syntax validated
- [x] `npm test` — 131 suites / 964 tests pass (unaffected by this change, included for completeness)
- [ ] Re-run `npm run publish:android` against a real release to confirm the fix (not yet done by reviewer)