### PR TITLE
chore: shield playAudio against old app versions

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,6 +2,6 @@
   "name": "Incyclist",
   "displayName": "Incyclist",
   "appVersion": "1.1.1",
-  "bundleVersion" : "0.3.2",
+  "bundleVersion" : "0.3.4",
   "androidVersionCode": 43
 }

--- a/src/components/WorkoutDetailsDialog/WorkoutDetailsDialog.tsx
+++ b/src/components/WorkoutDetailsDialog/WorkoutDetailsDialog.tsx
@@ -16,6 +16,7 @@ import {
     useUnmountEffect,
     STEP_CHANGE_AUDIO_SIGNAL_SETTING_KEY,
     DEFAULT_STEP_CHANGE_AUDIO_SIGNAL,
+    canPlayAudio,
 } from '../../hooks';
 import { navigate } from '../../services';
 
@@ -171,7 +172,8 @@ export const WorkoutDetailsDialog = ({ workoutId }: WorkoutDetailsDialogProps) =
             compact={compact}
             ftp={details.ftp}
             useErgMode={details.useErgMode}
-            stepChangeAudioSignal={stepChangeAudioSignal}
+            stepChangeAudioSignal={ canPlayAudio() && stepChangeAudioSignal}
+            stepChangeAudioSignalDisabled={ !canPlayAudio() }
             groups={details.groups}
             group={details.group}
             isScheduled={details.isScheduled}

--- a/src/components/WorkoutDetailsDialog/WorkoutDetailsView.tsx
+++ b/src/components/WorkoutDetailsDialog/WorkoutDetailsView.tsx
@@ -20,6 +20,7 @@ interface SettingsColumnProps {
     ftp: number;
     useErgMode: boolean;
     stepChangeAudioSignal: boolean;
+    stepChangeAudioSignalDisabled?:boolean;
     groups: string[];
     group: string;
     isScheduled: boolean;
@@ -32,7 +33,7 @@ interface SettingsColumnProps {
 /** FTP -> ERG -> Step Change Audio -> Group, always in this vertical order (never side-by-side). */
 const SettingsColumn = ({
     ftp, useErgMode, stepChangeAudioSignal, groups, group, isScheduled,
-    onFtpChange, onErgChange, onStepChangeAudioSignalChange, onGroupChange,
+    onFtpChange, onErgChange, onStepChangeAudioSignalChange,stepChangeAudioSignalDisabled, onGroupChange,
 }: SettingsColumnProps) => (
     <View>
         <View style={styles.settingsField}>
@@ -55,6 +56,7 @@ const SettingsColumn = ({
                 labelPosition="before"
                 labelWidth={180}
                 value={stepChangeAudioSignal}
+                disabled = {stepChangeAudioSignalDisabled}
                 trueLabel="On"
                 falseLabel="Off"
                 onValueChange={onStepChangeAudioSignalChange}
@@ -86,7 +88,7 @@ const GraphColumn = ({ plan, graphHeight, scheduledLabel, description }: GraphCo
 export const WorkoutDetailsView = (props: WorkoutDetailsViewProps) => {
     const {
         title, description, duration, plan, compact,
-        ftp, useErgMode, stepChangeAudioSignal, groups, group, isScheduled, scheduledLabel,
+        ftp, useErgMode, stepChangeAudioSignal, stepChangeAudioSignalDisabled=false,groups, group, isScheduled, scheduledLabel,
         canDelete, canStart, canStartWorkoutOnly,
         showDeleteConfirm, deleting,
         attachedRoute,
@@ -134,6 +136,7 @@ export const WorkoutDetailsView = (props: WorkoutDetailsViewProps) => {
             ftp={ftp}
             useErgMode={useErgMode}
             stepChangeAudioSignal={stepChangeAudioSignal}
+            stepChangeAudioSignalDisabled={stepChangeAudioSignalDisabled}
             groups={groups}
             group={group}
             isScheduled={isScheduled}

--- a/src/components/WorkoutDetailsDialog/types.ts
+++ b/src/components/WorkoutDetailsDialog/types.ts
@@ -32,6 +32,7 @@ export interface WorkoutDetailsViewProps {
      * WorkoutSettingsDialog's in-ride toggle.
      */
     stepChangeAudioSignal: boolean;
+    stepChangeAudioSignalDisabled?: boolean;
 
     groups: string[];
     group: string;

--- a/src/hooks/ride/useWorkoutStepAudioSignal.ts
+++ b/src/hooks/ride/useWorkoutStepAudioSignal.ts
@@ -2,6 +2,9 @@ import { useCallback, useEffect, useRef } from 'react';
 import { getRidePageService, useUserSettings, type IObserver, type StepCountdownTick } from 'incyclist-services';
 import { useUnmountEffect } from '../unmount';
 import { playTone, STEP_COUNTDOWN_TICK_TONE, STEP_CHANGE_TONE } from '../../utils/stepChangeAudio';
+import { Platform } from 'react-native';
+import { isVersionAtLeast } from '../../utils/version';
+import DeviceInfo from 'react-native-device-info';
 
 // Shared with the settings UI (WorkoutDetailsDialog, WorkoutSettingsDialog) - read/written directly
 // via useUserSettings(), not proxied through a page-service display-prop, same direct pattern
@@ -9,6 +12,14 @@ import { playTone, STEP_COUNTDOWN_TICK_TONE, STEP_CHANGE_TONE } from '../../util
 // audio cue is opt-out, not opt-in.
 export const STEP_CHANGE_AUDIO_SIGNAL_SETTING_KEY = 'preferences.workouts.stepChangeAudioSignal';
 export const DEFAULT_STEP_CHANGE_AUDIO_SIGNAL = true;
+export const MIN_ANDROID_PLAY_AUDIO_VERSION = '1.2.0'
+
+export const canPlayAudio = (): boolean => {
+    if (Platform.OS !== 'android') {
+        return true;
+    }
+    return isVersionAtLeast( DeviceInfo.getVersion() , MIN_ANDROID_PLAY_AUDIO_VERSION);
+};
 
 /**
  * Side-effect-only hook (no return value) that plays the Garmin-watch-style countdown
@@ -48,7 +59,8 @@ export const useWorkoutStepAudioSignal = (): void => {
         if (!tick || !isEnabled()) {
             return;
         }
-        playTone(tick.secondsRemaining === 0 ? STEP_CHANGE_TONE : STEP_COUNTDOWN_TICK_TONE);
+        if (canPlayAudio())        
+            playTone(tick.secondsRemaining === 0 ? STEP_CHANGE_TONE : STEP_COUNTDOWN_TICK_TONE);
     }, [isEnabled]);
 
     useEffect(() => {


### PR DESCRIPTION
Older App versions (that don't have react-native-audio-api installed) will crash when playAudio() is called.

Therefore we disabled this feature based on the app version (<0.2.0)