### PR TITLE
Show workout dashboard shoutout on phone (compact) too

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,6 +2,6 @@
   "name": "Incyclist",
   "displayName": "Incyclist",
   "appVersion": "1.2.1",
-  "bundleVersion" : "0.4.1",
+  "bundleVersion" : "0.4.2",
   "androidVersionCode": 45
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "axios": "^1.17.0",
         "events": "^3.3.0",
         "gd-eventlog": "^0.1.27",
-        "incyclist-services": "^1.7.121",
+        "incyclist-services": "^1.7.124",
         "mqtt": "^5.15.2",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
@@ -11831,9 +11831,9 @@
       }
     },
     "node_modules/incyclist-services": {
-      "version": "1.7.121",
-      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.121.tgz",
-      "integrity": "sha512-otknqyNxsZQwdAsJ4yUQtQxVfX2BIQOMfURiBhHF1R5TrChMOK8Yuy0RyrE89hk5zCgbxEU5l4/cy7x/t0I0FA==",
+      "version": "1.7.124",
+      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.124.tgz",
+      "integrity": "sha512-G35uNKuWVLxq9vnEsHtoiogbq7GarGxW6o+y8IWoGfRuokn5YPikA5KYw5FrMjwlKaQ1WGTlMr0vKj9rMxrQ0Q==",
       "dependencies": {
         "@garmin/fitsdk": "^21.213.0",
         "axios": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "axios": "^1.17.0",
     "events": "^3.3.0",
     "gd-eventlog": "^0.1.27",
-    "incyclist-services": "^1.7.121",
+    "incyclist-services": "^1.7.124",
     "mqtt": "^5.15.2",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",

--- a/src/components/RideDashboard/RideDashboard.stories.tsx
+++ b/src/components/RideDashboard/RideDashboard.stories.tsx
@@ -125,8 +125,9 @@ export const WorkoutShoutoutLongText: Story = {
 };
 
 /**
- * Workout ride screen, compact (phone) layout: the shoutout is tablet-only, so compact mode
- * renders exactly like a route ride in compact mode — no second line at all.
+ * Workout ride screen, compact (phone) layout: the shoutout renders below the metrics row at a
+ * smaller, single-line sizing (`textSizes.subtitle`), spanning the full window width — unlike
+ * tablet, where it can wrap to 2 lines at the larger metrics-row number size.
  */
 export const WorkoutShoutoutCompact: Story = {
     args: {

--- a/src/components/RideDashboard/RideDashboard.test.tsx
+++ b/src/components/RideDashboard/RideDashboard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act, render } from '@testing-library/react-native';
-import { Dimensions } from 'react-native';
+import { Dimensions, StyleSheet } from 'react-native';
 import { RideDashboardView } from './RideDashboardView';
 import { RideDashboard } from './RideDashboard';
 import { ActivityDashboardItem, WorkoutDashboardLine } from './types';
@@ -46,12 +46,29 @@ describe('RideDashboardView — workout shoutout', () => {
         expect(queryByText('170')).toBeNull();
     });
 
-    test('workout ride, compact layout: shoutout is tablet-only and does not render', () => {
-        const { queryByText } = render(
+    // Reversed 2026-09-02 (was 'shoutout is tablet-only and does not render'): WorkoutStepsList's
+    // current-step row only shows remaining time, never the step's planned target/duration — the
+    // shoutout is the only place that context exists, so phone riders need it too.
+    test('workout ride, compact layout: shoutout renders, at the compact (single-line) sizing', () => {
+        const { getByText, queryByText } = render(
             <RideDashboardView items={items} layout="icon-top" compact workoutShoutout={workoutShoutout} />
         );
 
-        expect(queryByText(workoutShoutout.text)).toBeNull();
+        const shoutoutText = getByText(workoutShoutout.text);
+        expect(shoutoutText).toBeTruthy();
+        expect(shoutoutText.props.numberOfLines).toBe(1);
+        // secondary rows are never shown in compact mode regardless of the shoutout
+        expect(queryByText('170')).toBeNull();
+    });
+
+    test('workout ride, compact layout: shoutout width matches the full window width (container stretches in compact)', () => {
+        const { getByTestId } = render(
+            <RideDashboardView items={items} layout="icon-top" compact workoutShoutout={workoutShoutout} />
+        );
+
+        const screenWidth = Dimensions.get('window').width;
+        const flattenedStyle = StyleSheet.flatten(getByTestId('workout-shoutout').props.style);
+        expect(flattenedStyle.width).toBe(screenWidth);
     });
 });
 

--- a/src/components/RideDashboard/RideDashboardView.tsx
+++ b/src/components/RideDashboard/RideDashboardView.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useWindowDimensions, View, Text, StyleSheet } from 'react-native';
 import { Icon, IconName } from '../Icon';
-import { colors } from '../../theme';
+import { colors, textSizes } from '../../theme';
 import { METRIC_ICON, RideDashboardViewProps, getValueColor, ActivityDashboardItem, WorkoutDashboardLine } from './types';
 
 const SEPARATOR_WIDTH = 1; // styles.separator's own width, below
@@ -9,7 +9,7 @@ const CONTAINER_H_PADDING = 8; // styles.container's own paddingHorizontal, belo
 
 export const RideDashboardView = ({ items, layout = 'icon-top', compact = false, workoutShoutout = null }: RideDashboardViewProps) => {
     const { width } = useWindowDimensions();
-    const showWorkoutShoutout = !!workoutShoutout && !compact;
+    const showWorkoutShoutout = !!workoutShoutout;
 
     const minColWidth = 70; // Minimum column width for calculation in compact mode
     const maxCols = Math.floor(width / minColWidth);
@@ -29,17 +29,21 @@ export const RideDashboardView = ({ items, layout = 'icon-top', compact = false,
     const iconSizeLeft = valueSize; // Fix 1: Reduce icon size to match value font height
     const colWidthLeft = colWidthBase + iconSizeLeft + 6; // Fix 1: Adjust column width
 
-    // The workout shoutout must share the metrics row's exact left/right edges. The row is
-    // intrinsically sized (centered, not stretched) in normal/tablet layout, so its width is
-    // computed analytically here from the same per-column width `renderMetric` uses below —
-    // deliberately not measured via onLayout, which this codebase has already found unreliable
-    // under both the Jest test renderer and the Storybook react-native-web renderer (see
-    // WorkoutGraph's smart wrapper), and would otherwise leave the shoutout permanently hidden
-    // in both tests and stories.
+    // The workout shoutout must share the metrics row's exact left/right edges. In normal/tablet
+    // layout the row is intrinsically sized (centered, not stretched), so its width is computed
+    // analytically here from the same per-column width `renderMetric` uses below — deliberately
+    // not measured via onLayout, which this codebase has already found unreliable under both the
+    // Jest test renderer and the Storybook react-native-web renderer (see WorkoutGraph's smart
+    // wrapper), and would otherwise leave the shoutout permanently hidden in both tests and
+    // stories. In compact layout the container is `alignSelf: 'stretch'` (see `container` style
+    // below), so its actual rendered width is simply the full window width — same value
+    // `getRideDashboardWidth()`'s own `compact` branch already uses.
     const nonCompactColWidth = layout === 'icon-left' ? colWidthLeft : colWidthBase;
-    const metricsRowWidth = visibleItems.length * nonCompactColWidth
-        + Math.max(0, visibleItems.length - 1) * SEPARATOR_WIDTH
-        + CONTAINER_H_PADDING * 2;
+    const metricsRowWidth = compact
+        ? width
+        : visibleItems.length * nonCompactColWidth
+            + Math.max(0, visibleItems.length - 1) * SEPARATOR_WIDTH
+            + CONTAINER_H_PADDING * 2;
 
     // Data helpers
     const getPrimary = (item: ActivityDashboardItem) => item.data[0];
@@ -170,23 +174,41 @@ export const RideDashboardView = ({ items, layout = 'icon-top', compact = false,
                 <WorkoutShoutoutLine
                     line={workoutShoutout as WorkoutDashboardLine}
                     width={metricsRowWidth}
-                    fontSize={valueSize}
+                    fontSize={compact ? textSizes.subtitle : valueSize}
+                    numberOfLines={compact ? 1 : 2}
                 />
             )}
         </View>
     );
 };
 
-// Tablet-only, workout-ride-screen-only shoutout that takes over the normal-layout second line
+// Workout-ride-screen-only shoutout that takes over the normal-layout second line
 // (workout-ride-page-service-design.md §3.3): one fully-composed sentence, e.g. "260W at
 // 100-120HR for 5min - VO2 max (3/5)" — no separate power/duration/remaining chips (those are
 // already live on WorkoutStepsList's current-step row; repeating them here was the pre-1.0
 // design and is now considered wrong, session 3.3 rework). `width` matches the metrics row above
 // it exactly, so the two share left/right boundaries instead of one being centered narrower/wider
-// than the other; `fontSize` matches the metrics row's own number size (`valueSize`).
-const WorkoutShoutoutLine = ({ line, width, fontSize }: { line: WorkoutDashboardLine; width: number; fontSize: number }) => (
-    <View style={[styles.shoutout, { width, alignSelf: 'center' }]}>
-        <Text style={[styles.shoutoutText, { fontSize }]} numberOfLines={2}>
+// than the other.
+//
+// Shown in compact (phone) layout too (session revisit, 2026-09-02): WorkoutStepsList's
+// current-step row only ever shows the *remaining* time on the current step, never its planned
+// duration/target — the shoutout is the only place that context exists, so hiding it on phone
+// left riders without it. Uses `RideOverlay`'s already-proven-fitting `fallbackShoutoutText`
+// sizing (`textSizes.subtitle`, one line) rather than the tablet's larger `valueSize`/two-line
+// treatment, which was tuned for a much wider, centered row.
+const WorkoutShoutoutLine = ({
+    line,
+    width,
+    fontSize,
+    numberOfLines,
+}: {
+    line: WorkoutDashboardLine
+    width: number
+    fontSize: number
+    numberOfLines: number
+}) => (
+    <View testID="workout-shoutout" style={[styles.shoutout, { width, alignSelf: 'center' }]}>
+        <Text style={[styles.shoutoutText, { fontSize }]} numberOfLines={numberOfLines}>
             {line.text}
         </Text>
     </View>

--- a/src/components/RideDashboard/types.ts
+++ b/src/components/RideDashboard/types.ts
@@ -28,9 +28,10 @@ export interface RideDashboardViewProps {
     layout?: DashboardLayout
     compact?:boolean
     /**
-     * Workout ride screen only (workout-ride-page-service-design.md §3.3). When set and the
-     * layout isn't compact, replaces every item's normal-layout secondary row with one shared
-     * target+description shoutout line. `null`/`undefined` leaves route-ride rendering untouched.
+     * Workout ride screen only (workout-ride-page-service-design.md §3.3). When set, replaces
+     * every item's normal-layout secondary row (non-compact) or renders as a single-line strip
+     * below the metrics row (compact) with one shared target+description shoutout line.
+     * `null`/`undefined` leaves route-ride rendering untouched.
      */
     workoutShoutout?: WorkoutDashboardLine | null
 }


### PR DESCRIPTION
## Summary
- The workout dashboard's single-line "shoutout" (target power/HR/duration + step name) was scoped tablet-only, on the assumption that `WorkoutStepsList`'s current-step row made it redundant on phone.
- That assumption doesn't hold: the step-list row only ever shows the *remaining* time on the current step, never its planned target or duration - so phone riders had no way to see that info at all.
- Reversed the scoping: the shoutout now renders on phone too, at a smaller single-line sizing (`textSizes.subtitle`, `numberOfLines={1}`) reusing the sizing already proven to fit by the combined Video/GPX ride screens' own fallback shoutout, rather than the tablet's larger two-line treatment.

## What changed
- `RideDashboardView.tsx`: shoutout renders in compact layout; fixed its width calculation for compact (container stretches to the full window width there, unlike tablet's centered/analytic width) and added compact-specific font size/line count.
- `types.ts`: doc comment updated.
- `RideDashboard.test.tsx`: reversed the old "tablet-only, does not render" test to assert it renders (single line); added a width-correctness test for compact.
- `RideDashboard.stories.tsx`: story doc comment updated to match.
- `mobile/internal/designs/workout-ride-page-service-design.md` §3.3: added a changelog entry documenting the reversal and why (not tracked by git, kept in sync locally).

## Test plan
- [x] `npm test` — full suite (144 suites / 1154 tests) passes
- [x] `npx eslint src/components/RideDashboard` — no new errors (2 pre-existing inline-style warnings)
- [ ] Visual check on a phone/tablet in Storybook or a real ride (`WorkoutShoutoutCompact` story covers this)