### PR TITLE
fix: guard BLE native callbacks against malformed events

### DIFF
--- a/src/bindings/ble/binding.test.ts
+++ b/src/bindings/ble/binding.test.ts
@@ -1,0 +1,71 @@
+import BleManager, { BleManagerDidUpdateStateEvent } from 'react-native-ble-manager'
+import { BleBindingRN } from './binding'
+
+jest.mock('react-native', () => ({
+    Platform: { OS: 'ios', Version: 14 },
+    NativeEventEmitter: jest.fn().mockImplementation(() => ({
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+    })),
+    NativeModules: { BleManager: {} },
+}))
+
+jest.mock('react-native-ble-manager', () => ({
+    __esModule: true,
+    default: {
+        onDidUpdateState: jest.fn(),
+        onDiscoverPeripheral: jest.fn(),
+        onStopScan: jest.fn(),
+        checkState: jest.fn(),
+        start: jest.fn(),
+        scan: jest.fn(),
+        stopScan: jest.fn(),
+    },
+}))
+
+// Avoid pulling in the full `services` barrel (incyclist-services, Navigation, IncyclistApi, ...)
+// which is unrelated to the BLE state-change callback under test.
+jest.mock('../../services', () => ({
+    PermissionService: jest.fn().mockImplementation(() => ({
+        hasBlePermission: jest.fn().mockResolvedValue(true),
+    })),
+}))
+
+const bleManager = BleManager as jest.Mocked<typeof BleManager>
+
+describe('BleBindingRN.onManagerStateChanged', () => {
+
+    let binding: BleBindingRN
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        binding = new BleBindingRN()
+    })
+
+    const stateEvent = { state: 'on' } as BleManagerDidUpdateStateEvent
+
+    test('updates state and emits "stateChange" for a well-formed event', () => {
+        const onStateChange = jest.fn()
+        binding.on('stateChange', onStateChange)
+
+        binding.onManagerStateChanged(stateEvent)
+
+        expect((binding as any)._state).toBe('poweredOn')
+        expect(onStateChange).toHaveBeenCalledWith('poweredOn')
+    })
+
+    test('does not throw when the downstream "stateChange" handler throws', () => {
+        binding.on('stateChange', () => { throw new Error('downstream boom') })
+
+        expect(() => binding.onManagerStateChanged(stateEvent)).not.toThrow()
+    })
+
+    test('does not throw when the native module hands back a malformed event', () => {
+        expect(() => binding.onManagerStateChanged(null as any)).not.toThrow()
+        expect(() => binding.onManagerStateChanged(undefined as any)).not.toThrow()
+    })
+
+    test('registers the native onDidUpdateState listener exactly once at construction', () => {
+        expect(bleManager.onDidUpdateState).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/bindings/ble/binding.ts
+++ b/src/bindings/ble/binding.ts
@@ -133,11 +133,16 @@ export class BleBindingRN extends EventEmitter implements BleBinding {
 
 
 
-    onManagerStateChanged( event:BleManagerDidUpdateStateEvent):void { 
-        if (Platform.OS==='android' && this._state==='unauthorized') {
-            return
+    onManagerStateChanged( event:BleManagerDidUpdateStateEvent):void {
+        try {
+            if (Platform.OS==='android' && this._state==='unauthorized') {
+                return
+            }
+            this.updateState(event.state)
         }
-        this.updateState(event.state)
+        catch(err:any) {
+            this.logger.logEvent({message:'error', fn:'onManagerStateChanged', error:err.message, stack:err.stack})
+        }
     }
 
 

--- a/src/bindings/ble/characteristics.test.ts
+++ b/src/bindings/ble/characteristics.test.ts
@@ -1,0 +1,121 @@
+import BleManager from 'react-native-ble-manager'
+import { BleRawCharacteristicRN } from './characteristics'
+
+type NativeCallback = (event: any) => void
+
+jest.mock('react-native-ble-manager', () => ({
+    __esModule: true,
+    default: {
+        onDidUpdateValueForCharacteristic: jest.fn(),
+        startNotification: jest.fn(),
+        stopNotification: jest.fn(),
+    },
+}))
+
+const bleManager = BleManager as jest.Mocked<typeof BleManager>
+
+describe('BleRawCharacteristicRN', () => {
+
+    const deviceId = 'AA:BB:CC:DD:EE:FF'
+    const serviceUuid = '1234'
+    const characteristicUuid = '5678'
+
+    let nativeCallback: NativeCallback
+    let removeSpy: jest.Mock
+
+    const createCharacteristic = () => new BleRawCharacteristicRN(
+        deviceId,
+        serviceUuid,
+        { characteristic: characteristicUuid, descriptor: 'test', properties: { Notify: 'Notify' } }
+    )
+
+    const validEvent = {
+        peripheral: deviceId,
+        service: serviceUuid,
+        characteristic: characteristicUuid,
+        value: [1, 2, 3],
+    }
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        removeSpy = jest.fn()
+
+        bleManager.onDidUpdateValueForCharacteristic.mockImplementation((cb: NativeCallback) => {
+            nativeCallback = cb
+            return { remove: removeSpy } as any
+        })
+        bleManager.startNotification.mockResolvedValue(undefined as any)
+        bleManager.stopNotification.mockResolvedValue(undefined as any)
+    })
+
+    describe('subscribe', () => {
+
+        test('registers exactly one native listener, even across repeated subscribe() calls', () => {
+            const char = createCharacteristic()
+
+            char.subscribe(() => { /* noop */ })
+            char.subscribe(() => { /* noop */ })
+            char.subscribe(() => { /* noop */ })
+
+            expect(bleManager.onDidUpdateValueForCharacteristic).toHaveBeenCalledTimes(1)
+        })
+
+        test('starts the native notification only once for repeated subscribe() calls', () => {
+            const char = createCharacteristic()
+
+            char.subscribe(() => { /* noop */ })
+            char.subscribe(() => { /* noop */ })
+
+            expect(bleManager.startNotification).toHaveBeenCalledTimes(1)
+        })
+
+        test('emits "data" for a matching, well-formed event', () => {
+            const char = createCharacteristic()
+            const onData = jest.fn()
+            char.on('data', onData)
+
+            char.subscribe(() => { /* noop */ })
+            nativeCallback(validEvent)
+
+            expect(onData).toHaveBeenCalledTimes(1)
+        })
+
+        test('does not throw when the downstream "data" handler throws', () => {
+            const char = createCharacteristic()
+            char.on('data', () => { throw new Error('downstream boom') })
+
+            char.subscribe(() => { /* noop */ })
+
+            expect(() => nativeCallback(validEvent)).not.toThrow()
+        })
+
+        test('does not throw when the native module hands back a malformed event.value', () => {
+            const char = createCharacteristic()
+            char.on('data', jest.fn())
+
+            char.subscribe(() => { /* noop */ })
+
+            expect(() => nativeCallback({ ...validEvent, value: undefined })).not.toThrow()
+        })
+
+        test('does not throw when the native module hands back a null event', () => {
+            const char = createCharacteristic()
+
+            char.subscribe(() => { /* noop */ })
+
+            expect(() => nativeCallback(null)).not.toThrow()
+        })
+    })
+
+    describe('unsubscribe', () => {
+
+        test('removes the native listener once the last subscriber unsubscribes', () => {
+            const char = createCharacteristic()
+
+            char.subscribe(() => { /* noop */ })
+            char.unsubscribe(() => { /* noop */ })
+
+            expect(removeSpy).toHaveBeenCalledTimes(1)
+        })
+    })
+})

--- a/src/bindings/ble/characteristics.ts
+++ b/src/bindings/ble/characteristics.ts
@@ -8,6 +8,7 @@ import {
 } from './types'
 import { EventSubscription} from 'react-native'
 import { matches } from './utils'
+import { EventLogger } from 'gd-eventlog'
 
 
 export class BleRawCharacteristicRN extends EventEmitter implements BleRawCharacteristic {
@@ -20,6 +21,7 @@ export class BleRawCharacteristicRN extends EventEmitter implements BleRawCharac
     private deviceId: string
     private subscribed: number = 0
     private subscription: EventSubscription|undefined
+    private logger = new EventLogger('BLE')
 
     constructor(
         deviceId: string,
@@ -39,22 +41,23 @@ export class BleRawCharacteristicRN extends EventEmitter implements BleRawCharac
     subscribe(callback: (err: Error | undefined) => void): void {
 
         if (!this.subscription) {
-            BleManager.onDidUpdateValueForCharacteristic((event) => {
+            this.subscription = BleManager.onDidUpdateValueForCharacteristic((event) => {
+                try {
+                    if (
+                        event.peripheral === this.deviceId &&
+                        matches(event.service,this._serviceUuid!) &&
+                        matches(event.characteristic,this.uuid)
+                    ) {
 
-
-                if (
-                    event.peripheral === this.deviceId &&
-                    matches(event.service,this._serviceUuid!) &&
-                    matches(event.characteristic,this.uuid)
-                ) {
-
-
-
-                    this.emit(
-                        'data',
-                        Buffer.from(event.value),
-                        true
-                    )
+                        this.emit(
+                            'data',
+                            Buffer.from(event.value),
+                            true
+                        )
+                    }
+                }
+                catch(err:any) {
+                    this.logger.logEvent({message:'error', fn:'onDidUpdateValueForCharacteristic', error:err.message, stack:err.stack})
                 }
             })
 

--- a/src/bindings/ble/peripheral.test.ts
+++ b/src/bindings/ble/peripheral.test.ts
@@ -1,0 +1,69 @@
+import BleManager from 'react-native-ble-manager'
+import { BlePeripheralRN } from './peripheral'
+
+type NativeCallback = (event: any) => void
+
+jest.mock('react-native-ble-manager', () => ({
+    __esModule: true,
+    default: {
+        connect: jest.fn(),
+        onDisconnectPeripheral: jest.fn(),
+    },
+}))
+
+const bleManager = BleManager as jest.Mocked<typeof BleManager>
+
+describe('BlePeripheralRN', () => {
+
+    const deviceId = 'AA:BB:CC:DD:EE:FF'
+
+    let nativeCallback: NativeCallback
+    let removeSpy: jest.Mock
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        removeSpy = jest.fn()
+
+        bleManager.connect.mockResolvedValue(undefined as any)
+        bleManager.onDisconnectPeripheral.mockImplementation((cb: NativeCallback) => {
+            nativeCallback = cb
+            return { remove: removeSpy } as any
+        })
+    })
+
+    const createPeripheral = () => new BlePeripheralRN({ id: deviceId, name: 'Test' } as any)
+
+    describe('connectAsync / onDisconnectPeripheral', () => {
+
+        test('sets state to disconnected and emits "disconnect" for a matching event', async () => {
+            const peripheral = createPeripheral()
+            const onDisconnect = jest.fn()
+            peripheral.on('disconnect', onDisconnect)
+
+            await peripheral.connectAsync()
+            nativeCallback({ peripheral: deviceId })
+
+            expect(peripheral.state).toBe('disconnected')
+            expect(onDisconnect).toHaveBeenCalledTimes(1)
+            expect(removeSpy).toHaveBeenCalledTimes(1)
+        })
+
+        test('does not throw when the downstream "disconnect" handler throws', async () => {
+            const peripheral = createPeripheral()
+            peripheral.on('disconnect', () => { throw new Error('downstream boom') })
+
+            await peripheral.connectAsync()
+
+            expect(() => nativeCallback({ peripheral: deviceId })).not.toThrow()
+        })
+
+        test('does not throw when the native module hands back a malformed event', async () => {
+            const peripheral = createPeripheral()
+
+            await peripheral.connectAsync()
+
+            expect(() => nativeCallback(null)).not.toThrow()
+            expect(() => nativeCallback(undefined)).not.toThrow()
+        })
+    })
+})

--- a/src/bindings/ble/peripheral.ts
+++ b/src/bindings/ble/peripheral.ts
@@ -5,6 +5,7 @@ import { BleServiceRN } from './service'
 import { BleRawCharacteristicRN } from './characteristics'
 import {  EventSubscription} from 'react-native'
 import { matches } from './utils'
+import { EventLogger } from 'gd-eventlog'
 
 
 export class BlePeripheralRN
@@ -18,6 +19,7 @@ export class BlePeripheralRN
     public advertisement: any
     public state: string = 'disconnected'
     private subDisconnect: EventSubscription|undefined
+    private logger = new EventLogger('BLE')
 
     constructor(private peripheral: Peripheral) {
         super()
@@ -38,16 +40,20 @@ export class BlePeripheralRN
         this.state = 'connected'
 
         this.subDisconnect = BleManager.onDisconnectPeripheral((event) => {
+            try {
+                if (event.peripheral === this.id) {
+                    this.state = 'disconnected'
+                    this.emit('disconnect')
 
-            if (event.peripheral === this.id) {
-                this.state = 'disconnected'
-                this.emit('disconnect')
+                    if (this.subDisconnect) {
+                        this.subDisconnect.remove()
+                        delete this.subDisconnect
+                    }
 
-                if (this.subDisconnect) {
-                    this.subDisconnect.remove()
-                    delete this.subDisconnect
                 }
-
+            }
+            catch(err:any) {
+                this.logger.logEvent({message:'error', fn:'onDisconnectPeripheral', error:err.message, stack:err.stack})
             }
         })
     }


### PR DESCRIPTION
## Summary

FIXES_BACKLOG item #69. Android Vitals reported a fatal `JavascriptException` on two low/mid-tier tablets, surfaced only as native RN-bridge frames with no JS detail (no crash reporter in the app to capture more). Root cause was identified via a captured on-device event log plus a static trace of the BLE native-callback chain: `BleManager.onDidUpdateValueForCharacteristic`'s callback in `characteristics.ts` had no try/catch around its body, including a `Buffer.from(event.value)` call that throws a `TypeError` if the native module ever hands back a malformed/null/undefined value — a known flaky-BLE-stack failure mode. Everything downstream of the callback's `emit('data', ...)` is already guarded; this specific callback was the gap.

## What changed

- `src/bindings/ble/characteristics.ts`: wrapped the `onDidUpdateValueForCharacteristic` callback body in try/catch, logging via `EventLogger`.
- `src/bindings/ble/peripheral.ts`: same hardening for the `onDisconnectPeripheral` callback.
- `src/bindings/ble/binding.ts`: same hardening for `onManagerStateChanged` (guards its `updateState()` → `emit('stateChange', ...)` chain).
- `src/bindings/ble/characteristics.ts`: fixed `subscribe()` — it declared a `subscription` field to dedup repeated `subscribe()` calls (e.g. on every reconnect) but never assigned it, so the dedup guard was always a no-op and every reconnect stacked another duplicate global listener for the life of the app process. The native subscription handle returned by `BleManager.onDidUpdateValueForCharacteristic(...)` is now actually stored.

Out of scope (per backlog item): the CSC/FM/other characteristic parsers in `devices/` are untouched (already protected by layers above them), and no crash reporting / `ErrorUtils.setGlobalHandler` / log-delivery work is included — that's separate, net-new feature work.

## Test plan

- [x] Added unit tests for all three hardened callbacks: a throwing downstream handler no longer propagates out of the native-callback wrapper, and a malformed/null event is handled without throwing.
- [x] Added a unit test asserting a second `subscribe()` call for an already-subscribed characteristic does not register a second native listener.
- [x] `npm test` — 137 suites / 1027 tests passing
- [x] `npm run lint` — 0 errors (pre-existing warnings only, none introduced by this change)
- [x] `npx tsc --noEmit` — clean