### PR TITLE
Ride overlay: show step list instead of graph in corner toggle

### DIFF
--- a/src/components/RideOverlay/RideOverlay.test.tsx
+++ b/src/components/RideOverlay/RideOverlay.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { StyleSheet } from 'react-native';
 import { fireEvent, render } from '@testing-library/react-native';
 import { RideOverlay, RideOverlayProps, PREV_RIDES_TABLET_WIDTH } from './RideOverlay';
 import { MOCK_DASHBOARD_MID_INTERVAL } from '../WorkoutDashboard/WorkoutDashboard.mock';
 import { MOCK_ROWS } from '../PrevRides/PrevRidesRow.mock';
+import { SLOT_GAP } from '../../hooks/render/useRideOverlayLayout';
 
 // Same pattern useRideOverlayLayout.test.ts (session 3.2) uses — the hook reads the real browser
 // window via useWindowDimensions(), so tests drive it by mocking that module directly rather than
@@ -141,6 +143,68 @@ describe('RideOverlay', () => {
 
         expect(getByTestId('ride-overlay-corner-toggle')).toBeTruthy();
         expect(mockWorkoutStepsList).not.toHaveBeenCalled();
+    });
+
+    // FIXES_BACKLOG #70 follow-up: on a real ~390dp-tall phone, the fixed elevation-graph height
+    // clipped WorkoutStepsList down to a single row (no upcoming-step row visible at all) — the
+    // 'workout' toggle state now auto-sizes to its own content instead of reusing that fixed height.
+    it('fallback, cornerWidget="workout": the corner slot does not force the fixed elevation-graph height, unlike cornerWidget="elevation"', () => {
+        setDimensions(844, 390);
+        const { getByTestId, rerender } = render(<RideOverlay {...baseProps} compact cornerWidget="elevation" />);
+        const elevationStyle = StyleSheet.flatten(getByTestId('ride-overlay-elevation').props.style);
+        expect(typeof elevationStyle.height).toBe('number');
+
+        rerender(<RideOverlay {...baseProps} compact cornerWidget="workout" />);
+        const workoutStyle = StyleSheet.flatten(getByTestId('ride-overlay-elevation').props.style);
+        expect(workoutStyle.height).toBeUndefined();
+    });
+
+    it('fallback, cornerWidget="workout": the corner slot widens beyond the elevation-preview width, and the shoutout line insets to make room for it', () => {
+        setDimensions(844, 390);
+        const { getByTestId, rerender } = render(<RideOverlay {...baseProps} compact cornerWidget="elevation" />);
+        const elevationSlotWidth = StyleSheet.flatten(getByTestId('ride-overlay-elevation').props.style).width;
+        const elevationShoutoutRight = StyleSheet.flatten(getByTestId('ride-overlay-shoutout').props.style).right;
+
+        rerender(<RideOverlay {...baseProps} compact cornerWidget="workout" />);
+        const workoutSlotWidth = StyleSheet.flatten(getByTestId('ride-overlay-elevation').props.style).width;
+        const workoutShoutoutRight = StyleSheet.flatten(getByTestId('ride-overlay-shoutout').props.style).right;
+
+        expect(workoutSlotWidth).toBeGreaterThan(elevationSlotWidth);
+        // The shoutout's own right inset always tracks the toggle's current width (plus SLOT_GAP),
+        // so its centered text can never grow into whichever box (elevation or workout) is showing.
+        expect(elevationShoutoutRight).toBe(elevationSlotWidth + SLOT_GAP);
+        expect(workoutShoutoutRight).toBe(workoutSlotWidth + SLOT_GAP);
+    });
+
+    it('fallback, cornerWidget="workout" with prevRides shown: the previous-rides panel anchors below the taller auto-sized slot, not the shorter fixed elevation height', () => {
+        setDimensions(844, 390);
+        const propsWithPrevRides = { ...baseProps, prevRides: MOCK_ROWS, getPrevRidesRows: () => MOCK_ROWS };
+
+        const { getByTestId: getByTestIdElevation } = render(
+            <RideOverlay {...propsWithPrevRides} compact cornerWidget="elevation" />
+        );
+        const elevationAnchorTop = StyleSheet.flatten(getByTestIdElevation('prev-rides-expanded-panel').props.style).top;
+
+        const { getByTestId: getByTestIdWorkout } = render(
+            <RideOverlay {...propsWithPrevRides} compact cornerWidget="workout" />
+        );
+        const workoutAnchorTop = StyleSheet.flatten(getByTestIdWorkout('prev-rides-expanded-panel').props.style).top;
+
+        expect(workoutAnchorTop).toBeGreaterThan(elevationAnchorTop);
+    });
+
+    it('fallback, cornerWidget="workout": measuring the slot\'s real (taller) rendered height pushes the previous-rides panel down further than the initial guess', () => {
+        setDimensions(844, 390);
+        const propsWithPrevRides = { ...baseProps, prevRides: MOCK_ROWS, getPrevRidesRows: () => MOCK_ROWS };
+        const { getByTestId } = render(<RideOverlay {...propsWithPrevRides} compact cornerWidget="workout" />);
+        const topBeforeMeasurement = StyleSheet.flatten(getByTestId('prev-rides-expanded-panel').props.style).top;
+
+        fireEvent(getByTestId('ride-overlay-elevation'), 'layout', {
+            nativeEvent: { layout: { height: 120 } },
+        });
+
+        const topAfterMeasurement = StyleSheet.flatten(getByTestId('prev-rides-expanded-panel').props.style).top;
+        expect(topAfterMeasurement).toBeGreaterThan(topBeforeMeasurement);
     });
 
     it('does not render a corner map when mapVisible is false, even in an arrangement with room for one', () => {

--- a/src/components/RideOverlay/RideOverlay.test.tsx
+++ b/src/components/RideOverlay/RideOverlay.test.tsx
@@ -37,11 +37,19 @@ jest.mock('../FreeMap', () => ({
         return null;
     },
 }));
+const mockWorkoutGraph = jest.fn();
 jest.mock('../WorkoutGraph', () => ({
-    WorkoutGraph: () => null,
+    WorkoutGraph: (props: any) => {
+        mockWorkoutGraph(props);
+        return null;
+    },
 }));
+const mockWorkoutStepsList = jest.fn();
 jest.mock('../WorkoutStepsList', () => ({
-    WorkoutStepsList: () => null,
+    WorkoutStepsList: (props: any) => {
+        mockWorkoutStepsList(props);
+        return null;
+    },
 }));
 
 const baseProps: RideOverlayProps = {
@@ -109,13 +117,30 @@ describe('RideOverlay', () => {
         expect(getByText(MOCK_DASHBOARD_MID_INTERVAL.line.text)).toBeTruthy();
     });
 
-    it('fallback, cornerWidget="workout": the toggle slot still renders (as the workout graph, mocked to null here) inside the same Pressable', () => {
+    it('fallback, cornerWidget="workout": the toggle slot renders WorkoutStepsList (not WorkoutGraph) inside the same Pressable', () => {
         setDimensions(844, 390);
+        mockWorkoutStepsList.mockClear();
+        mockWorkoutGraph.mockClear();
         const { getByTestId } = render(
             <RideOverlay {...baseProps} compact cornerWidget="workout" />
         );
 
         expect(getByTestId('ride-overlay-corner-toggle')).toBeTruthy();
+        expect(mockWorkoutStepsList).toHaveBeenCalledWith(
+            expect.objectContaining({ steps: baseProps.steps, compact: true, showEndHint: false })
+        );
+        expect(mockWorkoutGraph).not.toHaveBeenCalled();
+    });
+
+    it('fallback, cornerWidget="elevation": the toggle slot renders ElevationGraph, not WorkoutStepsList', () => {
+        setDimensions(844, 390);
+        mockWorkoutStepsList.mockClear();
+        const { getByTestId } = render(
+            <RideOverlay {...baseProps} compact cornerWidget="elevation" />
+        );
+
+        expect(getByTestId('ride-overlay-corner-toggle')).toBeTruthy();
+        expect(mockWorkoutStepsList).not.toHaveBeenCalled();
     });
 
     it('does not render a corner map when mapVisible is false, even in an arrangement with room for one', () => {

--- a/src/components/RideOverlay/RideOverlay.tsx
+++ b/src/components/RideOverlay/RideOverlay.tsx
@@ -8,7 +8,7 @@ import { ElevationGraph } from '../ElevationGraph';
 import type { AvatarConfig } from '../ElevationGraph/types';
 import { FreeMap } from '../FreeMap';
 import type { PrevRiderMarker } from '../FreeMap/types';
-import { WorkoutGraph } from '../WorkoutGraph';
+import { WorkoutStepsList } from '../WorkoutStepsList';
 import { PrevRidesRow, PrevRidesCornerPanel, ROW_MARGIN_BOTTOM, type PrevRidesRowProps } from '../PrevRides';
 import {
     useRideOverlayLayout,
@@ -298,19 +298,10 @@ export const RideOverlay = (props: RideOverlayProps) => {
                             style={styles.flexFill}
                             onPress={onToggleCornerWidget}
                             accessibilityRole="button"
-                            accessibilityLabel={cornerWidget === 'workout' ? 'Show elevation' : 'Show workout'}
+                            accessibilityLabel={cornerWidget === 'workout' ? 'Show elevation' : 'Show steps'}
                         >
-                            {cornerWidget === 'workout' && graph ? (
-                                <Dynamic observer={rideObserver ?? undefined} event="data-update" prop="actuals" transform={getGraphActuals}>
-                                    <WorkoutGraph
-                                        mode="live"
-                                        plan={graph}
-                                        height={elevation.height}
-                                        showAxes={false}
-                                        showFtpLine
-                                        showLegend={false}
-                                    />
-                                </Dynamic>
+                            {cornerWidget === 'workout' && steps ? (
+                                <WorkoutStepsList steps={steps} compact showEndHint={false} />
                             ) : (
                                 <ElevationGraph
                                     routeData={routeData}

--- a/src/components/RideOverlay/RideOverlay.tsx
+++ b/src/components/RideOverlay/RideOverlay.tsx
@@ -32,6 +32,23 @@ const PREV_RIDES_MAX_VISIBLE_ROWS = 10;
 const clampVisibleRows = (value: number): number =>
     Math.min(Math.max(value, PREV_RIDES_MIN_VISIBLE_ROWS), PREV_RIDES_MAX_VISIBLE_ROWS);
 
+// The fallback corner slot's fixed height (FALLBACK_ELEVATION_HEIGHT_RATIO) was tuned for the
+// elevation-preview graph, which scales down cleanly — it does not, e.g. on a real ~390dp-tall
+// phone screen only room for one WorkoutStepsList row survives, silently clipping the upcoming-
+// step row a rider actually needs (found via on-device testing, FIXES_BACKLOG #70). So the
+// 'workout' toggle state auto-sizes to its own content instead of using the fixed elevation
+// height — this is only the guess used for the very first frame, before onWorkoutSlotLayout
+// below reports the real measured height (same fallback-then-measure pattern as
+// PREV_RIDES_ROW_HEIGHT_FALLBACK/measuredRideDashboardHeight elsewhere in this file).
+const FALLBACK_WORKOUT_STEPS_HEIGHT_GUESS = 70;
+
+// Width alone wasn't the only problem: the fixed elevation-preview width (FALLBACK_ELEVATION_WIDTH_RATIO,
+// ~169dp on a phone) is too narrow for WorkoutStepsList's text to read at all (confirmed on-device,
+// FIXES_BACKLOG #70 — "Ramp 100-140W" truncates to "Ramp 10…"), unlike the dedicated workout-only
+// ride page, which reads fine. Matches that page's own compact step-list width exactly
+// (RidePage/Workout/View.tsx's `stepsCompact.width`) rather than inventing a new one.
+const FALLBACK_WORKOUT_STEPS_WIDTH = 260;
+
 // The tablet previous-rides list is its own component, sized for its own content — not derived
 // from the corner map/elevation preview's width (that varies with RideDashboard's own width,
 // which itself varies with tile count and, at the icon-top/icon-left threshold, the same tile
@@ -211,6 +228,24 @@ export const RideOverlay = (props: RideOverlayProps) => {
         ? Math.max(elevation.top + elevation.height, workoutDashboardBottom)
         : undefined;
 
+    // 'workout' toggle content auto-sizes (see FALLBACK_WORKOUT_STEPS_HEIGHT_GUESS above) rather
+    // than using the fixed elevation-graph height — measured here so PrevRidesCornerPanel (which
+    // anchors below this slot's actual bottom edge) shifts down with it instead of overlapping.
+    const isWorkoutToggleActive = cornerSlotIsToggle && cornerWidget === 'workout';
+    const [measuredWorkoutSlotHeight, setMeasuredWorkoutSlotHeight] = useState<number | undefined>(undefined);
+    const onWorkoutSlotLayout = useCallback((e: LayoutChangeEvent) => {
+        const height = e.nativeEvent.layout.height;
+        setMeasuredWorkoutSlotHeight((prev) => (prev === height ? prev : height));
+    }, []);
+    const cornerSlotWidth = isWorkoutToggleActive ? FALLBACK_WORKOUT_STEPS_WIDTH : elevation?.width;
+    const cornerSlotRect = elevation
+        ? {
+              ...elevation,
+              width: cornerSlotWidth as number,
+              height: isWorkoutToggleActive ? (measuredWorkoutSlotHeight ?? FALLBACK_WORKOUT_STEPS_HEIGHT_GUESS) : elevation.height,
+          }
+        : elevation;
+
     // The tablet list's own free vertical band (below its anchor, above the bottom bar). Only
     // meaningful where an actual side column exists (not the fallback toggle slot, which has its
     // own condensed/expanded reporting via PrevRidesCornerPanel below).
@@ -291,11 +326,22 @@ export const RideOverlay = (props: RideOverlayProps) => {
                     Always mounted when eligible — previous-rides (below) no longer competes with
                     this slot (repo-owner review 2026-08-25). ------------------------------------ */}
             {elevation && (
-                <View testID="ride-overlay-elevation" style={[styles.cornerWidget, rectStyle(elevation)]}>
+                <View
+                    testID="ride-overlay-elevation"
+                    style={[
+                        styles.cornerWidget,
+                        { top: elevation.top, left: elevation.left, right: elevation.right, width: cornerSlotWidth },
+                        // Auto-sizes to content in the 'workout' toggle state (see
+                        // FALLBACK_WORKOUT_STEPS_HEIGHT_GUESS above) — omitting height here, rather
+                        // than forcing the fixed elevation-graph height, is what lets it grow.
+                        isWorkoutToggleActive ? null : { height: elevation.height },
+                    ]}
+                    onLayout={isWorkoutToggleActive ? onWorkoutSlotLayout : undefined}
+                >
                     {cornerSlotIsToggle ? (
                         <Pressable
                             testID="ride-overlay-corner-toggle"
-                            style={styles.flexFill}
+                            style={isWorkoutToggleActive ? undefined : styles.flexFill}
                             onPress={onToggleCornerWidget}
                             accessibilityRole="button"
                             accessibilityLabel={cornerWidget === 'workout' ? 'Show elevation' : 'Show steps'}
@@ -340,7 +386,7 @@ export const RideOverlay = (props: RideOverlayProps) => {
             {elevation && cornerSlotIsToggle && prevRides && prevRides.length > 0 && (
                 <Dynamic observer={rideObserver ?? undefined} event="prev-rides-update" prop="rows" transform={getPrevRidesRows}>
                     <PrevRidesCornerPanel
-                        slotRect={elevation}
+                        slotRect={cornerSlotRect as Rect}
                         screenHeight={inputs.screenHeight}
                         rows={prevRides}
                         onExpandPrevRides={onExpandPrevRides}
@@ -382,9 +428,19 @@ export const RideOverlay = (props: RideOverlayProps) => {
             )}
 
             {/* --- §5.4(a): single-line current-step description, unconditional in 'fallback',
-                    workout attached only ------------------------------------------------------ */}
+                    workout attached only. Inset on the right by the corner toggle's own width
+                    (widened for 'workout', §6.2(b)) so its centered text can never grow into that
+                    column — same vertical band as the toggle box, see FALLBACK_WORKOUT_STEPS_WIDTH
+                    above. ------------------------------------------------------------------------ */}
             {arrangement === 'fallback' && dashboard && (
-                <View testID="ride-overlay-shoutout" style={[styles.absolute, styles.fallbackShoutout, { top: dashboardHeight }]}>
+                <View
+                    testID="ride-overlay-shoutout"
+                    style={[
+                        styles.absolute,
+                        styles.fallbackShoutout,
+                        { top: dashboardHeight, right: cornerSlotIsToggle && cornerSlotWidth ? cornerSlotWidth + SLOT_GAP : 0 },
+                    ]}
+                >
                     <Text style={styles.fallbackShoutoutText} numberOfLines={1}>
                         {dashboard.text}
                     </Text>


### PR DESCRIPTION
## Summary
- FIXES_BACKLOG #70: on the phone-fallback ride overlay, the corner toggle's "workout" state showed a live `WorkoutGraph`. At that slot's actual on-screen size (~169x47dp), the graph had too little resolution to convey remaining time on the current step or what's next — exactly what a rider needs mid-workout.
- Swaps the graph for the already-built `WorkoutStepsList` component (same compact usage as `WorkoutDashboard` and the dedicated Workout ride page), showing current + next step instead.
- `WorkoutStepsList` is driven directly by the plain `steps` prop, so the `<Dynamic>` observer wrapper the graph needed is dropped for this branch.
- The two-state toggle model (elevation preview ↔ workout info) and its tap-to-cycle gesture are unchanged — only what the "workout" state renders.

## What changed
- `src/components/RideOverlay/RideOverlay.tsx`: corner toggle's `'workout'` branch now renders `<WorkoutStepsList steps={steps} compact showEndHint={false} />` instead of `<WorkoutGraph mode="live" .../>` wrapped in `<Dynamic>`. Accessibility label updated to "Show steps" for clarity.
- `src/components/RideOverlay/RideOverlay.test.tsx`: updated/added coverage asserting `WorkoutStepsList` renders (not `WorkoutGraph`) when `cornerWidget === 'workout'`, and `ElevationGraph` renders when `cornerWidget === 'elevation'`.

## Test plan
- [x] `npm test` — 1014 tests passed
- [x] `npm run lint` — 0 errors (pre-existing warnings only, none new)
- [x] `npx tsc --noEmit` — clean