### PR TITLE
fix: Ride Menu combo-ride content and Load/Gear controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "axios": "^1.17.0",
         "events": "^3.3.0",
         "gd-eventlog": "^0.1.27",
-        "incyclist-services": "^1.7.119",
+        "incyclist-services": "^1.7.120",
         "mqtt": "^5.15.2",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
@@ -11832,9 +11832,9 @@
       }
     },
     "node_modules/incyclist-services": {
-      "version": "1.7.119",
-      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.119.tgz",
-      "integrity": "sha512-F0yxAau7F55SFZ7t6HV5r9Uik0u/24YntA2DEnhNaf716yIzPbbSaPptd98/b+GQkbkDnEfyYyhfycX+8JEilQ==",
+      "version": "1.7.120",
+      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.120.tgz",
+      "integrity": "sha512-6VGpmbPYlR3za8IRcoZjDrJmCd5Y+53AbhtBz41fxhfGURXQmLLfQS0zlTh2UgFi6QeYWKvVXUsh1o0wr/0j8w==",
       "dependencies": {
         "@garmin/fitsdk": "^21.213.0",
         "axios": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "axios": "^1.17.0",
     "events": "^3.3.0",
     "gd-eventlog": "^0.1.27",
-    "incyclist-services": "^1.7.119",
+    "incyclist-services": "^1.7.120",
     "mqtt": "^5.15.2",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",

--- a/src/components/RideMenu/RideMenu.component.test.tsx
+++ b/src/components/RideMenu/RideMenu.component.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+import { RideMenu } from './RideMenu';
+
+// Full end-to-end path (RidePageService -> RideMenu -> RideMenuView), unlike RideMenu.test.tsx
+// which targets RideMenuView directly - this is the seam that actually needs to react to a
+// service-driven update while the menu stays mounted (e.g. Gear Settings changing cycling mode).
+let capturedHandlers: Record<string, (...args: any[]) => void> = {};
+const mockOn = jest.fn((event: string, handler: (...args: any[]) => void) => { capturedHandlers[event] = handler; });
+const mockOff = jest.fn();
+const mockGetPageObserver = jest.fn(() => ({ on: mockOn, off: mockOff }));
+
+let mockMenuProps: any;
+const mockGetPageDisplayProps = jest.fn(() => ({ menuProps: mockMenuProps }));
+
+const mockService = {
+    getPageDisplayProps: mockGetPageDisplayProps,
+    getPageObserver: mockGetPageObserver,
+    onPause: jest.fn(),
+    onResume: jest.fn(),
+    onStepBack: jest.fn(),
+    onStepForward: jest.fn(),
+    onIncreaseLoad: jest.fn(),
+    onDecreaseLoad: jest.fn(),
+    adjustLoad: jest.fn(),
+};
+
+jest.mock('incyclist-services', () => ({
+    getRidePageService: () => mockService,
+    useRideSettingsDisplay: () => ({
+        open: jest.fn(() => ({ on: jest.fn(), off: jest.fn() })),
+        close: jest.fn(),
+        getDisplayProps: jest.fn(() => ({ rideView: 'sv', rideViewOptions: new Map([['sv', 'Street View']]) })),
+        setRideView: jest.fn(),
+    }),
+}));
+
+jest.mock('../../hooks', () => ({
+    useScreenLayout: jest.fn(() => 'normal'),
+    useIsTablet: jest.fn(() => false),
+    useLogging: jest.fn(() => ({ logEvent: jest.fn(), logError: jest.fn() })),
+}));
+
+jest.mock('../Icon', () => ({ Icon: () => null }));
+jest.mock('../GearSettings', () => ({ GearSettings: () => null }));
+jest.mock('../RideSettings', () => ({ RideSettings: () => null }));
+jest.mock('../SettingsPlaceholder', () => ({ SettingsPlaceholder: () => null }));
+jest.mock('../ActivitySummaryDialog', () => ({ ActivitySummaryDialog: () => null }));
+jest.mock('../WorkoutSettingsDialog', () => ({ WorkoutSettingsDialog: () => null }));
+
+const loadButtons = { inc1: '+5W', dec1: '-5W', inc5: '+50W', dec5: '-50W' };
+const gearButtons = { inc1: '+1', dec1: '-1', inc5: '+5', dec5: '-5' };
+
+describe('RideMenu (smart component)', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        capturedHandlers = {};
+        mockMenuProps = { showResume: false, loadControl: { visible: true, label: 'Load', buttons: loadButtons }, showRideSettings: true };
+    });
+
+    it('subscribes to page-update on mount and unsubscribes on unmount', () => {
+        const { unmount } = render(<RideMenu visible={true} onClose={jest.fn()} />);
+        expect(mockOn).toHaveBeenCalledWith('page-update', expect.any(Function));
+
+        unmount();
+        expect(mockOff).toHaveBeenCalledWith('page-update', expect.any(Function));
+    });
+
+    // The exact reported scenario: cycling mode changes (RidePageService.onDeviceModeChanged()
+    // recomputing menuProps.loadControl and emitting page-update) while the Ride Menu stays
+    // mounted - with no local RideMenu state change (no dialog open/close) to force a re-render.
+    it('re-renders with fresh loadControl when the service emits page-update, with no local state change', () => {
+        const { getByText, queryByText } = render(<RideMenu visible={true} onClose={jest.fn()} />);
+        expect(getByText('+5W')).toBeTruthy();
+
+        mockMenuProps = { ...mockMenuProps, loadControl: { visible: true, label: 'Gear', buttons: gearButtons } };
+        act(() => { capturedHandlers['page-update']?.(); });
+
+        expect(getByText('+1')).toBeTruthy();
+        expect(queryByText('+5W')).toBeNull();
+    });
+
+    it('hides the Load/Gear buttons when a page-update resolves loadControl to hidden', () => {
+        const { getByText, queryByText } = render(<RideMenu visible={true} onClose={jest.fn()} />);
+        expect(getByText('+5W')).toBeTruthy();
+
+        mockMenuProps = { ...mockMenuProps, loadControl: { visible: false } };
+        act(() => { capturedHandlers['page-update']?.(); });
+
+        expect(queryByText('+5W')).toBeNull();
+        expect(queryByText('+1')).toBeNull();
+    });
+});

--- a/src/components/RideMenu/RideMenu.stories.tsx
+++ b/src/components/RideMenu/RideMenu.stories.tsx
@@ -40,8 +40,13 @@ const meta: Meta<typeof RideMenuView> = {
 
         onStepBack: fn(),
         onStepForward: fn(),
+        // Default to the pre-existing "Load" wording (ERG mode) - stories that need the SIM/Gear
+        // variant override loadControl explicitly, see WorkoutOpenGearMode.
+        loadControl: { visible: true, label: 'Load', buttons: { inc1: '+5W', dec1: '-5W', inc5: '+50W', dec5: '-50W' } },
         onIncreaseLoad: fn(),
         onDecreaseLoad: fn(),
+        onIncreaseLoadBig: fn(),
+        onDecreaseLoadBig: fn(),
         onWorkoutSettings: fn(),
 
         renderGearSettings: () => <GearSettingsView {...AllTypes.args as any} onClose={fn()} />,
@@ -85,12 +90,42 @@ export const GearSettingsActive: Story = {
     },
 };
 
+/**
+ * A plain route ride (no workout attached, `workout` defaults false) in SIM mode with virtual
+ * shifting still needs Gear buttons - the row is not gated on `workout`. Ride Settings still
+ * applies (this ride has a route).
+ */
+export const RouteOnlyGearMode: Story = {
+    args: {
+        visible: true,
+        showResume: false,
+        activeDialog: null,
+        loadControl: { visible: true, label: 'Gear', buttons: { inc1: '+1', dec1: '-1', inc5: '+5', dec5: '-5' } },
+    },
+};
+
+/**
+ * A plain route ride in SIM mode without virtual shifting: no gear concept, nothing to nudge, so
+ * the row is hidden entirely (not just disabled).
+ */
+export const RouteOnlyLoadControlHidden: Story = {
+    args: {
+        visible: true,
+        showResume: false,
+        activeDialog: null,
+        loadControl: { visible: false },
+    },
+};
+
 export const WorkoutOpen: Story = {
     args: {
         visible: true,
         showResume: false,
         activeDialog: null,
         workout: true,
+        // These stories depict the dedicated Workout-only ride screen - no route, so no Ride
+        // View to select.
+        showRideSettings: false,
         canStepBack: true,
         canStepForward: true,
     },
@@ -102,31 +137,66 @@ export const WorkoutFirstStep: Story = {
         showResume: false,
         activeDialog: null,
         workout: true,
+        showRideSettings: false,
         canStepBack: false,
         canStepForward: true,
     },
 };
 
 /**
- * Session 5.10 fit check - the item list has grown across 5.4 (Step Back/Forward, Load), 5.5
- * (RideMenu workout gating), and now 5.10 (Workout Settings). `iphone15Pro` (852x393) is the
- * same viewport already registered in `.storybook/preview.ts` and used by
- * `WorkoutRidePage.stories.tsx` for its compact/normal breakpoint checks (<420dp height =
- * compact). Every workout-ride menu item is present here: Pause, End Ride (footer, always),
- * Step Back/Forward, Increase/Decrease Load, Gear Settings, Ride Settings, Workout Settings
- * (content, this story).
+ * SIM mode with virtual shifting: the row relabels to "Gear" (matching ShiftingControl's
+ * non-workout gear-shift wording) instead of "Load". Same layout as WorkoutOpen otherwise - only
+ * loadControl.label differs.
+ */
+export const WorkoutOpenGearMode: Story = {
+    args: {
+        visible: true,
+        showResume: false,
+        activeDialog: null,
+        workout: true,
+        // These stories depict the dedicated Workout-only ride screen - no route, so no Ride
+        // View to select.
+        showRideSettings: false,
+        canStepBack: true,
+        canStepForward: true,
+        loadControl: { visible: true, label: 'Gear', buttons: { inc1: '+1', dec1: '-1', inc5: '+5', dec5: '-5' } },
+    },
+};
+
+/**
+ * SIM mode without virtual shifting: there is no gear concept and nothing to nudge, so
+ * RidePageService resolves loadControl.visible to false and the row must not render at all (not
+ * just show disabled buttons).
+ */
+export const WorkoutOpenLoadControlHidden: Story = {
+    args: {
+        visible: true,
+        showResume: false,
+        activeDialog: null,
+        workout: true,
+        // These stories depict the dedicated Workout-only ride screen - no route, so no Ride
+        // View to select.
+        showRideSettings: false,
+        canStepBack: true,
+        canStepForward: true,
+        loadControl: { visible: false },
+    },
+};
+
+/**
+ * Fit check - the item list has grown over several rounds of changes: Step Back/Forward, Load
+ * (now 4 individual small/big Load buttons instead of one shared row), Gear Settings/Ride
+ * Settings/Workout Settings. `iphone15Pro` (852x393) is the same viewport already registered in
+ * `.storybook/preview.ts` and used by `WorkoutRidePage.stories.tsx` for its compact/normal
+ * breakpoint checks (<420dp height = compact). Every workout-ride menu item is present here:
+ * Pause, End Ride (footer, always), Step Back/Forward, the 4 Load buttons, Gear Settings, Ride
+ * Settings, Workout Settings (content, this story).
  *
- * FIXED (follow-up session): a headless Playwright screenshot against this exact story at
- * 852x393 originally showed the content list did NOT fully fit above the fixed footer
- * (Pause/End Ride) - "Ride Settings" was the last item visible without scrolling and "Workout
- * Settings" sat below the fold. Row height (`minHeight: 52`) is a deliberate touch-target size
- * and was not reduced. Instead, since ride screens run landscape (width is the generous
- * resource, height is scarce - workout-mobile-hld.md §5), `Gear Settings`/`Ride Settings`/
- * `Workout Settings` were rearranged into a 2-column tile layout (`renderMenuTile`/
- * `renderTileRow`), the same way `Step Back/Forward` and `Load +/-` already share a row. This
- * removes exactly one 52px row, which lined up with the observed one-item overflow. Re-verified
- * via headless Playwright screenshot against this story: the full list, including Workout
- * Settings, now fits above the footer without scrolling.
+ * A prior overflow (content not fitting above the fixed footer) was fixed by packing
+ * Gear/Ride/Workout Settings into a 2-column tile layout instead of one-per-row. The Load row
+ * split into 4 individual buttons (small step + the swipe gesture's "big" step) added a second
+ * content row that fit check has not been re-verified against via a fresh screenshot - if a
+ * future overflow shows up here, this is the most likely place to look first.
  */
 export const WorkoutFullListCompact: Story = {
     args: {
@@ -134,6 +204,9 @@ export const WorkoutFullListCompact: Story = {
         showResume: false,
         activeDialog: null,
         workout: true,
+        // These stories depict the dedicated Workout-only ride screen - no route, so no Ride
+        // View to select.
+        showRideSettings: false,
         canStepBack: true,
         canStepForward: true,
     },
@@ -145,8 +218,8 @@ export const WorkoutFullListCompact: Story = {
 /**
  * Tablet-width verification (`ipadAir`, 1180x820 - a registered `.storybook/preview.ts` viewport,
  * same convention `WorkoutRidePage.stories.tsx` uses for its own compact/tablet pair). Below the
- * tablet-width breakpoint, the panel is capped at 300px and Step Back/Forward, Increase/Decrease
- * Load, and the settings tiles pack two-per-row (see `WorkoutFullListCompact` above and
+ * tablet-width breakpoint, the panel is capped at 300px and Step Back/Forward, the 4 Load
+ * buttons, and the settings tiles pack two-per-row (see `WorkoutFullListCompact` above and
  * `WorkoutOpen`). At this width the panel widens proportionally to the screen and every one of
  * those items renders on its own row instead, since there is no vertical pressure forcing the
  * 2-column packing here.
@@ -157,6 +230,9 @@ export const WorkoutOpenTablet: Story = {
         showResume: false,
         activeDialog: null,
         workout: true,
+        // These stories depict the dedicated Workout-only ride screen - no route, so no Ride
+        // View to select.
+        showRideSettings: false,
         canStepBack: true,
         canStepForward: true,
     },

--- a/src/components/RideMenu/RideMenu.test.tsx
+++ b/src/components/RideMenu/RideMenu.test.tsx
@@ -61,6 +61,13 @@ const mockProps = {
     onExitFromSummary: jest.fn(),
 };
 
+// The Load/Gear row is now 4 individual icon+label tiles (small step, then the swipe gesture's
+// "big" step) instead of icon-only buttons sharing a row with a separate static caption - each
+// button's own visible text is its tap target, so there is no inert text next to a small icon a
+// tablet user could mistakenly tap.
+const loadButtons = { inc1: '+5W', dec1: '-5W', inc5: '+50W', dec5: '-50W' };
+const gearButtons = { inc1: '+1', dec1: '-1', inc5: '+5', dec5: '-5' };
+
 const workoutProps = {
     ...mockProps,
     workout: true,
@@ -68,8 +75,11 @@ const workoutProps = {
     canStepForward: true,
     onStepBack: jest.fn(),
     onStepForward: jest.fn(),
+    loadControl: { visible: true, label: 'Load' as const, buttons: loadButtons },
     onIncreaseLoad: jest.fn(),
     onDecreaseLoad: jest.fn(),
+    onIncreaseLoadBig: jest.fn(),
+    onDecreaseLoadBig: jest.fn(),
     onWorkoutSettings: jest.fn(),
 };
 
@@ -102,7 +112,7 @@ describe('RideMenuView', () => {
         render(<RideMenuView {...mockProps} visible={true} showResume={false} activeDialog={null} />);
     });
 
-    it('renders the workout controls (Step Back/Forward, Increase/Decrease Load)', () => {
+    it('renders the workout controls (Step Back/Forward, Load buttons)', () => {
         render(<RideMenuView {...workoutProps} visible={true} activeDialog={null} />);
     });
 
@@ -151,24 +161,6 @@ describe('RideMenuView', () => {
         expect(onStepForward).toHaveBeenCalledTimes(1);
     });
 
-    it('calls onIncreaseLoad when Increase Load is pressed', () => {
-        const onIncreaseLoad = jest.fn();
-        const { getByLabelText } = render(
-            <RideMenuView {...workoutProps} visible={true} activeDialog={null} onIncreaseLoad={onIncreaseLoad} />
-        );
-        fireEvent.press(getByLabelText('Increase Load'));
-        expect(onIncreaseLoad).toHaveBeenCalledTimes(1);
-    });
-
-    it('calls onDecreaseLoad when Decrease Load is pressed', () => {
-        const onDecreaseLoad = jest.fn();
-        const { getByLabelText } = render(
-            <RideMenuView {...workoutProps} visible={true} activeDialog={null} onDecreaseLoad={onDecreaseLoad} />
-        );
-        fireEvent.press(getByLabelText('Decrease Load'));
-        expect(onDecreaseLoad).toHaveBeenCalledTimes(1);
-    });
-
     it('does not call onStepBack when Step Back is disabled', () => {
         const onStepBack = jest.fn();
         const { getByLabelText } = render(
@@ -178,12 +170,140 @@ describe('RideMenuView', () => {
         expect(onStepBack).not.toHaveBeenCalled();
     });
 
-    it('does not render workout controls outside workout mode', () => {
-        const { queryByLabelText } = render(
+    describe('Load/Gear buttons', () => {
+        it('renders all four button labels from menuProps.loadControl.buttons, unchanged', () => {
+            const { getByText } = render(<RideMenuView {...workoutProps} visible={true} activeDialog={null} />);
+            expect(getByText('+5W')).toBeTruthy();
+            expect(getByText('-5W')).toBeTruthy();
+            expect(getByText('+50W')).toBeTruthy();
+            expect(getByText('-50W')).toBeTruthy();
+        });
+
+        // Three-column layout: "Increase Load   +5W   +50W" / "Decrease Load   -5W   -50W" - the
+        // row label states the direction, each numeric value is its own separate tappable chip.
+        it('renders "Increase {label}"/"Decrease {label}" row captions', () => {
+            const { getByText } = render(<RideMenuView {...workoutProps} visible={true} activeDialog={null} />);
+            expect(getByText('Increase Load')).toBeTruthy();
+            expect(getByText('Decrease Load')).toBeTruthy();
+        });
+
+        it('renders "Increase Gear"/"Decrease Gear" row captions in Gear mode', () => {
+            const { getByText } = render(
+                <RideMenuView {...workoutProps} loadControl={{ visible: true, label: 'Gear', buttons: gearButtons }} visible={true} activeDialog={null} />
+            );
+            expect(getByText('Increase Gear')).toBeTruthy();
+            expect(getByText('Decrease Gear')).toBeTruthy();
+        });
+
+        it('calls onIncreaseLoad/onDecreaseLoad (small step) when the small tiles are pressed', () => {
+            const onIncreaseLoad = jest.fn();
+            const onDecreaseLoad = jest.fn();
+            const { getByText } = render(
+                <RideMenuView {...workoutProps} visible={true} activeDialog={null} onIncreaseLoad={onIncreaseLoad} onDecreaseLoad={onDecreaseLoad} />
+            );
+            fireEvent.press(getByText('+5W'));
+            fireEvent.press(getByText('-5W'));
+            expect(onIncreaseLoad).toHaveBeenCalledTimes(1);
+            expect(onDecreaseLoad).toHaveBeenCalledTimes(1);
+        });
+
+        it('calls onIncreaseLoadBig/onDecreaseLoadBig when the big tiles are pressed', () => {
+            const onIncreaseLoadBig = jest.fn();
+            const onDecreaseLoadBig = jest.fn();
+            const { getByText } = render(
+                <RideMenuView {...workoutProps} visible={true} activeDialog={null} onIncreaseLoadBig={onIncreaseLoadBig} onDecreaseLoadBig={onDecreaseLoadBig} />
+            );
+            fireEvent.press(getByText('+50W'));
+            fireEvent.press(getByText('-50W'));
+            expect(onIncreaseLoadBig).toHaveBeenCalledTimes(1);
+            expect(onDecreaseLoadBig).toHaveBeenCalledTimes(1);
+        });
+
+        // Label/icon/visibility/button text all come from menuProps.loadControl (RidePageService),
+        // resolved from LoadButtonMode - this view must not interpret cycling mode itself.
+        it('renders Gear-mode button labels verbatim (SIM mode, virtual shifting)', () => {
+            const { getByText } = render(
+                <RideMenuView {...workoutProps} loadControl={{ visible: true, label: 'Gear', buttons: gearButtons }} visible={true} activeDialog={null} />
+            );
+            expect(getByText('+1')).toBeTruthy();
+            expect(getByText('-1')).toBeTruthy();
+            expect(getByText('+5')).toBeTruthy();
+            expect(getByText('-5')).toBeTruthy();
+        });
+
+        it('does not render any Load/Gear button when loadControl.visible is false (SIM mode, no virtual shifting)', () => {
+            const { queryByText } = render(
+                <RideMenuView {...workoutProps} loadControl={{ visible: false }} visible={true} activeDialog={null} />
+            );
+            expect(queryByText('+5W')).toBeNull();
+            expect(queryByText('-5W')).toBeNull();
+            expect(queryByText('+50W')).toBeNull();
+            expect(queryByText('-50W')).toBeNull();
+        });
+
+        it('does not render any Load/Gear button when loadControl is absent', () => {
+            const { queryByText } = render(
+                <RideMenuView {...workoutProps} loadControl={undefined} visible={true} activeDialog={null} />
+            );
+            expect(queryByText('+5W')).toBeNull();
+        });
+
+        it('does not render any Load/Gear button when loadControl.visible is true but buttons is absent', () => {
+            const { queryByText } = render(
+                <RideMenuView {...workoutProps} loadControl={{ visible: true, label: 'Load' }} visible={true} activeDialog={null} />
+            );
+            expect(queryByText('+5W')).toBeNull();
+        });
+
+        // A plain route ride (no workout attached) still needs Load/Gear buttons whenever cycling
+        // mode calls for them - not gated on `workout`, only on loadControl.
+        it('renders outside workout mode when loadControl.visible is true', () => {
+            const { getByText } = render(
+                <RideMenuView {...mockProps} loadControl={{ visible: true, label: 'Load', buttons: loadButtons }} visible={true} activeDialog={null} />
+            );
+            expect(getByText('+5W')).toBeTruthy();
+            expect(getByText('-50W')).toBeTruthy();
+        });
+
+        it('renders Gear-mode buttons outside workout mode too', () => {
+            const { getByText } = render(
+                <RideMenuView {...mockProps} loadControl={{ visible: true, label: 'Gear', buttons: gearButtons }} visible={true} activeDialog={null} />
+            );
+            expect(getByText('+1')).toBeTruthy();
+        });
+
+        it('does not render outside workout mode when loadControl is absent', () => {
+            const { queryByText } = render(
+                <RideMenuView {...mockProps} visible={true} activeDialog={null} />
+            );
+            expect(queryByText('+5W')).toBeNull();
+        });
+    });
+
+    it('does not render Step Back/Forward or Workout Settings outside workout mode', () => {
+        const { queryByLabelText, queryByText } = render(
             <RideMenuView {...mockProps} visible={true} activeDialog={null} />
         );
         expect(queryByLabelText('Step Back')).toBeNull();
-        expect(queryByLabelText('Increase Load')).toBeNull();
+        expect(queryByText('Workout Settings')).toBeNull();
+    });
+
+    // Ride Settings (Ride View selector) is route-specific - hidden on a route-less Workout-only
+    // ride, shown otherwise. Driven by menuProps.showRideSettings, not derived from `workout` in
+    // this view.
+    it('renders Ride Settings by default', () => {
+        const { getByText } = render(
+            <RideMenuView {...mockProps} visible={true} activeDialog={null} />
+        );
+        expect(getByText('Ride Settings')).toBeTruthy();
+    });
+
+    it('does not render Ride Settings when showRideSettings is false (route-less Workout-only ride)', () => {
+        const { queryByText, getByText } = render(
+            <RideMenuView {...workoutProps} showRideSettings={false} visible={true} activeDialog={null} />
+        );
+        expect(queryByText('Ride Settings')).toBeNull();
+        expect(getByText('Gear Settings')).toBeTruthy();
     });
 
     it('renders the Workout Settings menu item on a workout ride', () => {
@@ -262,23 +382,29 @@ describe('RideMenuView', () => {
             expect(queryByText('Step')).toBeNull();
         });
 
-        it('splits Increase/Decrease Load onto their own rows instead of sharing the "Load" row', () => {
-            const { getByText, queryByText } = render(
+        // Unlike Step/Settings, the Load/Gear rows (renderMagnitudeRow) never pack two unrelated
+        // items onto a shared row to begin with - each row is already just one label + its two
+        // values, so tablet width changes nothing here.
+        it('still renders the Load rows unchanged at tablet width', () => {
+            const { getByText } = render(
                 <RideMenuView {...workoutProps} visible={true} activeDialog={null} />
             );
             expect(getByText('Increase Load')).toBeTruthy();
             expect(getByText('Decrease Load')).toBeTruthy();
-            expect(queryByText('Load')).toBeNull();
+            expect(getByText('+5W')).toBeTruthy();
+            expect(getByText('-5W')).toBeTruthy();
+            expect(getByText('+50W')).toBeTruthy();
+            expect(getByText('-50W')).toBeTruthy();
         });
 
         it('still triggers Step Back/Forward and Load callbacks when split onto their own rows', () => {
             const onStepBack = jest.fn();
             const onIncreaseLoad = jest.fn();
-            const { getByLabelText } = render(
+            const { getByLabelText, getByText } = render(
                 <RideMenuView {...workoutProps} visible={true} activeDialog={null} onStepBack={onStepBack} onIncreaseLoad={onIncreaseLoad} />
             );
             fireEvent.press(getByLabelText('Step Back'));
-            fireEvent.press(getByLabelText('Increase Load'));
+            fireEvent.press(getByText('+5W'));
             expect(onStepBack).toHaveBeenCalledTimes(1);
             expect(onIncreaseLoad).toHaveBeenCalledTimes(1);
         });
@@ -313,14 +439,24 @@ describe('RideMenuView', () => {
             (useScreenLayout as jest.Mock).mockReturnValue('normal');
         });
 
-        it('keeps the phone-style paired "Step"/"Load" rows instead of splitting - compact wins over tablet width', () => {
+        it('keeps the phone-style paired "Step" row instead of splitting - compact wins over tablet width', () => {
             const { getByText, queryByText } = render(
                 <RideMenuView {...workoutProps} visible={true} activeDialog={null} />
             );
             expect(getByText('Step')).toBeTruthy();
-            expect(getByText('Load')).toBeTruthy();
             expect(queryByText('Step Back')).toBeNull();
-            expect(queryByText('Increase Load')).toBeNull();
+        });
+
+        it('still renders the Load rows unchanged in compact tablet layout too', () => {
+            const { getByText } = render(
+                <RideMenuView {...workoutProps} visible={true} activeDialog={null} />
+            );
+            expect(getByText('Increase Load')).toBeTruthy();
+            expect(getByText('Decrease Load')).toBeTruthy();
+            expect(getByText('+5W')).toBeTruthy();
+            expect(getByText('-5W')).toBeTruthy();
+            expect(getByText('+50W')).toBeTruthy();
+            expect(getByText('-50W')).toBeTruthy();
         });
     });
 });

--- a/src/components/RideMenu/RideMenu.tsx
+++ b/src/components/RideMenu/RideMenu.tsx
@@ -14,11 +14,11 @@ export const RideMenu = ({ visible, finished, onClose, onCloseRidePage=()=>{} }:
     // render, but without this nothing re-renders RideMenu itself when the service updates
     // menuProps out from under it (e.g. RidePageService.onDeviceModeChanged() recomputing
     // loadControl while the menu stays open behind the Gear Settings dialog).
-    const [, forceUpdate] = useState(0);
+    const [_renderTick, setRenderTick] = useState(0);
 
     useEffect(() => {
         const observer = service.getPageObserver();
-        const onPageUpdate = () => forceUpdate(n => n + 1);
+        const onPageUpdate = () => setRenderTick(n => n + 1);
         observer?.on('page-update', onPageUpdate);
         return () => { observer?.off('page-update', onPageUpdate); };
     }, [service]);

--- a/src/components/RideMenu/RideMenu.tsx
+++ b/src/components/RideMenu/RideMenu.tsx
@@ -2,18 +2,45 @@ import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { RideMenuProps, ActiveDialog } from './types';
 import { getRidePageService } from 'incyclist-services';
 import { RideMenuView } from './RideMenuView';
+import { LARGE_LOAD_INCREMENT } from '../../hooks/ride/useRideGestures';
 
-export const RideMenu = ({ visible, finished, workout = false, onClose, onCloseRidePage=()=>{} }: RideMenuProps) => {
+export const RideMenu = ({ visible, finished, onClose, onCloseRidePage=()=>{} }: RideMenuProps) => {
     const service = getRidePageService();
     const refInitialized = useRef(false)
 
     const [activeDialog, setActiveDialog] = useState<ActiveDialog>(null);
+    // Forces a re-render on every page-update while the menu is mounted, matching
+    // WorkoutSettingsDialog's subscription pattern - menuProps below is read fresh on every
+    // render, but without this nothing re-renders RideMenu itself when the service updates
+    // menuProps out from under it (e.g. RidePageService.onDeviceModeChanged() recomputing
+    // loadControl while the menu stays open behind the Gear Settings dialog).
+    const [, forceUpdate] = useState(0);
 
-    // menuProps are derived from service display props, which means they reflect current state
+    useEffect(() => {
+        const observer = service.getPageObserver();
+        const onPageUpdate = () => forceUpdate(n => n + 1);
+        observer?.on('page-update', onPageUpdate);
+        return () => { observer?.off('page-update', onPageUpdate); };
+    }, [service]);
+
+    // menuProps are derived from service display props, which means they reflect current state.
+    // Whether this ride has workout controls (Step/Load/Workout Settings) - Workout-only or a
+    // combo ride with a workout attached, either way - is decided by RidePageService, not here:
+    // menuProps only ever carries canStepBack/canStepForward together when isWorkoutAttached() is
+    // true, so their presence alone is the signal, with no separate `workout` flag to thread in
+    // from the parent ride screen and risk dropping along the way.
     const menuProps = service.getPageDisplayProps()?.menuProps;
+    const workout = menuProps?.canStepBack !== undefined;
     const showResume = menuProps?.showResume ?? false;
     const canStepBack = menuProps?.canStepBack ?? false;
     const canStepForward = menuProps?.canStepForward ?? false;
+    // loadControl is governed by cycling mode alone (RidePageService.getLoadButtonMode()), not by
+    // workout attachment - a plain route ride still needs Load/Gear buttons, exactly like a
+    // workout ride.
+    const loadControl = menuProps?.loadControl;
+    // Ride Settings (Ride View selector) applies to any ride with a route - false only for a
+    // route-less Workout-only ride. Defaults to true (show) if menuProps hasn't resolved yet.
+    const showRideSettings = menuProps?.showRideSettings ?? true;
 
     // Handles closing the menu, considering if a dialog is active
     const handleCloseMenu = useCallback(() => {
@@ -77,6 +104,17 @@ export const RideMenu = ({ visible, finished, workout = false, onClose, onCloseR
         service.onDecreaseLoad();
     }, [service]);
 
+    // Big-step equivalents, matching the swipe gesture's left/right step - onIncreaseLoad/
+    // onDecreaseLoad above only ever apply the small (loadIncrement) step, so the big step goes
+    // through adjustLoad() directly, exactly like useRideGestures.ts's left/right handler does.
+    const handleIncreaseLoadBig = useCallback(() => {
+        service.adjustLoad(LARGE_LOAD_INCREMENT);
+    }, [service]);
+
+    const handleDecreaseLoadBig = useCallback(() => {
+        service.adjustLoad(-LARGE_LOAD_INCREMENT);
+    }, [service]);
+
     // Generic handler to close any active dialog
     const handleDialogClose = useCallback(() => {
         setActiveDialog(null);
@@ -97,6 +135,8 @@ export const RideMenu = ({ visible, finished, workout = false, onClose, onCloseR
             workout={workout}
             canStepBack={canStepBack}
             canStepForward={canStepForward}
+            loadControl={loadControl}
+            showRideSettings={showRideSettings}
             onClose={handleCloseMenu} // Pass the smart component's close handler
             onPause={handlePauseResume}
             onResume={handlePauseResume}
@@ -105,6 +145,8 @@ export const RideMenu = ({ visible, finished, workout = false, onClose, onCloseR
             onStepForward={handleStepForward}
             onIncreaseLoad={handleIncreaseLoad}
             onDecreaseLoad={handleDecreaseLoad}
+            onIncreaseLoadBig={handleIncreaseLoadBig}
+            onDecreaseLoadBig={handleDecreaseLoadBig}
             onGearSettings={handleGearSettings}
             onRideSettings={handleRideSettings}
             onWorkoutSettings={handleWorkoutSettings}

--- a/src/components/RideMenu/RideMenu.tsx
+++ b/src/components/RideMenu/RideMenu.tsx
@@ -9,27 +9,25 @@ export const RideMenu = ({ visible, finished, onClose, onCloseRidePage=()=>{} }:
     const refInitialized = useRef(false)
 
     const [activeDialog, setActiveDialog] = useState<ActiveDialog>(null);
-    // Forces a re-render on every page-update while the menu is mounted, matching
-    // WorkoutSettingsDialog's subscription pattern - menuProps below is read fresh on every
-    // render, but without this nothing re-renders RideMenu itself when the service updates
-    // menuProps out from under it (e.g. RidePageService.onDeviceModeChanged() recomputing
-    // loadControl while the menu stays open behind the Gear Settings dialog).
-    const [_renderTick, setRenderTick] = useState(0);
+    // menuProps in state, seeded from the current service value and refreshed on every
+    // page-update while the menu is mounted (matching WorkoutSettingsDialog's subscription
+    // pattern) - without this, nothing re-renders RideMenu when the service updates menuProps
+    // out from under it (e.g. RidePageService.onDeviceModeChanged() recomputing loadControl while
+    // the menu stays open behind the Gear Settings dialog).
+    const [menuProps, setMenuProps] = useState(() => service.getPageDisplayProps()?.menuProps);
 
     useEffect(() => {
         const observer = service.getPageObserver();
-        const onPageUpdate = () => setRenderTick(n => n + 1);
+        const onPageUpdate = () => setMenuProps(service.getPageDisplayProps()?.menuProps);
         observer?.on('page-update', onPageUpdate);
         return () => { observer?.off('page-update', onPageUpdate); };
     }, [service]);
 
-    // menuProps are derived from service display props, which means they reflect current state.
     // Whether this ride has workout controls (Step/Load/Workout Settings) - Workout-only or a
     // combo ride with a workout attached, either way - is decided by RidePageService, not here:
     // menuProps only ever carries canStepBack/canStepForward together when isWorkoutAttached() is
     // true, so their presence alone is the signal, with no separate `workout` flag to thread in
     // from the parent ride screen and risk dropping along the way.
-    const menuProps = service.getPageDisplayProps()?.menuProps;
     const workout = menuProps?.canStepBack !== undefined;
     const showResume = menuProps?.showResume ?? false;
     const canStepBack = menuProps?.canStepBack ?? false;

--- a/src/components/RideMenu/RideMenuView.tsx
+++ b/src/components/RideMenu/RideMenuView.tsx
@@ -33,6 +33,15 @@ interface TileSpec {
     label: string;
     onPress: () => void;
     disabled?: boolean;
+    // Fuller wording for screen readers when the visible label is a short numeric abbreviation
+    // (e.g. "+5W") that reads unclearly on its own - defaults to `label` otherwise.
+    accessibilityLabel?: string;
+}
+
+interface MagnitudeRowSpec {
+    label: string;
+    small: { text: string; onPress: () => void };
+    big: { text: string; onPress: () => void };
 }
 
 // Panel width caps, named rather than inlined. PHONE_MAX_PANEL_WIDTH is the pre-existing 300px
@@ -60,9 +69,13 @@ export const RideMenuView = ({
     canStepForward = false,
     onStepBack = () => {},
     onStepForward = () => {},
+    loadControl,
     onIncreaseLoad = () => {},
     onDecreaseLoad = () => {},
+    onIncreaseLoadBig = () => {},
+    onDecreaseLoadBig = () => {},
     onWorkoutSettings = () => {},
+    showRideSettings = true,
 
     renderGearSettings = () => <GearSettings onClose={onDialogClose} />,
     renderRideSettings = () => <RideSettings onClose={onDialogClose} />,
@@ -167,12 +180,50 @@ export const RideMenuView = ({
         );
     };
 
+    // Small/big magnitude value, its own tappable chip with its own visible text (e.g. "+5W") -
+    // there is no separate static caption next to it, so there is nothing inert nearby to
+    // mistakenly tap instead of the value itself.
+    const renderValueButton = (text: string, onPress: () => void) => {
+        const handlePress = () => {
+            logEvent({ message: 'button clicked', button: text });
+            onPress();
+        };
+
+        return (
+            <Pressable
+                key={text}
+                onPress={handlePress}
+                accessibilityLabel={text}
+                style={({ pressed }) => [
+                    styles.valueButton,
+                    pressed && styles.menuItemPressed,
+                ]}
+            >
+                <Text style={styles.valueButtonText}>{text}</Text>
+            </Pressable>
+        );
+    };
+
+    // Three-column row (label, small step, big step) for the Load/Gear row - e.g.
+    // "Increase Load   +5W   +50W" / "Decrease Load   -5W   -50W". Small = loadIncrement (via
+    // onIncreaseLoad/onDecreaseLoad), big = the swipe gesture's own "big" step (via
+    // onIncreaseLoadBig/onDecreaseLoadBig).
+    const renderMagnitudeRow = ({ label, small, big }: MagnitudeRowSpec) => (
+        <View style={styles.menuRow} key={label}>
+            <Text style={styles.menuItemLabel}>{label}</Text>
+            <View style={styles.menuRowButtons}>
+                {renderValueButton(small.text, small.onPress)}
+                {renderValueButton(big.text, big.onPress)}
+            </View>
+        </View>
+    );
+
     // Half-width icon+label tile, used to pack two unrelated settings entries (Gear Settings,
     // Ride Settings, Workout Settings) onto shared rows the same way Step/Load already share
     // rows. Unlike renderRowButton (icon-only, one shared row caption), each of these actions
     // needs its own visible label, so this uses the same icon+label content as a full-width
     // menu item, just at roughly half width.
-    const renderMenuTile = ({ icon, label, onPress, disabled = false }: TileSpec) => {
+    const renderMenuTile = ({ icon, label, onPress, disabled = false, accessibilityLabel }: TileSpec) => {
         const handlePress = () => {
             logEvent({ message: 'button clicked', button: label });
             onPress();
@@ -183,6 +234,7 @@ export const RideMenuView = ({
                 key={label}
                 onPress={handlePress}
                 disabled={disabled}
+                accessibilityLabel={accessibilityLabel ?? label}
                 style={({ pressed }) => [
                     styles.menuTile,
                     pressed && !disabled && styles.menuItemPressed,
@@ -280,18 +332,39 @@ export const RideMenuView = ({
                             { icon: 'chevron-left', label: 'Step Back', onPress: onStepBack, disabled: !canStepBack },
                             { icon: 'chevron-right', label: 'Step Forward', onPress: onStepForward, disabled: !canStepForward }
                         )}
-                        {workout && renderMenuRow('Load',
-                            { icon: 'minus', label: 'Decrease Load', onPress: onDecreaseLoad },
-                            { icon: 'plus', label: 'Increase Load', onPress: onIncreaseLoad }
-                        )}
+                        {/* Label/icon/visibility come from RidePageService.menuProps.loadControl -
+                            this view renders it as-is rather than deciding "Load" vs "Gear" (or
+                            whether to show the row at all) from cycling mode itself, per the
+                            workspace's services=what/mobile=how split. Independent of `workout` -
+                            a plain route ride still needs Load/Gear buttons whenever cycling mode
+                            calls for them.
+
+                            Three-column rows (label, small step, big step) - e.g.
+                            "Increase Load   +5W   +50W" / "Decrease Load   -5W   -50W" - each
+                            value is its own tappable chip with its own visible text, so there is
+                            no separate static caption sitting next to a small icon-only button a
+                            rider could mistakenly tap instead. */}
+                        {loadControl?.visible && loadControl.buttons && renderMagnitudeRow({
+                            label: `Increase ${loadControl.label ?? 'Load'}`,
+                            small: { text: loadControl.buttons.inc1, onPress: onIncreaseLoad },
+                            big: { text: loadControl.buttons.inc5, onPress: onIncreaseLoadBig },
+                        })}
+                        {loadControl?.visible && loadControl.buttons && renderMagnitudeRow({
+                            label: `Decrease ${loadControl.label ?? 'Load'}`,
+                            small: { text: loadControl.buttons.dec1, onPress: onDecreaseLoad },
+                            big: { text: loadControl.buttons.dec5, onPress: onDecreaseLoadBig },
+                        })}
                         {/* Settings tiles have no icon - all three line up flush-left with each
                             other regardless of which row/column they land in. Gear/Ride Settings
                             pair onto one row and Workout Settings gets its own row - a 2-column
                             layout, same reasoning as the Step/Load rows above, to remove one 52px
-                            row on the height-constrained landscape phone layout. */}
+                            row on the height-constrained landscape phone layout. Ride Settings
+                            (Ride View selector) is route-specific - omitted (via renderTileRow's
+                            optional `right`) on a route-less Workout-only ride, per
+                            menuProps.showRideSettings. */}
                         {renderTileRow('SettingsRow1',
                             { label: 'Gear Settings', onPress: onGearSettings },
-                            { label: 'Ride Settings', onPress: onRideSettings }
+                            showRideSettings ? { label: 'Ride Settings', onPress: onRideSettings } : undefined
                         )}
                         {workout && renderTileRow('SettingsRow2',
                             { label: 'Workout Settings', onPress: onWorkoutSettings }
@@ -394,6 +467,24 @@ const styles = StyleSheet.create({
         justifyContent: 'center',
         marginLeft: 8,
         borderRadius: 4,
+    },
+    // Chip-style value button (e.g. "+5W") - a subtle outline gives it a tappable affordance
+    // (unlike rowButton, which relies on its icon for that) since its content is just numeric
+    // text sitting inline with the row's own label.
+    valueButton: {
+        minWidth: 48,
+        paddingHorizontal: 10,
+        paddingVertical: 6,
+        alignItems: 'center',
+        justifyContent: 'center',
+        marginLeft: 8,
+        borderRadius: 4,
+        borderWidth: 1,
+        borderColor: 'rgba(255,255,255,0.25)',
+    },
+    valueButtonText: {
+        color: colors.text,
+        fontSize: textSizes.normalText,
     },
     menuTileRow: {
         flexDirection: 'row',

--- a/src/components/RideMenu/types.ts
+++ b/src/components/RideMenu/types.ts
@@ -1,10 +1,6 @@
 export interface RideMenuProps {
     visible: boolean;
     finished?:boolean;
-    // true when the ride has an associated workout (workout-only ride today; a GPX/Video ride
-    // with an attached workout, phase 2, will also set this) - controls presence of the
-    // Step Back/Step Forward/Increase-Decrease Load controls, wired to WorkoutRidePageService
-    workout?: boolean;
     onClose: () => void;
     onCloseRidePage?:()=> void;
 }
@@ -31,15 +27,37 @@ export interface RideMenuViewProps {
     // workout are the same action; a distinct "Stop Workout" action (stop workout, keep riding
     // in SIM mode) only makes sense once a ride can carry a workout AND a route, phase 2.
     // Menu gains Step Back / Step Forward / Increase / Decrease Load / Workout Settings.
+    //
+    // `workout` and `loadControl` are resolved service-side (RidePageService.menuProps) and
+    // forwarded here verbatim by the smart RideMenu component - this pure view must not re-derive
+    // them from ride type or cycling mode itself (services drives *what*, this view drives *how*
+    // - workspace CLAUDE.md).
     workout?: boolean;
     canStepBack?: boolean;
     canStepForward?: boolean;
     onStepBack?: () => void;
     onStepForward?: () => void;
+    // Resolved Load/Gear row state - undefined/`visible:false` means the row must not render at
+    // all (LoadButtonMode==='hidden', no gear concept and nothing to nudge). Independent of
+    // `workout` - a plain route ride (no workout attached) still needs Load/Gear buttons whenever
+    // cycling mode calls for them. `buttons` gives each of the 4 magnitude buttons its own
+    // resolved label (e.g. "+5W"/"-50W" or "+1"/"-5") - this view renders them as-is, it must not
+    // compute Watt/gear-step wording itself.
+    loadControl?: { visible: boolean, label?: 'Load' | 'Gear', buttons?: { inc1: string, dec1: string, inc5: string, dec5: string } };
     onIncreaseLoad?: () => void;
     onDecreaseLoad?: () => void;
+    // Big-step equivalents (LARGE_LOAD_INCREMENT, matching the swipe gesture's left/right step) -
+    // each button carries its own label, so there is no shared row-caption text a rider could tap
+    // expecting it to do something (the original tablet layout bug this replaces).
+    onIncreaseLoadBig?: () => void;
+    onDecreaseLoadBig?: () => void;
     // Opens WorkoutSettingsDialog (session 5.10) - load-increment editing, gated by `workout`.
     onWorkoutSettings?: () => void;
+
+    // Whether the Ride Settings (Ride View selector) tile applies - false only for a route-less
+    // Workout-only ride, which has no view to select. Resolved service-side
+    // (RidePageService.menuProps.showRideSettings), not derived from `workout` or ride type here.
+    showRideSettings?: boolean;
 
     // the following props are required for Storybook
     renderGearSettings?: () => React.ReactNode;

--- a/src/pages/RidePage/Workout/View.tsx
+++ b/src/pages/RidePage/Workout/View.tsx
@@ -170,7 +170,6 @@ export const WorkoutRidePageView = (props: WorkoutRidePageViewProps) => {
                 <RideMenu
                     visible={true}
                     finished={menuProps.finished}
-                    workout={true}
                     onClose={onMenuClose}
                     onCloseRidePage={onCloseRidePage}
                 />

--- a/src/pages/RidePage/Workout/WorkoutRidePage.stories.tsx
+++ b/src/pages/RidePage/Workout/WorkoutRidePage.stories.tsx
@@ -203,7 +203,7 @@ export const AfterSkipBack: Story = {
 
 export const MenuOpen: Story = {
     args: {
-        displayProps: { ...MID_WORKOUT, menuProps: { showResume: false, canStepBack: true, canStepForward: true } },
+        displayProps: { ...MID_WORKOUT, menuProps: { showResume: false, canStepBack: true, canStepForward: true, loadControl: { visible: true, label: 'Load' }, showRideSettings: false } },
         getGraphActuals: (): WorkoutGraphActuals => MOCK_ACTUALS_MID,
     },
 };

--- a/src/pages/RidePage/Workout/WorkoutRidePrototype.stories.tsx
+++ b/src/pages/RidePage/Workout/WorkoutRidePrototype.stories.tsx
@@ -83,7 +83,7 @@ const MID_WORKOUT: WorkoutRidePageDisplayProps = {
     rideType: 'Workout',
     startOverlayProps: null,
     startGateProps: null,
-    menuProps: { showResume: false, canStepBack: true, canStepForward: true },
+    menuProps: { showResume: false, canStepBack: true, canStepForward: true, loadControl: { visible: true, label: 'Load' }, showRideSettings: false },
     graph: MOCK_PLAN_LIVE_MID,
     steps: {
         previous: { label: '200W', targetPower: 200, duration: 300, remaining: null, isCurrent: false },
@@ -117,7 +117,7 @@ const AFTER_SKIP_BACK: WorkoutRidePageDisplayProps = {
     rideType: 'Workout',
     startOverlayProps: null,
     startGateProps: null,
-    menuProps: { showResume: false, canStepBack: true, canStepForward: false },
+    menuProps: { showResume: false, canStepBack: true, canStepForward: false, loadControl: { visible: true, label: 'Load' }, showRideSettings: false },
     graph: MOCK_PLAN_LIVE_SKIPBACK,
     steps: {
         previous: { label: '130W', targetPower: 130, duration: 120, remaining: null, isCurrent: false },


### PR DESCRIPTION
## Summary
- Combo (route/video + attached workout) rides were missing Step Back/Forward, the Load row and Workout Settings entirely. `RideMenu` now derives "does this ride have workout controls" from the presence of `menuProps.canStepBack` (set by `RidePageService` whenever a workout is attached, combo or not) instead of a `workout` prop threaded in by each parent ride screen — which is exactly what was silently dropped for combo rides.
- The Load/Gear row is no longer gated on workout attachment at all — a plain route ride still needs Load/Gear buttons whenever cycling mode calls for them, exactly like a workout ride.
- "Ride Settings" (Ride View selector) is now hidden on a route-less Workout-only ride, which has no view to select.
- The Load/Gear row is now two three-column rows (`Increase Load  +5W  +50W` / `Decrease Load  -5W  -50W`) instead of icon-only buttons sharing a row with a separate static caption, so there's no inert text next to a small tap target a rider could mistakenly tap on a tablet-width screen. Small step reuses the existing loadIncrement action; big step matches the swipe gesture's own big-step magnitude.
- `RideMenu` now re-renders on every service `page-update` while mounted (matching `WorkoutSettingsDialog`'s existing pattern), so it reflects a cycling-mode change made via Gear Settings even with no other local state change to trigger a re-render.

Pairs with the `services` PR, which resolves the underlying `menuProps.loadControl`/`showRideSettings` fields this UI renders.

## Test plan
- [x] `npm test` (1048 tests, all passing)
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] Verified via real-device logs (mode + settings changes, combo and workout-only rides) that the menu content and Load/Gear labels update correctly and promptly