### PR TITLE
fix: Play Integrity attestation fails on released Android builds

### DIFF
--- a/.github/workflows/upload-google-play.yml
+++ b/.github/workflows/upload-google-play.yml
@@ -66,10 +66,16 @@ jobs:
 
       - name: Create config.json
         env:
-          GOOGLE_PROJECT_NUMBER: ${{ secrets.GOOGLE_PROJECT_NUMBER }} 
+          GOOGLE_PROJECT_NUMBER: ${{ secrets.GOOGLE_PROJECT_NUMBER }}
         run: |
+          # Play Integrity parses this as a Long. A missing or non-numeric value only
+          # surfaces at runtime as WRONG_GOOGLE_CLOUD_PROJECT_NUMBER_FORMAT, so fail here.
+          if ! [[ "$GOOGLE_PROJECT_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "GOOGLE_PROJECT_NUMBER is missing or not numeric"
+            exit 1
+          fi
           mkdir -p config
-          echo '{"GOOGLE_PROJECT_NUMBER":"$GOOGLE_PROJECT_NUMBER"}' > config/config.json
+          node -e 'require("node:fs").writeFileSync("config/config.json", JSON.stringify({ GOOGLE_PROJECT_NUMBER: process.env.GOOGLE_PROJECT_NUMBER }))'
 
       - name: Build release AAB
         working-directory: android

--- a/src/bindings/secret/attestation-android.test.ts
+++ b/src/bindings/secret/attestation-android.test.ts
@@ -1,0 +1,47 @@
+jest.mock('@pagopa/io-react-native-integrity', () => ({
+    prepareIntegrityToken: jest.fn(),
+    requestIntegrityToken: jest.fn(),
+}));
+jest.mock('@config', () => ({ __esModule: true, default: {} }), { virtual: true });
+
+import { prepareIntegrityToken, requestIntegrityToken } from '@pagopa/io-react-native-integrity';
+import config from '@config';
+import { AndroidAttestationProvider } from './attestation-android';
+
+const mutableConfig = config as Record<string, string | undefined>;
+
+describe('AndroidAttestationProvider', () => {
+    let provider: AndroidAttestationProvider;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        provider = new AndroidAttestationProvider();
+        (prepareIntegrityToken as jest.Mock).mockResolvedValue(undefined);
+        (requestIntegrityToken as jest.Mock).mockResolvedValue('token');
+    });
+
+    describe('getAttestationToken', () => {
+        test('a numeric project number is passed to the Play Integrity SDK', async () => {
+            mutableConfig.GOOGLE_PROJECT_NUMBER = '123456789012';
+
+            await expect(provider.getAttestationToken()).resolves.toBe('token');
+            expect(prepareIntegrityToken).toHaveBeenCalledWith('123456789012');
+        });
+
+        // A build that writes the placeholder literally instead of expanding it used to reach
+        // prepareIntegrityToken and fail there with WRONG_GOOGLE_CLOUD_PROJECT_NUMBER_FORMAT.
+        test('an unexpanded shell placeholder never reaches the SDK', async () => {
+            mutableConfig.GOOGLE_PROJECT_NUMBER = '$GOOGLE_PROJECT_NUMBER';
+
+            await expect(provider.getAttestationToken()).rejects.toThrow(/missing or not numeric/);
+            expect(prepareIntegrityToken).not.toHaveBeenCalled();
+        });
+
+        test('a missing project number never reaches the SDK', async () => {
+            delete mutableConfig.GOOGLE_PROJECT_NUMBER;
+
+            await expect(provider.getAttestationToken()).rejects.toThrow(/missing or not numeric/);
+            expect(prepareIntegrityToken).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/bindings/secret/attestation-android.ts
+++ b/src/bindings/secret/attestation-android.ts
@@ -13,11 +13,14 @@ export class AndroidAttestationProvider implements AttestationProvider {
 
     async getAttestationToken(): Promise<string> {
 
-        // 1. Validate that the Google Cloud project number is available
+        // 1. Validate that the Google Cloud project number is available.
+        // Play Integrity parses it as a Long, so anything non-numeric (e.g. an
+        // unexpanded shell placeholder written by the build) must be rejected here
+        // rather than surfacing as WRONG_GOOGLE_CLOUD_PROJECT_NUMBER_FORMAT at runtime.
         const googleCloudProjectNumber = (config as Record<string, string>).GOOGLE_PROJECT_NUMBER;
-        if (!googleCloudProjectNumber) {
+        if (!googleCloudProjectNumber || !/^\d+$/.test(googleCloudProjectNumber)) {
             throw new Error(
-                'AndroidAttestationProvider: GOOGLE_PROJECT_NUMBER is not set in config/config.json. ' +
+                'AndroidAttestationProvider: GOOGLE_PROJECT_NUMBER is missing or not numeric in config/config.json. ' +
                 'This value is required to initialise the Play Integrity SDK.',
             );
         }


### PR DESCRIPTION
## Summary

Play Integrity attestation has failed on every released Android build since 2026-08-26, logging

```
{"context":"Secrets","message":"attestation failed","reason":"WRONG_GOOGLE_CLOUD_PROJECT_NUMBER_FORMAT"}
```

The `Create config.json` step in `upload-google-play.yml` writes the project number with a single-quoted `echo`. That was harmless while the value came from a `${{ secrets... }}` expression, because GitHub substituted it before the shell ran. When the secret moved into an `env:` block, the single quotes suppressed expansion, so every AAB built since has shipped:

```json
{"GOOGLE_PROJECT_NUMBER":"$GOOGLE_PROJECT_NUMBER"}
```

Metro bakes `config.json` into the JS bundle, and `AndroidAttestationProvider` only checked the value was truthy, so the literal placeholder reached `prepareIntegrityToken()`. The Play Integrity SDK parses it as a `Long` and rejects it, leaving the secrets binding in `missing` state and `getSecret()` returning empty strings on release builds.

## What changed

- **`.github/workflows/upload-google-play.yml`** — write `config.json` via `node` with proper JSON encoding, and fail the build up front when the secret is absent or non-numeric, mirroring the fail-fast the workflow already applies to `MAPS_API_KEY`.
- **`src/bindings/secret/attestation-android.ts`** — reject a non-numeric `GOOGLE_PROJECT_NUMBER` instead of merely checking it is truthy, so a future mis-substitution fails in tests rather than in production logs.
- **`src/bindings/secret/attestation-android.test.ts`** — new, covering the valid, placeholder, and missing cases.

## Test plan

- [x] `npx jest` — 148 suites, 1214 tests pass
- [x] New tests are red without the provider guard (2 of 3 fail)
- [x] `tsc --noEmit` and `eslint` clean
- [x] Differential check on the workflow step: executing the extracted `run:` block with the env var set yields `123456789012` on this branch and `$GOOGLE_PROJECT_NUMBER` on `main`
- [x] With an empty secret the step exits 1 rather than writing a bad config

## Notes for the reviewer

This does not repair installs already in the field. v1.1.1 (build 43) and v1.2.0 (build 44) carry the broken value in their embedded bundle; the fix takes effect on the next CI-built AAB. Installs that pull an OTA bundle recover on their own, since the bundle carries the config value from the machine that built it, but a fresh install still logs one `attestation failed` before the OTA lands.
