### PR TITLE
fix: include androidVersionCode in the release tag

### DIFF
--- a/scripts/release-android.js
+++ b/scripts/release-android.js
@@ -349,17 +349,29 @@ async function checkBranchSync(dryRun) {
     }
 }
 
-// appVersion ends up in a git tag name and a `gh workflow run -f` argument — validate its shape
-// before it's used anywhere rather than trusting app.json content blindly.
+// appVersion and androidVersionCode end up in a git tag name and a `gh workflow run -f`
+// argument — validate their shape before they're used anywhere rather than trusting app.json
+// content blindly.
 function validateAppVersion(appVersion) {
     if (!/^\d+\.\d+\.\d+$/.test(appVersion)) {
         throw new Error(`app.json's appVersion ("${appVersion}") is not a plain semver string.`);
     }
 }
 
-function tagRelease(appVersion, notes, dryRun) {
+function validateAndroidVersionCode(androidVersionCode) {
+    if (!Number.isInteger(androidVersionCode) || androidVersionCode <= 0) {
+        throw new Error(`app.json's androidVersionCode (${JSON.stringify(androidVersionCode)}) is not a positive integer.`);
+    }
+}
+
+// appVersion alone isn't a reliable release identity: Play requires androidVersionCode to be
+// unique and strictly increasing per upload, but appVersion can stay the same across two
+// separate uploads (e.g. a rebuild with no marketing version change). Including both in the tag
+// avoids one release's tag silently overwriting a different release that happened to share the
+// same appVersion.
+function tagRelease(appVersion, androidVersionCode, notes, dryRun) {
     if (!notes) return null;
-    const tagName = `android-release/v${appVersion}`;
+    const tagName = `android-release/v${appVersion}-${androidVersionCode}`;
     if (dryRun) {
         console.log(`[dry-run] Would tag and push ${tagName} with this message:\n${notes}\n`);
         return tagName;
@@ -436,10 +448,12 @@ async function main() {
 
     const appJson = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'app.json'), 'utf8'));
     const appVersion = appJson.appVersion;
+    const androidVersionCode = appJson.androidVersionCode;
     validateAppVersion(appVersion);
+    validateAndroidVersionCode(androidVersionCode);
 
     const notes = await collectReleaseNotes(appVersion);
-    const tagName = tagRelease(appVersion, notes, dryRun);
+    const tagName = tagRelease(appVersion, androidVersionCode, notes, dryRun);
 
     const { track, rollout } = await pickTrackAndRollout();
 


### PR DESCRIPTION
## Summary
`appVersion` alone isn't a reliable release identity for tagging: Play requires `androidVersionCode` to be unique and strictly increasing per upload, but `appVersion` can stay the same across two separate uploads (e.g. a rebuild/re-push with no marketing version change). The release tag now includes both, so two distinct releases that happen to share an `appVersion` don't collide on the same tag.

## What changed
- `scripts/release-android.js` — tag format is now `android-release/v<appVersion>-<androidVersionCode>` (e.g. `android-release/v1.1.1-43`) instead of `android-release/v<appVersion>`
- Added `validateAndroidVersionCode()`, mirroring the existing `validateAppVersion()` shape-validation before the value is used in a git tag / `gh workflow run -f` argument

## Test plan
- [x] `npm test` — 131 suites / 964 tests pass
- [x] `eslint scripts/release-android.js` clean
- [x] Verified tag format and validation logic directly (`android-release/v1.1.1-43`; rejects non-integer/negative values)