### PR TITLE
fix: load route details before showing the route details dialog body

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "axios": "^1.17.0",
         "events": "^3.3.0",
         "gd-eventlog": "^0.1.27",
-        "incyclist-services": "^1.7.128",
+        "incyclist-services": "^1.7.129",
         "mqtt": "^5.15.2",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
@@ -11832,9 +11832,9 @@
       }
     },
     "node_modules/incyclist-services": {
-      "version": "1.7.128",
-      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.128.tgz",
-      "integrity": "sha512-978PR8NIZzAkUKjdknfp5PpOK1kV31l34cHV5oth2jC8f3sAkVktC3eOKh8d5MUKPmr7wn+i9Zw8EBHkPMDN+w==",
+      "version": "1.7.129",
+      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.129.tgz",
+      "integrity": "sha512-QWtWBnDCNvyw3Pg04nmNwdS/2rv+sdrEVAdB7gJhAQ8sRxDRwJQzuLZjGPU3O/5GT0ruBWWWzfeYtnUhwEAoGA==",
       "dependencies": {
         "@garmin/fitsdk": "^21.213.0",
         "axios": "^1.19.0",
@@ -11842,7 +11842,7 @@
         "promise.any": "^2.0.6",
         "semver": "^7.7.4",
         "tcx-builder": "^1.1.1",
-        "uuid": "^14.0.0",
+        "uuid": "^14.0.2",
         "xml2js": "^0.6.2"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "axios": "^1.17.0",
     "events": "^3.3.0",
     "gd-eventlog": "^0.1.27",
-    "incyclist-services": "^1.7.128",
+    "incyclist-services": "^1.7.129",
     "mqtt": "^5.15.2",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",

--- a/src/components/EditNumber/EditNumber.test.tsx
+++ b/src/components/EditNumber/EditNumber.test.tsx
@@ -67,3 +67,45 @@ describe('EditNumber', () => {
         expect(getByDisplayValue('abc')).toBeTruthy();
     });
 });
+// `min`, `max` and `value` are typed as optional numbers, but callers routinely pass an explicit
+// null for "not known yet" - e.g. RouteDetailsView feeds `max={totalDistance.value}`, and a route
+// whose details carry no points has a distance of null rather than undefined.
+describe('EditNumber - null instead of undefined for an absent number', () => {
+
+    it('renders when max is null', () => {
+        const { getByText } = render(
+            <EditNumber label="Start" value={0} max={null as any} onValueChange={jest.fn()} />
+        );
+        expect(getByText('Start')).toBeTruthy();
+    });
+
+    it('renders when min is null', () => {
+        const { getByText } = render(
+            <EditNumber label="Start" value={0} min={null as any} onValueChange={jest.fn()} />
+        );
+        expect(getByText('Start')).toBeTruthy();
+    });
+
+    it('renders when value is null and no bounds are given', () => {
+        const { getByText } = render(
+            <EditNumber label="Start" value={null as any} onValueChange={jest.fn()} />
+        );
+        expect(getByText('Start')).toBeTruthy();
+    });
+
+    it('does not enforce a null bound as if it were zero', () => {
+        const onValueChange = jest.fn();
+        const { getByDisplayValue, queryByText } = render(
+            <EditNumber label="Start" value={10} min={null as any} max={null as any}
+                onValueChange={onValueChange} />
+        );
+        const input = getByDisplayValue('10');
+
+        fireEvent.changeText(input, '25');
+        fireEvent(input, 'blur');
+
+        expect(queryByText(/Maximum value is/)).toBeNull();
+        expect(queryByText(/Minimum value is/)).toBeNull();
+        expect(onValueChange).toHaveBeenCalledWith(25);
+    });
+});

--- a/src/components/EditNumber/EditNumber.tsx
+++ b/src/components/EditNumber/EditNumber.tsx
@@ -8,6 +8,11 @@ import { useLogging } from '../../hooks';
 
 const LABEL_MARGIN = 8;
 
+// `value`, `min` and `max` are typed as optional numbers, but callers routinely pass an explicit
+// null for "not known" - a route distance, for instance, is null until the route's points have
+// been loaded. Both spellings of absent have to read the same way here.
+const isSet = (v?: number): v is number => v !== undefined && v !== null;
+
 export const EditNumber = ({
     label,
     value,
@@ -23,7 +28,7 @@ export const EditNumber = ({
 }: EditNumberProps) => {
     const formatValue = useCallback(
         (val?: number) => {
-            if (val === undefined || val === null) return '';
+            if (!isSet(val)) return '';
             return val.toFixed(digits);
         },
         [digits]
@@ -63,12 +68,12 @@ export const EditNumber = ({
             return;
         }
 
-        if (min !== undefined && numericValue < min) {
+        if (isSet(min) && numericValue < min) {
             setError(`Minimum value is ${min}`);
             return;
         }
 
-        if (max !== undefined && numericValue > max) {
+        if (isSet(max) && numericValue > max) {
             setError(`Maximum value is ${max}`);
             return;
         }
@@ -83,12 +88,12 @@ export const EditNumber = ({
 
     const deriveLength = useCallback((): number | undefined => {
         if (length !== undefined) return length;
-        if (min === undefined && max === undefined) {
-            if (value === undefined) return undefined;
+        if (!isSet(min) && !isSet(max)) {
+            if (!isSet(value)) return undefined;
             return value.toFixed(digits).length + 3;
         }
-        const minStr = min !== undefined ? min.toString() : '';
-        const maxStr = max !== undefined ? max.toString() : '';
+        const minStr = isSet(min) ? min.toString() : '';
+        const maxStr = isSet(max) ? max.toString() : '';
         const longestLen = Math.max(minStr.length, maxStr.length);
         return longestLen + 3;
     }, [length, min, max, value, digits]);

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.test.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.test.tsx
@@ -247,3 +247,85 @@ describe('RouteDetailsDialog - canNotStartReason (AVI vs offline)', () => {
         expect(queryByText('You are offline (no network)')).toBeNull();
     });
 });
+
+// A route's details (points, video info) are loaded lazily, so the dialog is routinely mounted
+// before they exist. Everything RouteCard.openSettings() derives from them - distance, elevation,
+// whether the video is reachable - is provisional until `detailsAvailable` turns true, so the
+// dialog has to read the settings again once the load lands instead of keeping the mount-time copy.
+describe('RouteDetailsDialog - settings captured before the route details are loaded', () => {
+
+    const provisionalProps = {
+        ...mockCardProps,
+        detailsAvailable: false,
+        canStart: false,
+        totalDistance: { value: null, unit: 'km' },
+        totalElevation: { value: null, unit: 'm' },
+    };
+
+    const loadedProps = { ...mockCardProps, detailsAvailable: true };
+
+    let resolveDetails: (value?: unknown) => void;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockGetRouteDetailsProps.mockReturnValue(baseRouteDetailsProps());
+        mockOnlineStatusMonitor.onlineStatus = true;
+        mockRouteData.description.videoFormat = undefined;
+
+        mockRouteData.details = undefined;
+        mockCard.openSettings.mockReturnValue(provisionalProps);
+        mockRouteListService.getRouteDetails.mockImplementation(() => new Promise(resolve => {
+            resolveDetails = () => {
+                mockRouteData.details = { points: [] };
+                mockCard.openSettings.mockReturnValue(loadedProps);
+                resolve(mockRouteData.details);
+            };
+        }));
+    });
+
+    afterEach(() => {
+        mockRouteData.details = { points: [] };
+        mockRouteListService.getRouteDetails.mockResolvedValue(undefined);
+    });
+
+    it('shows a loading body instead of provisional distance, elevation and settings', () => {
+        const { getByText, queryByText } = render(<RouteDetailsDialog routeId="r1" onStart={jest.fn()} />);
+
+        expect(getByText('Loading route details…')).toBeTruthy();
+        expect(queryByText('50 km')).toBeNull();
+    });
+
+    it('does not offer Start while the settings are still provisional', () => {
+        const { queryAllByText } = render(<RouteDetailsDialog routeId="r1" onStart={jest.fn()} />);
+
+        expect(queryAllByText('Start')).toHaveLength(0);
+    });
+
+    it('re-reads the card settings once the details have loaded', async () => {
+        const { getByText, queryByText } = render(<RouteDetailsDialog routeId="r1" onStart={jest.fn()} />);
+        expect(queryByText('50 km')).toBeNull();
+
+        await act(async () => { resolveDetails(); });
+
+        expect(queryByText('Loading route details…')).toBeNull();
+        expect(getByText('50 km')).toBeTruthy();
+        expect(getByText('800 m')).toBeTruthy();
+    });
+
+    it('offers Start again once the details have loaded', async () => {
+        const { queryAllByText } = render(<RouteDetailsDialog routeId="r1" onStart={jest.fn()} />);
+
+        await act(async () => { resolveDetails(); });
+
+        expect(queryAllByText('Start').length).toBeGreaterThan(0);
+    });
+
+    it('does not re-read the settings when the details are already available at mount', () => {
+        mockRouteData.details = { points: [] };
+        mockCard.openSettings.mockReturnValue(loadedProps);
+
+        render(<RouteDetailsDialog routeId="r1" onStart={jest.fn()} />);
+
+        expect(mockRouteListService.getRouteDetails).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
@@ -43,7 +43,10 @@ export const RouteDetailsDialog = ({ routeId, onStart }: RouteDetailsDialogProps
     const refDownloadObserver = useRef<any>(null);
 
     const [cardProps, setCardProps] = useState(() => card?.openSettings());
-    const [loading, setLoading] = useState(false);
+    // The route details are loaded lazily, so the settings above can be a provisional copy in
+    // which distance, elevation and the video location are not known yet. `detailsAvailable`
+    // says so, and the dialog shows a loading body until the real values have been read.
+    const [loading, setLoading] = useState(() => cardProps?.detailsAvailable === false);
     const [prevRides, setPrevRides] = useState<any[] | null>(null);
     const [showPrev, setShowPrev] = useState(false);
     const [showDownloadModal, setShowDownloadModal] = useState(false);
@@ -96,10 +99,16 @@ export const RouteDetailsDialog = ({ routeId, onStart }: RouteDetailsDialogProps
 
         const data = card.getData();
 
-        if (!data.details) {
+        if (currentProps?.detailsAvailable === false) {
             setLoading(true);
             service.getRouteDetails(routeId)
-                .then(() => { if (refMounted.current) setLoading(false); })
+                .then(() => {
+                    if (!refMounted.current) return;
+                    // Loading the details fills in distance, elevation and the video location, so
+                    // everything read above is stale by now - read the settings again.
+                    setCardProps(card.openSettings());
+                    setLoading(false);
+                })
                 .catch(() => { if (refMounted.current) setLoading(false); });
         }
 
@@ -196,7 +205,9 @@ export const RouteDetailsDialog = ({ routeId, onStart }: RouteDetailsDialogProps
     const routeType = `${hasVideo ? 'Video' : 'GPX'} - ${isLoop ? 'Loop' : 'Point to Point'}`;
     const isAvi = videoFormat?.toLowerCase() === 'avi';
     const downloadStatus = downloadRow?.status ?? 'none'
-    const canStart = !isAvi && (cardCanStart ?? true) && downloadStatus !== 'downloading';
+    // Nothing is startable on provisional settings - a GPX route has no points to ride yet, and
+    // for a video route the location of the video is still unknown.
+    const canStart = !isAvi && (cardCanStart ?? true) && downloadStatus !== 'downloading' && !loading;
     const isOnline = onlineStatusMonitor.onlineStatus;
     const canNotStartReason = getCanNotStartReason({ canStart, isAvi, isOnline });
 

--- a/src/components/RouteDetailsDialog/RouteDetailsView.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.tsx
@@ -175,7 +175,21 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
         return <Text style={styles.placeholderText}>No preview available</Text>;
     };
 
+    // Distance and elevation are derived from the route details, so they read as unknown for as
+    // long as those are still loading.
+    const formatStat = (stat: { value: number, unit: string }, separator = ' ') =>
+        loading ? '—' : `${stat.value}${separator}${stat.unit}`;
+
     const renderForm = () => {
+        if (loading) {
+            return (
+                <View style={styles.formLoading}>
+                    <ActivityIndicator color={colors.text} />
+                    <Text style={styles.placeholderText}>Loading route details…</Text>
+                </View>
+            );
+        }
+
         const useChips = !compact && (segments?.length ?? 0) <= SEGMENT_CHIP_THRESHOLD;
 
         return (
@@ -297,7 +311,7 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
         const infoBar = (
             <View style={styles.infoBar}>
                 <Text style={styles.infoBarText}>
-                    {routeType} • {totalDistance.value}{totalDistance.unit} • {totalElevation.value}{totalElevation.unit}
+                    {routeType} • {formatStat(totalDistance, '')} • {formatStat(totalElevation, '')}
                 </Text>
                 {!!canNotStartReason && <Text style={styles.errorText}>{canNotStartReason}</Text>}
             </View>
@@ -350,11 +364,11 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
             <View style={styles.statsRow}>
                 <View style={styles.statBox}>
                     <Text style={styles.statLabel}>Distance</Text>
-                    <Text style={styles.statValue}>{totalDistance.value} {totalDistance.unit}</Text>
+                    <Text style={styles.statValue}>{formatStat(totalDistance)}</Text>
                 </View>
                 <View style={styles.statBox}>
                     <Text style={styles.statLabel}>Elevation</Text>
-                    <Text style={styles.statValue}>{totalElevation.value} {totalElevation.unit}</Text>
+                    <Text style={styles.statValue}>{formatStat(totalElevation)}</Text>
                 </View>
                 <View style={styles.statBox}>
                     <Text style={styles.statLabel}>Type</Text>
@@ -384,6 +398,7 @@ const styles = StyleSheet.create({
     mediaContainer: { flex: 1, backgroundColor: 'rgba(0,0,0,0.3)', borderRadius: 8, overflow: 'hidden', justifyContent: 'center', alignItems: 'center' },
     fullMedia: { width: '100%', height: '100%' },
     placeholderText: { color: colors.disabled, fontSize: 12 },
+    formLoading: { alignItems: 'center', justifyContent: 'center', gap: 10, paddingVertical: 30 },
     statsRow: { flexDirection: 'row', paddingHorizontal: 15, paddingBottom: 10, borderBottomWidth: 1, borderBottomColor: 'rgba(255,255,255,0.1)' },
     statBox: { flex: 1, alignItems: 'center' },
     statLabel: { color: colors.disabled, fontSize: 10, textTransform: 'uppercase' },


### PR DESCRIPTION
## Summary

Consuming half of incyclist/services#575, which fixes a production crash on 0.4.1 (5 users affected):

```
error in component, error:Cannot read property 'video' of undefined
  at openSettings
  at mountStateImpl / useState
  at RouteDetailsDialog
```

The services PR stops the throw. This PR fixes what caused the dialog to ask for the settings too early in the first place, and makes the wait visible instead of rendering provisional data as if it were final.

## What changed

**`RouteDetailsDialog`** — route details are loaded lazily, so the dialog was routinely mounted before they existed and captured `RouteCard.openSettings()` while distance, elevation and video availability were all still provisional. It then only cleared its loading flag when the load resolved, never re-reading the settings, so those provisional values stayed on screen for the lifetime of the dialog.

- triggers the load off the new `detailsAvailable` flag rather than reaching into `card.getData().details`
- **re-reads `openSettings()` once the load resolves** — this is the actual fix
- withholds Start until the settings are real: a GPX route has no points to ride yet, and for a video route the location of the video is still unknown

**`RouteDetailsView`** — a spinner plus "Loading route details…" replaces the settings form while the load runs, matching the idiom `renderMedia()`/`renderPreview()` already used for the map and preview tiles. The stats row shows `—` instead of rendering `null km` / `null m`.

**`EditNumber`** — a separate latent crash found while building the repro. `value`/`min`/`max` were guarded with `!== undefined`, but an absent number reaches this component as `null` (`Route.distance` is `null` until the route's points are loaded). Two of those five sites threw on `.toString()` / `.toFixed()`, and the bounds checks coerced a null bound to `0`, rejecting valid input with "Minimum value is null". All five now treat null and undefined alike. `formatValue` already special-cased null, so this makes the component consistent with itself.

## Test plan

New tests, all red before the fix.

`RouteDetailsDialog.test.tsx` — 5 cases covering the lazy-load window:
- shows a loading body instead of provisional distance, elevation and settings
- does not offer Start while the settings are still provisional
- re-reads the card settings once the details have loaded
- offers Start again once the details have loaded
- does not re-read the settings when the details are already available at mount

`EditNumber.test.tsx` — 4 cases for null bounds and values, including `does not enforce a null bound as if it were zero` (which catches the validation bug rather than the crash).

```
npx jest          → 1223 passed, 148 suites
npx tsc --noEmit  → clean
npx eslint        → 0 errors
```

## Dependency

Needs a release of incyclist/services#575 — `detailsAvailable` does not exist in 1.7.128, so `tsc` reports two errors against the currently pinned version. Verified clean against a local build of that branch. The `package.json` pin still needs bumping once it is published.
