### PR TITLE
fix: Load/Gear two-row layout is tablet-only; ignore swipes while Ride Menu is open

### DIFF
--- a/src/components/RideMenu/RideMenu.component.test.tsx
+++ b/src/components/RideMenu/RideMenu.component.test.tsx
@@ -69,25 +69,26 @@ describe('RideMenu (smart component)', () => {
     // The exact reported scenario: cycling mode changes (RidePageService.onDeviceModeChanged()
     // recomputing menuProps.loadControl and emitting page-update) while the Ride Menu stays
     // mounted - with no local RideMenu state change (no dialog open/close) to force a re-render.
+    // useIsTablet is mocked false (phone width) here, so this exercises the single-row layout.
     it('re-renders with fresh loadControl when the service emits page-update, with no local state change', () => {
         const { getByText, queryByText } = render(<RideMenu visible={true} onClose={jest.fn()} />);
-        expect(getByText('+5W')).toBeTruthy();
+        expect(getByText('Load')).toBeTruthy();
 
         mockMenuProps = { ...mockMenuProps, loadControl: { visible: true, label: 'Gear', buttons: gearButtons } };
         act(() => { capturedHandlers['page-update']?.(); });
 
-        expect(getByText('+1')).toBeTruthy();
-        expect(queryByText('+5W')).toBeNull();
+        expect(getByText('Gear')).toBeTruthy();
+        expect(queryByText('Load')).toBeNull();
     });
 
-    it('hides the Load/Gear buttons when a page-update resolves loadControl to hidden', () => {
+    it('hides the Load/Gear row when a page-update resolves loadControl to hidden', () => {
         const { getByText, queryByText } = render(<RideMenu visible={true} onClose={jest.fn()} />);
-        expect(getByText('+5W')).toBeTruthy();
+        expect(getByText('Load')).toBeTruthy();
 
         mockMenuProps = { ...mockMenuProps, loadControl: { visible: false } };
         act(() => { capturedHandlers['page-update']?.(); });
 
-        expect(queryByText('+5W')).toBeNull();
-        expect(queryByText('+1')).toBeNull();
+        expect(queryByText('Load')).toBeNull();
+        expect(queryByText('Gear')).toBeNull();
     });
 });

--- a/src/components/RideMenu/RideMenu.test.tsx
+++ b/src/components/RideMenu/RideMenu.test.tsx
@@ -170,113 +170,90 @@ describe('RideMenuView', () => {
         expect(onStepBack).not.toHaveBeenCalled();
     });
 
-    describe('Load/Gear buttons', () => {
-        it('renders all four button labels from menuProps.loadControl.buttons, unchanged', () => {
-            const { getByText } = render(<RideMenuView {...workoutProps} visible={true} activeDialog={null} />);
-            expect(getByText('+5W')).toBeTruthy();
-            expect(getByText('-5W')).toBeTruthy();
-            expect(getByText('+50W')).toBeTruthy();
-            expect(getByText('-50W')).toBeTruthy();
+    // Phone width (the default in this file - useIsTablet mocked false): a single icon-only row,
+    // small step only - phones have no vertical room for the tablet's two-row/small+big layout.
+    // See the "on a tablet-width screen" describe block below for that variant.
+    describe('Load/Gear buttons (phone width)', () => {
+        it('renders the row caption and icon-only Increase/Decrease buttons', () => {
+            const { getByText, getByLabelText } = render(<RideMenuView {...workoutProps} visible={true} activeDialog={null} />);
+            expect(getByText('Load')).toBeTruthy();
+            expect(getByLabelText('Increase Load')).toBeTruthy();
+            expect(getByLabelText('Decrease Load')).toBeTruthy();
         });
 
-        // Three-column layout: "Increase Load   +5W   +50W" / "Decrease Load   -5W   -50W" - the
-        // row label states the direction, each numeric value is its own separate tappable chip.
-        it('renders "Increase {label}"/"Decrease {label}" row captions', () => {
-            const { getByText } = render(<RideMenuView {...workoutProps} visible={true} activeDialog={null} />);
-            expect(getByText('Increase Load')).toBeTruthy();
-            expect(getByText('Decrease Load')).toBeTruthy();
-        });
-
-        it('renders "Increase Gear"/"Decrease Gear" row captions in Gear mode', () => {
+        it('renders "Gear" in gear mode', () => {
             const { getByText } = render(
                 <RideMenuView {...workoutProps} loadControl={{ visible: true, label: 'Gear', buttons: gearButtons }} visible={true} activeDialog={null} />
             );
-            expect(getByText('Increase Gear')).toBeTruthy();
-            expect(getByText('Decrease Gear')).toBeTruthy();
+            expect(getByText('Gear')).toBeTruthy();
         });
 
-        it('calls onIncreaseLoad/onDecreaseLoad (small step) when the small tiles are pressed', () => {
+        it('calls onIncreaseLoad/onDecreaseLoad (small step only) when the icon buttons are pressed', () => {
             const onIncreaseLoad = jest.fn();
             const onDecreaseLoad = jest.fn();
-            const { getByText } = render(
+            const { getByLabelText } = render(
                 <RideMenuView {...workoutProps} visible={true} activeDialog={null} onIncreaseLoad={onIncreaseLoad} onDecreaseLoad={onDecreaseLoad} />
             );
-            fireEvent.press(getByText('+5W'));
-            fireEvent.press(getByText('-5W'));
+            fireEvent.press(getByLabelText('Increase Load'));
+            fireEvent.press(getByLabelText('Decrease Load'));
             expect(onIncreaseLoad).toHaveBeenCalledTimes(1);
             expect(onDecreaseLoad).toHaveBeenCalledTimes(1);
         });
 
-        it('calls onIncreaseLoadBig/onDecreaseLoadBig when the big tiles are pressed', () => {
-            const onIncreaseLoadBig = jest.fn();
-            const onDecreaseLoadBig = jest.fn();
-            const { getByText } = render(
-                <RideMenuView {...workoutProps} visible={true} activeDialog={null} onIncreaseLoadBig={onIncreaseLoadBig} onDecreaseLoadBig={onDecreaseLoadBig} />
-            );
-            fireEvent.press(getByText('+50W'));
-            fireEvent.press(getByText('-50W'));
-            expect(onIncreaseLoadBig).toHaveBeenCalledTimes(1);
-            expect(onDecreaseLoadBig).toHaveBeenCalledTimes(1);
+        it('does not render the tablet-only big-step buttons or numeric labels', () => {
+            const { queryByText } = render(<RideMenuView {...workoutProps} visible={true} activeDialog={null} />);
+            expect(queryByText('+50W')).toBeNull();
+            expect(queryByText('+5W')).toBeNull();
+            expect(queryByText('Increase Load')).toBeNull();
+            expect(queryByText('Decrease Load')).toBeNull();
         });
 
-        // Label/icon/visibility/button text all come from menuProps.loadControl (RidePageService),
-        // resolved from LoadButtonMode - this view must not interpret cycling mode itself.
-        it('renders Gear-mode button labels verbatim (SIM mode, virtual shifting)', () => {
+        it('renders even when loadControl.buttons is absent - phone width does not need the numeric labels', () => {
             const { getByText } = render(
-                <RideMenuView {...workoutProps} loadControl={{ visible: true, label: 'Gear', buttons: gearButtons }} visible={true} activeDialog={null} />
+                <RideMenuView {...workoutProps} loadControl={{ visible: true, label: 'Load' }} visible={true} activeDialog={null} />
             );
-            expect(getByText('+1')).toBeTruthy();
-            expect(getByText('-1')).toBeTruthy();
-            expect(getByText('+5')).toBeTruthy();
-            expect(getByText('-5')).toBeTruthy();
+            expect(getByText('Load')).toBeTruthy();
         });
 
-        it('does not render any Load/Gear button when loadControl.visible is false (SIM mode, no virtual shifting)', () => {
-            const { queryByText } = render(
+        it('does not render the row when loadControl.visible is false (SIM mode, no virtual shifting)', () => {
+            const { queryByText, queryByLabelText } = render(
                 <RideMenuView {...workoutProps} loadControl={{ visible: false }} visible={true} activeDialog={null} />
             );
-            expect(queryByText('+5W')).toBeNull();
-            expect(queryByText('-5W')).toBeNull();
-            expect(queryByText('+50W')).toBeNull();
-            expect(queryByText('-50W')).toBeNull();
+            expect(queryByText('Load')).toBeNull();
+            expect(queryByText('Gear')).toBeNull();
+            expect(queryByLabelText('Increase Load')).toBeNull();
+            expect(queryByLabelText('Decrease Load')).toBeNull();
         });
 
-        it('does not render any Load/Gear button when loadControl is absent', () => {
+        it('does not render the row when loadControl is absent', () => {
             const { queryByText } = render(
                 <RideMenuView {...workoutProps} loadControl={undefined} visible={true} activeDialog={null} />
             );
-            expect(queryByText('+5W')).toBeNull();
-        });
-
-        it('does not render any Load/Gear button when loadControl.visible is true but buttons is absent', () => {
-            const { queryByText } = render(
-                <RideMenuView {...workoutProps} loadControl={{ visible: true, label: 'Load' }} visible={true} activeDialog={null} />
-            );
-            expect(queryByText('+5W')).toBeNull();
+            expect(queryByText('Load')).toBeNull();
         });
 
         // A plain route ride (no workout attached) still needs Load/Gear buttons whenever cycling
         // mode calls for them - not gated on `workout`, only on loadControl.
         it('renders outside workout mode when loadControl.visible is true', () => {
-            const { getByText } = render(
+            const { getByText, getByLabelText } = render(
                 <RideMenuView {...mockProps} loadControl={{ visible: true, label: 'Load', buttons: loadButtons }} visible={true} activeDialog={null} />
             );
-            expect(getByText('+5W')).toBeTruthy();
-            expect(getByText('-50W')).toBeTruthy();
+            expect(getByText('Load')).toBeTruthy();
+            expect(getByLabelText('Increase Load')).toBeTruthy();
         });
 
-        it('renders Gear-mode buttons outside workout mode too', () => {
+        it('renders Gear-mode row outside workout mode too', () => {
             const { getByText } = render(
                 <RideMenuView {...mockProps} loadControl={{ visible: true, label: 'Gear', buttons: gearButtons }} visible={true} activeDialog={null} />
             );
-            expect(getByText('+1')).toBeTruthy();
+            expect(getByText('Gear')).toBeTruthy();
         });
 
         it('does not render outside workout mode when loadControl is absent', () => {
             const { queryByText } = render(
                 <RideMenuView {...mockProps} visible={true} activeDialog={null} />
             );
-            expect(queryByText('+5W')).toBeNull();
+            expect(queryByText('Load')).toBeNull();
         });
     });
 
@@ -382,10 +359,10 @@ describe('RideMenuView', () => {
             expect(queryByText('Step')).toBeNull();
         });
 
-        // Unlike Step/Settings, the Load/Gear rows (renderMagnitudeRow) never pack two unrelated
-        // items onto a shared row to begin with - each row is already just one label + its two
-        // values, so tablet width changes nothing here.
-        it('still renders the Load rows unchanged at tablet width', () => {
+        // Tablet width only: two three-column rows (label, small step, big step) instead of the
+        // phone's single icon-only row - there's vertical room here, so both magnitudes get their
+        // own tappable value with its own visible text.
+        it('renders Load as two magnitude rows (Increase/Decrease, small + big step)', () => {
             const { getByText } = render(
                 <RideMenuView {...workoutProps} visible={true} activeDialog={null} />
             );
@@ -395,6 +372,65 @@ describe('RideMenuView', () => {
             expect(getByText('-5W')).toBeTruthy();
             expect(getByText('+50W')).toBeTruthy();
             expect(getByText('-50W')).toBeTruthy();
+        });
+
+        it('renders "Increase Gear"/"Decrease Gear" row captions and values in Gear mode', () => {
+            const { getByText } = render(
+                <RideMenuView {...workoutProps} loadControl={{ visible: true, label: 'Gear', buttons: gearButtons }} visible={true} activeDialog={null} />
+            );
+            expect(getByText('Increase Gear')).toBeTruthy();
+            expect(getByText('Decrease Gear')).toBeTruthy();
+            expect(getByText('+1')).toBeTruthy();
+            expect(getByText('-1')).toBeTruthy();
+            expect(getByText('+5')).toBeTruthy();
+            expect(getByText('-5')).toBeTruthy();
+        });
+
+        it('calls onIncreaseLoad/onDecreaseLoad (small step) when the small values are pressed', () => {
+            const onIncreaseLoad = jest.fn();
+            const onDecreaseLoad = jest.fn();
+            const { getByText } = render(
+                <RideMenuView {...workoutProps} visible={true} activeDialog={null} onIncreaseLoad={onIncreaseLoad} onDecreaseLoad={onDecreaseLoad} />
+            );
+            fireEvent.press(getByText('+5W'));
+            fireEvent.press(getByText('-5W'));
+            expect(onIncreaseLoad).toHaveBeenCalledTimes(1);
+            expect(onDecreaseLoad).toHaveBeenCalledTimes(1);
+        });
+
+        it('calls onIncreaseLoadBig/onDecreaseLoadBig when the big values are pressed', () => {
+            const onIncreaseLoadBig = jest.fn();
+            const onDecreaseLoadBig = jest.fn();
+            const { getByText } = render(
+                <RideMenuView {...workoutProps} visible={true} activeDialog={null} onIncreaseLoadBig={onIncreaseLoadBig} onDecreaseLoadBig={onDecreaseLoadBig} />
+            );
+            fireEvent.press(getByText('+50W'));
+            fireEvent.press(getByText('-50W'));
+            expect(onIncreaseLoadBig).toHaveBeenCalledTimes(1);
+            expect(onDecreaseLoadBig).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not render any Load/Gear row when loadControl.visible is false', () => {
+            const { queryByText } = render(
+                <RideMenuView {...workoutProps} loadControl={{ visible: false }} visible={true} activeDialog={null} />
+            );
+            expect(queryByText('Increase Load')).toBeNull();
+            expect(queryByText('+5W')).toBeNull();
+        });
+
+        it('does not render any Load/Gear row when loadControl.buttons is absent', () => {
+            const { queryByText } = render(
+                <RideMenuView {...workoutProps} loadControl={{ visible: true, label: 'Load' }} visible={true} activeDialog={null} />
+            );
+            expect(queryByText('Increase Load')).toBeNull();
+        });
+
+        it('renders outside workout mode too (not gated on `workout`, only on loadControl)', () => {
+            const { getByText } = render(
+                <RideMenuView {...mockProps} loadControl={{ visible: true, label: 'Load', buttons: loadButtons }} visible={true} activeDialog={null} />
+            );
+            expect(getByText('Increase Load')).toBeTruthy();
+            expect(getByText('+50W')).toBeTruthy();
         });
 
         it('still triggers Step Back/Forward and Load callbacks when split onto their own rows', () => {
@@ -447,16 +483,16 @@ describe('RideMenuView', () => {
             expect(queryByText('Step Back')).toBeNull();
         });
 
-        it('still renders the Load rows unchanged in compact tablet layout too', () => {
-            const { getByText } = render(
+        // Compact height (even at tablet width) has no more vertical room than a phone, so it
+        // falls back to the same single icon-only row, not the two-row magnitude layout.
+        it('keeps the phone-style single Load row instead of the tablet magnitude rows - compact wins over tablet width', () => {
+            const { getByText, getByLabelText, queryByText } = render(
                 <RideMenuView {...workoutProps} visible={true} activeDialog={null} />
             );
-            expect(getByText('Increase Load')).toBeTruthy();
-            expect(getByText('Decrease Load')).toBeTruthy();
-            expect(getByText('+5W')).toBeTruthy();
-            expect(getByText('-5W')).toBeTruthy();
-            expect(getByText('+50W')).toBeTruthy();
-            expect(getByText('-50W')).toBeTruthy();
+            expect(getByText('Load')).toBeTruthy();
+            expect(getByLabelText('Increase Load')).toBeTruthy();
+            expect(queryByText('Increase Load')).toBeNull();
+            expect(queryByText('+50W')).toBeNull();
         });
     });
 });

--- a/src/components/RideMenu/RideMenuView.tsx
+++ b/src/components/RideMenu/RideMenuView.tsx
@@ -339,21 +339,32 @@ export const RideMenuView = ({
                             a plain route ride still needs Load/Gear buttons whenever cycling mode
                             calls for them.
 
-                            Three-column rows (label, small step, big step) - e.g.
-                            "Increase Load   +5W   +50W" / "Decrease Load   -5W   -50W" - each
+                            Tablet width only: three-column rows (label, small step, big step) -
+                            e.g. "Increase Load   +5W   +50W" / "Decrease Load   -5W   -50W" - each
                             value is its own tappable chip with its own visible text, so there is
                             no separate static caption sitting next to a small icon-only button a
-                            rider could mistakenly tap instead. */}
-                        {loadControl?.visible && loadControl.buttons && renderMagnitudeRow({
-                            label: `Increase ${loadControl.label ?? 'Load'}`,
-                            small: { text: loadControl.buttons.inc1, onPress: onIncreaseLoad },
-                            big: { text: loadControl.buttons.inc5, onPress: onIncreaseLoadBig },
-                        })}
-                        {loadControl?.visible && loadControl.buttons && renderMagnitudeRow({
-                            label: `Decrease ${loadControl.label ?? 'Load'}`,
-                            small: { text: loadControl.buttons.dec1, onPress: onDecreaseLoad },
-                            big: { text: loadControl.buttons.dec5, onPress: onDecreaseLoadBig },
-                        })}
+                            rider could mistakenly tap instead. Phones have no vertical room for a
+                            second row here, so they keep the original single "Load  <  >" /
+                            "Gear  <  >" row (small step only - big step is tablet-only, gated the
+                            same way as the Step/Settings rows above). */}
+                        {useSingleColumnRows
+                            ? <>
+                                {loadControl?.visible && loadControl.buttons && renderMagnitudeRow({
+                                    label: `Increase ${loadControl.label ?? 'Load'}`,
+                                    small: { text: loadControl.buttons.inc1, onPress: onIncreaseLoad },
+                                    big: { text: loadControl.buttons.inc5, onPress: onIncreaseLoadBig },
+                                })}
+                                {loadControl?.visible && loadControl.buttons && renderMagnitudeRow({
+                                    label: `Decrease ${loadControl.label ?? 'Load'}`,
+                                    small: { text: loadControl.buttons.dec1, onPress: onDecreaseLoad },
+                                    big: { text: loadControl.buttons.dec5, onPress: onDecreaseLoadBig },
+                                })}
+                              </>
+                            : loadControl?.visible && renderMenuRow(loadControl.label ?? 'Load',
+                                { icon: 'minus', label: `Decrease ${loadControl.label ?? 'Load'}`, onPress: onDecreaseLoad },
+                                { icon: 'plus', label: `Increase ${loadControl.label ?? 'Load'}`, onPress: onIncreaseLoad }
+                              )
+                        }
                         {/* Settings tiles have no icon - all three line up flush-left with each
                             other regardless of which row/column they land in. Gear/Ride Settings
                             pair onto one row and Workout Settings gets its own row - a 2-column

--- a/src/hooks/ride/useRideGestures.test.ts
+++ b/src/hooks/ride/useRideGestures.test.ts
@@ -17,6 +17,9 @@ const mockGetLoadButtonMode = jest.fn(() => 'power');
 // Defaults true - this hook was originally only wired to the Workout ride screen (always
 // workout-attached); tests below that exercise a plain GPX/Video ride override it to false.
 const mockIsWorkoutAttached = jest.fn(() => true);
+// Defaults to "menu closed" (menuProps null) - the Ride Menu open/closed tests below override
+// this to a non-null object.
+const mockGetPageDisplayProps = jest.fn(() => ({ menuProps: null as any }));
 const mockGetValue = jest.fn((_key: string, def: any) => def);
 const mockGetVersion = jest.fn(() => '1.0.19');
 
@@ -33,6 +36,7 @@ jest.mock('incyclist-services', () => ({
         adjustLoad: mockAdjustLoad,
         getLoadButtonMode: mockGetLoadButtonMode,
         isWorkoutAttached: mockIsWorkoutAttached,
+        getPageDisplayProps: mockGetPageDisplayProps,
     }),
     useUserSettings: () => ({ getValue: mockGetValue }),
 }));
@@ -144,6 +148,7 @@ describe('useRideGestures', () => {
         mockAdjustLoad.mockReturnValue(undefined);
         mockGetLoadButtonMode.mockReturnValue('power');
         mockIsWorkoutAttached.mockReturnValue(true);
+        mockGetPageDisplayProps.mockReturnValue({ menuProps: null });
         mockGetVersion.mockReturnValue('1.0.19');
         Platform.OS = 'ios';
         jest.useFakeTimers();
@@ -158,6 +163,46 @@ describe('useRideGestures', () => {
         const { result } = renderHook(() => useRideGestures());
         expect(result.current.gesture).toBe(mockPanBuilder);
         expect(capturedOnEnd).toBeInstanceOf(Function);
+    });
+
+    // The Ride Menu overlay doesn't block the underlying gesture surface - scrolling the menu's
+    // own ScrollView can still register as a swipe underneath it, unintentionally shifting
+    // gear/load while the rider is just trying to scroll the menu.
+    describe('Ride Menu open (menuProps non-null)', () => {
+        beforeEach(() => {
+            mockGetPageDisplayProps.mockReturnValue({ menuProps: { showResume: false } });
+        });
+
+        it('ignores a left/right swipe (step or big-load) while the menu is open', () => {
+            const { result } = renderHook(() => useRideGestures());
+            act(() => {
+                capturedOnEnd!({ translationX: -100, translationY: 0, velocityX: 0, velocityY: 0 });
+            });
+            expect(mockOnStepBack).not.toHaveBeenCalled();
+            expect(result.current.feedback).toEqual({ visible: false, message: '' });
+        });
+
+        it('ignores an up/down swipe (load adjust) while the menu is open', () => {
+            renderHook(() => useRideGestures());
+            act(() => {
+                capturedOnEnd!({ translationX: 0, translationY: -100, velocityX: 0, velocityY: 0 });
+            });
+            expect(mockAdjustLoad).not.toHaveBeenCalled();
+        });
+
+        it('resumes handling swipes once the menu closes (re-checked fresh on every swipe)', () => {
+            renderHook(() => useRideGestures());
+            act(() => {
+                capturedOnEnd!({ translationX: -100, translationY: 0, velocityX: 0, velocityY: 0 });
+            });
+            expect(mockOnStepBack).not.toHaveBeenCalled();
+
+            mockGetPageDisplayProps.mockReturnValue({ menuProps: null });
+            act(() => {
+                capturedOnEnd!({ translationX: -100, translationY: 0, velocityX: 0, velocityY: 0 });
+            });
+            expect(mockOnStepBack).toHaveBeenCalledTimes(1);
+        });
     });
 
     it('exposes the live loadIncrement setting, never a hardcoded value', () => {

--- a/src/hooks/ride/useRideGestures.ts
+++ b/src/hooks/ride/useRideGestures.ts
@@ -212,6 +212,17 @@ export const useRideGestures = (): UseRideGesturesResult => {
     }, [logEvent, service, getLoadIncrement, showFeedback]);
 
     const handleSwipe = useCallback((direction: SwipeDirection) => {
+        // The Ride Menu overlay sits on top of this gesture surface but doesn't block it -
+        // scrolling the menu's own ScrollView can still register as a swipe underneath,
+        // unintentionally shifting gear/load while the rider is just trying to scroll the menu.
+        // menuProps is only non-null while the menu is open (RidePageService.onMenuOpen()/
+        // onMenuClose()), read directly off the service rather than threaded in as a prop so this
+        // stays self-contained and always current.
+        if (service.getPageDisplayProps()?.menuProps) {
+            logEvent({ message: 'gesture ignored', gesture: `swipe-${direction}`, reason: 'menu open', eventSource: 'user' });
+            return;
+        }
+
         // FIXES_BACKLOG #37: in SIM/Resistance mode with virtual shifting disabled there is no
         // gear concept and no power target to nudge, so a load-adjust swipe would be a silent
         // no-op. Disable the gesture outright in that case (rather than a "no effect" toast, which


### PR DESCRIPTION
## Summary
Follow-up to #431 (merged) - two corrections found in UI review of that PR:

- The three-column small+big magnitude rows (`"Increase Load  +5W  +50W"` / `"Decrease Load  -5W  -50W"`) should only have applied to tablet width, not phones. Phones have no vertical room for a second row - they now keep the original single `"Load  <  >"` / `"Gear  <  >"` row, small step only (unchanged icon buttons). Gated on the same `useSingleColumnRows` flag the adjacent Step/Settings rows already use, so a compact-height tablet also correctly falls back to the phone layout.
- The Ride Menu overlay doesn't block the underlying swipe-gesture surface - scrolling the menu's own list could still register as a swipe underneath it, unintentionally shifting gear/load. `useRideGestures` now ignores every swipe direction while `menuProps` is non-null (the menu is open), read directly off the service (no new prop plumbing needed).

## Test plan
- [x] `npm test` (1055 tests, all passing)
- [x] `npm run lint`
- [x] `npx tsc --noEmit`