### PR TITLE
fix: "Compare prev rides" toggle reverted to on when turned off

### DIFF
--- a/src/components/RouteDetailsDialog/RouteDetailsView.test.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, act } from '@testing-library/react-native';
 import { ScrollView } from 'react-native';
 import { RouteDetailsView } from './RouteDetailsView';
 import type { UIRouteSettings, UIStartSettings } from 'incyclist-services';
@@ -235,6 +235,47 @@ describe('RouteDetailsView', () => {
             );
             fireEvent.press(getByText('Add Workout'));
             expect(MOCK_PROPS.onAddWorkout).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('"Compare prev rides" toggle', () => {
+        // Regression test: turning the toggle off used to round-trip through onSettingsChanged
+        // (refreshPrevRides in RouteDetailsDialog), which always recomputes showPrev from whether
+        // past activities exist for the current position - ignoring the value the user just set -
+        // and so silently reverted the toggle back to "on".
+        it('does not call onSettingsChanged when toggled', () => {
+            const onSettingsChanged = jest.fn().mockResolvedValue({});
+            const { getByText } = render(
+                <RouteDetailsView
+                    {...MOCK_PROPS}
+                    prevRides={[{ id: 'a1' }]}
+                    showPrev={true}
+                    onSettingsChanged={onSettingsChanged}
+                />
+            );
+            fireEvent.press(getByText('No'));
+            expect(onSettingsChanged).not.toHaveBeenCalled();
+        });
+
+        it('stays off (and is carried into onStart) after being turned off, even if onSettingsChanged would say otherwise', async () => {
+            const onSettingsChanged = jest.fn().mockResolvedValue({ showPrev: true });
+            const onStart = jest.fn();
+            const { getByText, getAllByText } = render(
+                <RouteDetailsView
+                    {...MOCK_PROPS}
+                    prevRides={[{ id: 'a1' }]}
+                    showPrev={true}
+                    onSettingsChanged={onSettingsChanged}
+                    onStart={onStart}
+                />
+            );
+            fireEvent.press(getByText('No'));
+            // Let any in-flight onSettingsChanged round-trip (and its state merge) fully settle
+            // before checking - a prior version of this fix only "worked" because the test raced
+            // ahead of that merge, which made it pass even on the buggy code.
+            await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+            getAllByText('Start').forEach(el => fireEvent.press(el));
+            expect(onStart).toHaveBeenCalledWith(expect.objectContaining({ showPrev: false }));
         });
     });
 });

--- a/src/components/RouteDetailsDialog/RouteDetailsView.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.tsx
@@ -104,9 +104,14 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
         handleApplySettings({ ...data, nextOverwrite: v });
     }, [handleApplySettings, data]);
 
+    // Local-only: unlike the other handlers above, this must not round-trip through
+    // onSettingsChanged (refreshPrevRides) - that re-queries past activities for the current
+    // position and always recomputes showPrev from whether results exist, clobbering the
+    // user's explicit choice right back to "on". Toggling display doesn't change which
+    // activities are available, so there's nothing to refresh.
     const handleShowPrevChange = useCallback((v: boolean) => {
-        handleApplySettings({ ...data, showPrev: v });
-    }, [handleApplySettings, data]);
+        setData(prev => ({ ...prev, showPrev: v }));
+    }, []);
 
 
     const markerPosition = useMemo(() => {


### PR DESCRIPTION
## Summary
- Turning off the "Compare prev rides" toggle in the route-start dialog had no lasting effect — it immediately snapped back to "on".
- Root cause: the toggle change routed through the same `onSettingsChanged` handler used for position/segment/reality-factor changes. That handler re-queries past activities for the current start position and always recomputes `showPrev` from whether results exist, overwriting the value the user just set.
- Fix: the toggle now updates local component state directly instead of round-tripping through that handler, since a display preference doesn't change which past activities exist.

## Test plan
- [x] Added regression tests in `RouteDetailsView.test.tsx` that fail on the pre-fix code (reproducing the exact symptom) and pass with the fix
- [x] Full suite: `npm test` — 144 suites / 1153 tests pass
- [x] `npm run lint` clean on changed files