### PR TITLE
Only explain a Start button that is actually unavailable

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "Incyclist",
   "displayName": "Incyclist",
-  "appVersion": "1.2.1",
-  "bundleVersion" : "0.4.2",
-  "androidVersionCode": 45
+  "appVersion": "1.2.2",
+  "bundleVersion" : "0.5.0",
+  "androidVersionCode": 46
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "axios": "^1.17.0",
         "events": "^3.3.0",
         "gd-eventlog": "^0.1.27",
-        "incyclist-services": "^1.7.126",
+        "incyclist-services": "^1.7.128",
         "mqtt": "^5.15.2",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
@@ -11832,9 +11832,9 @@
       }
     },
     "node_modules/incyclist-services": {
-      "version": "1.7.126",
-      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.126.tgz",
-      "integrity": "sha512-gzIp9sjPRQOZcuao4KlGi8Bc3HRKrYninlJV2RQf+pLJsOqFUwgQ33tfFN3tlXPa/PS9x91qFv+yFVQuG4hwKQ==",
+      "version": "1.7.128",
+      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.128.tgz",
+      "integrity": "sha512-978PR8NIZzAkUKjdknfp5PpOK1kV31l34cHV5oth2jC8f3sAkVktC3eOKh8d5MUKPmr7wn+i9Zw8EBHkPMDN+w==",
       "dependencies": {
         "@garmin/fitsdk": "^21.213.0",
         "axios": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "axios": "^1.17.0",
     "events": "^3.3.0",
     "gd-eventlog": "^0.1.27",
-    "incyclist-services": "^1.7.126",
+    "incyclist-services": "^1.7.128",
     "mqtt": "^5.15.2",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.test.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.test.tsx
@@ -219,11 +219,23 @@ describe('RouteDetailsDialog - canNotStartReason (AVI vs offline)', () => {
         expect(queryByText('You are offline (no network)')).toBeNull();
     });
 
-    it('offline + not-AVI: shows the offline reason', () => {
+    it('offline + not-AVI + not startable: shows the offline reason', () => {
         mockOnlineStatusMonitor.onlineStatus = false;
         mockRouteData.description.videoFormat = undefined;
+        // e.g. a GPX route, or a video that has not been downloaded - RouteCard.canStart()
+        // returns false while offline for both.
+        mockCard.openSettings.mockReturnValue({ ...mockCardProps, canStart: false });
         const { getByText, queryByText } = render(<RouteDetailsDialog routeId="r1" onStart={jest.fn()} />);
         expect(getByText('You are offline (no network)')).toBeTruthy();
+        expect(queryByText('AVI videos are not supported on mobile')).toBeNull();
+    });
+
+    it('offline + not-AVI + startable: no reason shown, since a downloaded video plays locally', () => {
+        mockOnlineStatusMonitor.onlineStatus = false;
+        mockRouteData.description.videoFormat = undefined;
+        mockCard.openSettings.mockReturnValue({ ...mockCardProps, canStart: true });
+        const { queryByText } = render(<RouteDetailsDialog routeId="r1" onStart={jest.fn()} />);
+        expect(queryByText('You are offline (no network)')).toBeNull();
         expect(queryByText('AVI videos are not supported on mobile')).toBeNull();
     });
 

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
@@ -181,12 +181,16 @@ export const RouteDetailsDialog = ({ routeId, onStart }: RouteDetailsDialogProps
     const downloadStatus = downloadRow?.status ?? 'none'
     const canStart = !isAvi && (cardCanStart ?? true) && downloadStatus !== 'downloading';
     const isOnline = onlineStatusMonitor.onlineStatus;
-    // AVI takes precedence when both reasons apply - it is checked first below.
+    // Only ever explains a Start button that is actually unavailable. Being offline is not by
+    // itself a reason - a downloaded video plays from local storage and starts fine offline.
+    // AVI takes precedence when both apply.
     let canNotStartReason: string | undefined;
-    if (isAvi)
-        canNotStartReason = 'AVI videos are not supported on mobile';
-    else if (!isOnline)
-        canNotStartReason = 'You are offline (no network)';
+    if (!canStart) {
+        if (isAvi)
+            canNotStartReason = 'AVI videos are not supported on mobile';
+        else if (!isOnline)
+            canNotStartReason = 'You are offline (no network)';
+    }
 
     const hasDownloadUrl = !!(routeDescr.downloadUrl || (routeDescr.videoUrl?.startsWith('https://')));
     const showDownloadButton = hasDownloadUrl || routeDescr.requiresDownload === true;

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
@@ -7,6 +7,23 @@ import { RouteDetailsView } from './RouteDetailsView';
 import { RouteDetailsDialogProps } from './types';
 import { navigate } from '../../services';
 
+/**
+ * Explains a Start button that is actually unavailable. Being offline is not by itself a reason -
+ * a downloaded video plays from local storage and starts fine offline - so this only ever
+ * describes a route that genuinely cannot be started. AVI takes precedence when both apply.
+ */
+const getCanNotStartReason = (props: { canStart: boolean, isAvi: boolean, isOnline: boolean }): string | undefined => {
+    const { canStart, isAvi, isOnline } = props;
+
+    if (canStart)
+        return undefined;
+    if (isAvi)
+        return 'AVI videos are not supported on mobile';
+    if (!isOnline)
+        return 'You are offline (no network)';
+    return undefined;
+};
+
 export const RouteDetailsDialog = ({ routeId, onStart }: RouteDetailsDialogProps) => {
     const { height } = useWindowDimensions();
     const compact = height < 420;
@@ -181,16 +198,7 @@ export const RouteDetailsDialog = ({ routeId, onStart }: RouteDetailsDialogProps
     const downloadStatus = downloadRow?.status ?? 'none'
     const canStart = !isAvi && (cardCanStart ?? true) && downloadStatus !== 'downloading';
     const isOnline = onlineStatusMonitor.onlineStatus;
-    // Only ever explains a Start button that is actually unavailable. Being offline is not by
-    // itself a reason - a downloaded video plays from local storage and starts fine offline.
-    // AVI takes precedence when both apply.
-    let canNotStartReason: string | undefined;
-    if (!canStart) {
-        if (isAvi)
-            canNotStartReason = 'AVI videos are not supported on mobile';
-        else if (!isOnline)
-            canNotStartReason = 'You are offline (no network)';
-    }
+    const canNotStartReason = getCanNotStartReason({ canStart, isAvi, isOnline });
 
     const hasDownloadUrl = !!(routeDescr.downloadUrl || (routeDescr.videoUrl?.startsWith('https://')));
     const showDownloadButton = hasDownloadUrl || routeDescr.requiresDownload === true;


### PR DESCRIPTION
## Summary
Follow-up to the offline-start fix (services#574). With that fix in place, a downloaded video route correctly offers Start while offline — but the dialog still showed "You are offline (no network)" right next to the working button, which reads as a contradiction.

`canNotStartReason` was computed purely from `isAvi`/`isOnline`, independently of whether the route could actually be started. Being offline is not by itself a reason: a downloaded video plays entirely from local storage.

## What changed
- `RouteDetailsDialog.tsx` — the reason is now only computed when `!canStart`. `canStart` already accounts for both the AVI and offline cases, so the precedence (AVI first) is unchanged for the cases that do block starting.
- `RouteDetailsDialog.test.tsx` — the existing `offline + not-AVI` case is split into the two cases that now differ: **not startable** (GPX, or a video not yet downloaded) still shows the offline reason; **startable** (downloaded video) shows nothing.

Desktop already behaves this way — `RouteDetails/component.jsx:361` renders its offline banner as general information in the preview area, separate from the Start button's own enablement.

## Test plan
- [x] `npm test` — 1211 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/` — 0 errors
- [ ] On-device confirmation alongside services#574

## Note
Depends on services#574 to be observable — without it, a downloaded video is not startable offline anyway, so the reason still shows (correctly).