### PR TITLE
Add Android-only crash reporting for uncaught JS errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,8 @@ if (!EventEmitter.default) {
 }
 */
 
+import { installCrashReporting } from './src/services/CrashReporting/CrashReporting.ts';
+installCrashReporting();
 
 import { Loader } from './src/Loader.tsx';
 

--- a/src/services/CrashReporting/CrashReporting.test.ts
+++ b/src/services/CrashReporting/CrashReporting.test.ts
@@ -1,0 +1,99 @@
+// Verifies the fatal-crash path logs and flushes before the platform's default handler runs
+// (which is what actually takes the app down), and that this only ever installs on Android -
+// the App Store data-safety declaration doesn't cover crash reporting, only Play Store's does.
+
+describe('installCrashReporting', () => {
+    let logEvent: jest.Mock;
+    let flushLogs: jest.Mock;
+    let defaultHandler: jest.Mock;
+    let errorUtils: { getGlobalHandler: jest.Mock; setGlobalHandler: jest.Mock };
+
+    const setup = (platformOS: string) => {
+        jest.resetModules();
+
+        logEvent = jest.fn();
+        flushLogs = jest.fn().mockResolvedValue(undefined);
+        defaultHandler = jest.fn();
+        errorUtils = {
+            getGlobalHandler: jest.fn(() => defaultHandler),
+            setGlobalHandler: jest.fn(),
+        };
+        (global as any).ErrorUtils = errorUtils;
+
+        jest.doMock('react-native', () => ({ Platform: { OS: platformOS } }));
+        jest.doMock('gd-eventlog', () => ({
+            EventLogger: jest.fn().mockImplementation(() => ({ logEvent })),
+        }));
+        jest.doMock('../RestLogging', () => ({ flushLogs }));
+
+        const { installCrashReporting } = require('./CrashReporting');
+        installCrashReporting();
+    };
+
+    afterEach(() => {
+        delete (global as any).ErrorUtils;
+    });
+
+    it('does not install a handler on iOS', () => {
+        setup('ios');
+
+        expect(errorUtils.setGlobalHandler).not.toHaveBeenCalled();
+    });
+
+    it('installs a handler on Android', () => {
+        setup('android');
+
+        expect(errorUtils.setGlobalHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('logs and flushes before calling the default handler on a fatal error', async () => {
+        setup('android');
+        const handler = errorUtils.setGlobalHandler.mock.calls[0][0];
+        const error = new Error('boom');
+
+        await handler(error, true);
+
+        expect(logEvent).toHaveBeenCalledWith({
+            message: 'crash in main window',
+            error: 'boom',
+            stack: error.stack,
+            errorName: 'Error',
+            isFatal: true,
+        });
+        expect(flushLogs).toHaveBeenCalledTimes(1);
+        expect(defaultHandler).toHaveBeenCalledWith(error, true);
+
+        // the whole point of the flush is that it completes before the app is handed back
+        // to the handler that actually kills the process
+        expect(flushLogs.mock.invocationCallOrder[0])
+            .toBeLessThan(defaultHandler.mock.invocationCallOrder[0]);
+    });
+
+    it('logs without flushing on a non-fatal error', async () => {
+        setup('android');
+        const handler = errorUtils.setGlobalHandler.mock.calls[0][0];
+        const error = new Error('minor');
+
+        await handler(error, false);
+
+        expect(logEvent).toHaveBeenCalledWith({
+            message: 'error',
+            fn: 'native code',
+            error: 'minor',
+            stack: error.stack,
+        });
+        expect(flushLogs).not.toHaveBeenCalled();
+        expect(defaultHandler).toHaveBeenCalledWith(error, false);
+    });
+
+    it('still calls the default handler if logging/flushing throws', async () => {
+        setup('android');
+        flushLogs.mockImplementation(() => Promise.reject(new Error('network down')));
+        const handler = errorUtils.setGlobalHandler.mock.calls[0][0];
+        const error = new Error('boom');
+
+        await handler(error, true);
+
+        expect(defaultHandler).toHaveBeenCalledWith(error, true);
+    });
+});

--- a/src/services/CrashReporting/CrashReporting.ts
+++ b/src/services/CrashReporting/CrashReporting.ts
@@ -1,0 +1,64 @@
+import { EventLogger } from 'gd-eventlog'
+import { Platform } from 'react-native'
+import { flushLogs } from '../RestLogging'
+
+type ErrorHandler = (error: any, isFatal?: boolean) => void
+
+interface RNErrorUtils {
+    getGlobalHandler: () => ErrorHandler
+    setGlobalHandler: (handler: ErrorHandler) => void
+}
+
+const logger = new EventLogger('CrashReporting')
+
+/**
+ * Installs a global handler for uncaught JS errors. Android only - the current App Store
+ * data-safety declaration does not cover crash reporting, only the Play Store one does.
+ *
+ * Fatal errors are logged and force-flushed to the backend before the original (platform
+ * default) handler runs, since that handler is what ultimately takes the app down - without
+ * the flush, the event would still be sitting in the REST adapter's batch queue when the
+ * process dies. Non-fatal errors don't crash the app, so they go through the normal batched
+ * pipeline instead.
+ */
+export const installCrashReporting = (): void => {
+    if (Platform.OS !== 'android')
+        return
+
+    const errorUtils = (global as any).ErrorUtils as RNErrorUtils | undefined
+    if (!errorUtils)
+        return
+
+    const defaultHandler = errorUtils.getGlobalHandler()
+
+    errorUtils.setGlobalHandler(async (error: any, isFatal?: boolean) => {
+        try {
+            if (isFatal) {
+                logger.logEvent({
+                    message: 'crash in main window',
+                    error: error?.message,
+                    stack: error?.stack,
+                    errorName: error?.name,
+                    isFatal: true,
+                })
+                await flushLogs()
+            }
+            else {
+                logger.logEvent({
+                    message: 'error',
+                    fn: 'native code',
+                    error: error?.message,
+                    stack: error?.stack,
+                })
+            }
+        }
+        catch (loggingError) {
+            // Never let a logging/flush failure surface as an unhandled rejection or stop the
+            // platform's own handler from running - it's what actually takes the app down.
+            console.warn('CrashReporting: failed to log/flush crash', loggingError)
+        }
+        finally {
+            defaultHandler(error, isFatal)
+        }
+    })
+}

--- a/src/services/CrashReporting/index.ts
+++ b/src/services/CrashReporting/index.ts
@@ -1,0 +1,1 @@
+export * from './CrashReporting'

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -8,6 +8,7 @@ export * from './PermissionsService';
 export * from './Navigation';
 export * from './IncyclistApi';
 export * from './RestLogging';
+export * from './CrashReporting';
 
 let currentSecretsStatus: SecretsStatus = 'missing';
 


### PR DESCRIPTION
## Summary
- Install a global handler for uncaught JS errors, Android only (the iOS App Store data-safety declaration does not yet cover crash reporting, while the Play Store one does).
- Fatal errors are logged (`message: 'crash in main window'`, `error`, `stack`, `errorName`, `isFatal: true`) and force-flushed to the backend before the platform's default handler runs, so the event isn't lost when that handler subsequently takes the app down.
- Non-fatal errors (`isFatal: false`) are logged (`message: 'error'`, `fn: 'native code'`, `error`, `stack`) through the normal batched REST logging pipeline, with no forced flush since the app doesn't crash in that case.
- Reuses the existing `flushLogs()` helper and `RestLogAdapter` — no changes to either.

## What changed
- `src/services/CrashReporting/CrashReporting.ts` (+ barrel `index.ts`): `installCrashReporting()`.
- `index.js`: calls `installCrashReporting()` as early as possible, right after the existing startup polyfills.
- `src/services/index.ts`: re-exports the new module.

## Not in this PR
- Breadcrumb trail of recent events leading up to a crash (planned fast-follow).
- Any native crash SDK (Crashlytics/Sentry) — this stays JS-only; correlation with Android Vitals crash entries is best-effort (timestamp/app version/error text), not a shared crash ID.
- A dedicated remote kill switch — relies on the Android-only gate plus the existing `logRest.enabled` setting.

## Test plan
- [x] `CrashReporting.test.ts`: iOS no-op, Android install, fatal path (flush completes before default handler runs), non-fatal path, resilience when the flush itself rejects.
- [x] Full suite: `npm test` — 145 suites / 1152 tests pass.
- [x] `eslint` clean on changed files.
- [x] `tsc --noEmit` shows no new errors.
- [ ] Manual on-device test: trigger a real fatal JS error on an Android build and confirm the event reaches the backend log pipeline before the app dies.