### PR TITLE
fix: omit Ride Again for workout-only activities, Close becomes primary

### DIFF
--- a/src/components/ActivityDetailsDialog/ActivityDetailsDialogView.test.tsx
+++ b/src/components/ActivityDetailsDialog/ActivityDetailsDialogView.test.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { ActivityDetailsDialogView } from './ActivityDetailsDialogView';
 import { ActivityDetailsDialogViewProps } from './types';
+import { colors } from '../../theme';
 
 const MOCK_LOADING = {
     loading: true,
@@ -150,6 +151,51 @@ describe('ActivityDetailsDialogView', () => {
             );
             expect(queryByText('Add Workout')).toBeNull();
             expect(queryByText(/^Workout:/)).toBeNull();
+        });
+    });
+
+    // FIXES_BACKLOG: workout-only activities (no route attached) have canStart===false. "Ride
+    // Again" used to render disabled but still pressable (the shared Button component ignores
+    // its `disabled` prop), so tapping it silently did nothing. It's now omitted entirely, and
+    // "Close" takes over as the primary action.
+    describe('Ride Again / Close', () => {
+        const loadedProps = (overrides = {}): ActivityDetailsDialogViewProps => ({
+            ...MOCK_LOADING,
+            loading: false,
+            activity: {
+                title: 'Test Ride',
+                startTime: new Date().toISOString(),
+                distance: 10000,
+                time: 3600,
+                totalElevation: 500,
+                logs: [],
+                stats: { speed: { avg: 25, min: 0, max: 40 } },
+            } as any,
+            ...overrides,
+        });
+
+        it('shows "Ride Again" and calls onRideAgain on press when canStart is true', () => {
+            const props = loadedProps({ canStart: true });
+            const { getByText } = render(<ActivityDetailsDialogView {...props} />);
+            fireEvent.press(getByText('Ride Again'));
+            expect(props.onRideAgain).toHaveBeenCalledTimes(1);
+        });
+
+        it('omits "Ride Again" for a workout-only activity (canStart false)', () => {
+            const { queryByText } = render(
+                <ActivityDetailsDialogView {...loadedProps({ canStart: false })} />
+            );
+            expect(queryByText('Ride Again')).toBeNull();
+        });
+
+        it('makes "Close" the primary button for a workout-only activity (canStart false)', () => {
+            const { getByText } = render(
+                <ActivityDetailsDialogView {...loadedProps({ canStart: false })} />
+            );
+            const closeButtonStyle = getByText('Close').parent?.parent?.props.style;
+            expect(closeButtonStyle).toEqual(
+                expect.objectContaining({ backgroundColor: colors.buttonPrimary })
+            );
         });
     });
 });

--- a/src/components/ActivityDetailsDialog/ActivityDetailsDialogView.tsx
+++ b/src/components/ActivityDetailsDialog/ActivityDetailsDialogView.tsx
@@ -74,9 +74,9 @@ export const ActivityDetailsDialogView = (props: ActivityDetailsDialogViewProps)
     const showWorkoutChip = canStart && !!attachedWorkout;
 
     const dialogButtons = [
-        { label: 'Ride Again', onClick: onRideAgain, primary: true, disabled: !canStart },
+        ...(canStart ? [{ label: 'Ride Again', onClick: onRideAgain, primary: true }] : []),
         ...(showAddWorkout ? [{ label: 'Add Workout', onClick: onAddWorkout }] : []),
-        { label: 'Close', onClick: onClose },
+        { label: 'Close', onClick: onClose, primary: !canStart },
     ];
 
     const renderKeyFact = (label: string, value: any, unitKey?: 'distance' | 'elevation' | 'speed' | 'time' | 'power') => {


### PR DESCRIPTION
## Summary
- Opening an activity from the Activities page for a workout-only ride (no route attached) and tapping "Ride Again" silently did nothing - the button rendered as if enabled even though the activity can't be started.
- Root cause was in `incyclist-services`: `canStart` could incorrectly evaluate to `true` for this case (see incyclist/services#559). Separately, the shared `Button` component doesn't actually wire up its `disabled` prop, so even the existing `disabled: !canStart` had no visual or functional effect.
- `ActivityDetailsDialogView` now omits "Ride Again" entirely when `canStart` is false (matching web-ui's disabled behavior, but removed rather than disabled), and makes "Close" the primary action in that case.
- No contract change. Needs incyclist/services#559 to fully resolve (this PR alone stops the dead click; the services fix corrects the underlying `canStart` value) - can be merged independently of each other but both are required together for the fix to be complete.

## Test plan
- [x] New tests in `ActivityDetailsDialogView.test.tsx`: "Ride Again" omitted when `canStart` is false, shown and functional when true, "Close" is primary when `canStart` is false
- [x] Full unit suite passes (`npx jest`)
- [x] `tsc --noEmit` clean