### PR TITLE
fix: place ride-overlay corner widgets below the dashboard instead of dropping them

### DIFF
--- a/src/components/RideOverlay/RideOverlay.test.tsx
+++ b/src/components/RideOverlay/RideOverlay.test.tsx
@@ -98,13 +98,14 @@ describe('RideOverlay', () => {
         expect(getByTestId('ride-overlay-elevation')).toBeTruthy();
     });
 
-    it('column-only: renders the dashboard, drops both corner widgets entirely (not relocated)', () => {
+    it('below: renders the dashboard AND both corner widgets, relocated under the column', () => {
         setDimensions(860, 480);
-        const { getByTestId, queryByTestId } = render(<RideOverlay {...baseProps} />);
+        const { getByTestId } = render(<RideOverlay {...baseProps} />);
 
         expect(getByTestId('ride-overlay-dashboard')).toBeTruthy();
-        expect(queryByTestId('ride-overlay-map')).toBeNull();
-        expect(queryByTestId('ride-overlay-elevation')).toBeNull();
+        // Relocated, not dropped - this is the arrangement that used to return null rects.
+        expect(getByTestId('ride-overlay-map')).toBeTruthy();
+        expect(getByTestId('ride-overlay-elevation')).toBeTruthy();
     });
 
     it('fallback (compact): no WorkoutDashboard, no corner map — the elevation slot becomes a toggle, plus the shoutout line', () => {
@@ -319,15 +320,15 @@ describe('RideOverlay — no workout attached', () => {
         expect(queryByTestId('ride-overlay-prev-rides')).toBeNull();
     });
 
-    it('column-only: drops the side-region occupants and the previous-rides list entirely (no WorkoutDashboard, no crash on the now-optional props)', () => {
+    it('below: relocates the side-region occupants and the previous-rides list under the column (no WorkoutDashboard, no crash on the now-optional props)', () => {
         setDimensions(860, 480);
         expect(() => render(<RideOverlay {...routeOnlyProps} />)).not.toThrow();
 
-        const { queryByTestId } = render(<RideOverlay {...routeOnlyProps} />);
-        expect(queryByTestId('ride-overlay-dashboard')).toBeNull();
-        expect(queryByTestId('ride-overlay-map')).toBeNull();
-        expect(queryByTestId('ride-overlay-elevation')).toBeNull();
-        expect(queryByTestId('ride-overlay-prev-rides')).toBeNull();
+        const { queryByTestId, getByTestId } = render(<RideOverlay {...routeOnlyProps} />);
+        expect(queryByTestId('ride-overlay-dashboard')).toBeNull(); // no workout attached
+        expect(getByTestId('ride-overlay-map')).toBeTruthy();
+        expect(getByTestId('ride-overlay-elevation')).toBeTruthy();
+        expect(getByTestId('ride-overlay-prev-rides')).toBeTruthy();
     });
 
     it('fallback (compact): no WorkoutDashboard, no shoutout line, no Stop-Workout slot, no crash', () => {
@@ -482,24 +483,40 @@ describe('RideOverlay — nearby-riders overlay wiring', () => {
         expect(queryByTestId('nearby-riders-tablet-list')).toBeNull();
     });
 
-    it('does not render the nearby-riders list when the corner map itself is not rendered (mapVisible false) — no reserved left ear without the map', () => {
+    // Design doc §5.2 requires this list to be "an independent, always-visible-when-eligible
+    // sibling", "not derived from the map's geometry". It used to be gated on the corner map's rect,
+    // which is null whenever mapVisible is false — i.e. on every ride whose main view is itself a map
+    // (rideView === 'map'), where the list was therefore unreachable at any screen size.
+    it('renders the nearby-riders list when the corner map is not rendered (mapVisible false) — it anchors to the widget row, not to the map', () => {
         setDimensions(1400, 900);
         const { queryByTestId, getByTestId } = render(
             <RideOverlay {...nearbyRidersProps} mapVisible={false} mapPoints={undefined} />
         );
 
         expect(queryByTestId('ride-overlay-map')).toBeNull();
-        expect(queryByTestId('nearby-riders-tablet-list')).toBeNull();
+        expect(getByTestId('nearby-riders-tablet-list')).toBeTruthy();
         // the right ear (elevation) is unaffected
         expect(getByTestId('ride-overlay-elevation')).toBeTruthy();
     });
 
-    it('column-only: drops the nearby-riders list entirely along with the other side-region occupants', () => {
-        setDimensions(860, 480);
-        const { queryByTestId } = render(<RideOverlay {...nearbyRidersProps} />);
+    it('anchors the nearby-riders list at the same depth whether or not the corner map is rendered', () => {
+        setDimensions(1400, 900);
+        const topOf = (mapVisible: boolean) => {
+            const { getByTestId } = render(
+                <RideOverlay {...nearbyRidersProps} mapVisible={mapVisible} mapPoints={mapVisible ? nearbyRidersProps.mapPoints : undefined} />
+            );
+            return Object.assign({}, ...[getByTestId('nearby-riders-tablet-list').props.style].flat()).top;
+        };
 
-        expect(queryByTestId('ride-overlay-map')).toBeNull();
-        expect(queryByTestId('nearby-riders-tablet-list')).toBeNull();
+        expect(topOf(false)).toBe(topOf(true));
+    });
+
+    it('below: relocates the nearby-riders list under the column along with the other side-region occupants', () => {
+        setDimensions(860, 480);
+        const { getByTestId } = render(<RideOverlay {...nearbyRidersProps} />);
+
+        expect(getByTestId('ride-overlay-map')).toBeTruthy();
+        expect(getByTestId('nearby-riders-tablet-list')).toBeTruthy();
     });
 
     // Tablet has separate left/right ears (no shared corner slot), so the phone-only "PrevRides

--- a/src/components/RideOverlay/RideOverlay.tsx
+++ b/src/components/RideOverlay/RideOverlay.tsx
@@ -318,22 +318,20 @@ export const RideOverlay = (props: RideOverlayProps) => {
         }
     }, [prevRidesTabletVisibleRows, onVisibleRowsChange]);
 
-    // Left ear: NearbyRiders stacks below the corner Map, mirroring PrevRides' own right-ear list
-    // below Elevation (design doc §2.4/§5.2 - "left ear v1 occupant: corner Map... Phase 3 reserve:
-    // NearbyRiders"). Unlike the right ear, there is no always-present left-ear widget to anchor
-    // below when the map itself isn't rendered (`map` is `null` whenever `!mapVisible`, even in a
-    // side arrangement) - `RideOverlayPrototype.stories.tsx`'s own Phase-3 ghost gates identically
-    // on `mapRect` truthiness, so this list is simply not shown in that case rather than reserving
-    // an anchor for it.
-    const nearbyRidersAnchorBottom = map ? map.top + map.height : undefined;
-    // Unlike prevRidesFreeBand above, this feeds a plain CSS `maxHeight` clamp on
-    // NearbyRidersTabletList's `style` prop below, not a separate visibleRows formula — that
-    // component has no internal row-count clamping of its own (design doc §5.2 "Correction 3").
-    // So no TABLET_LIST_HEADER_HEIGHT subtraction here: NearbyRidersTabletList now renders its own
-    // title as a real child inside this same maxHeight-bounded box, which already eats into the
-    // row space exactly once. Subtracting the header height here too would double-count it (title
-    // space reserved both by a smaller maxHeight AND by the title itself), clipping one row more
-    // than intended.
+    // NearbyRiders sits on the row below the map/elevation widgets, left side - the mirror of
+    // PrevRides on the right (nearby-riders-mobile-design.md §5.2: "an independent,
+    // always-visible-when-eligible sibling", "not derived from the map's geometry").
+    //
+    // Anchored to whichever widget actually occupies that row, NOT to the corner map specifically.
+    // `map` is null whenever `mapVisible` is false, which is the case on every ride whose main view
+    // is itself a map (`rideView === 'map'`) - anchoring on it made this list unreachable there at
+    // any screen size. `elevation` is present in every arrangement `map` is, at the identical top
+    // and height (both `buildSideRects` and `buildBelowRects` build them as a pair), so it is an
+    // exact stand-in when the map is absent and the left ear is simply empty.
+    const nearbyRidersRowOccupant = map ?? elevation;
+    const nearbyRidersAnchorBottom = nearbyRidersRowOccupant
+        ? nearbyRidersRowOccupant.top + nearbyRidersRowOccupant.height
+        : undefined;
     const nearbyRidersFreeBand = nearbyRidersAnchorBottom !== undefined && !cornerSlotIsToggle
         ? inputs.screenHeight - BOTTOM_BAR_RATIO * inputs.screenHeight - nearbyRidersAnchorBottom - 2 * SLOT_GAP
         : undefined;
@@ -393,12 +391,13 @@ export const RideOverlay = (props: RideOverlayProps) => {
                 </View>
             )}
 
-            {/* --- Nearby-riders list: stacked below the corner map, left side — the left-ear
-                    counterpart to the previous-rides list stacked below elevation on the right
-                    (design doc §2.4/§5.2). Only where the map itself is rendered (`map` non-null)
-                    and an actual side column exists (not the fallback toggle slot, which has no
-                    left ear at all — see NearbyRidersCornerPanel below for that case). ---------- */}
-            {map && !cornerSlotIsToggle && nearbyRiders && nearbyRiders.length > 0 && (
+            {/* --- Nearby-riders list: the row below the map/elevation widgets, left side - the
+                    left-hand counterpart to the previous-rides list on the right (design doc
+                    §2.4/§5.2). Shown whenever that row exists and an actual side/below column does
+                    (not the fallback toggle slot, which has no left ear at all - see
+                    NearbyRidersCornerPanel below for that case). Deliberately not gated on the
+                    corner map - see nearbyRidersRowOccupant above. ---------- */}
+            {nearbyRidersAnchorBottom !== undefined && !cornerSlotIsToggle && nearbyRiders && nearbyRiders.length > 0 && (
                 <ErrorBoundary>
                     <Dynamic observer={rideObserver ?? undefined} event="nearby-riders-update" prop="rows" transform={extractNearbyRiderRows}>
                         <NearbyRidersTabletList

--- a/src/hooks/render/useRideOverlayLayout.test.ts
+++ b/src/hooks/render/useRideOverlayLayout.test.ts
@@ -11,6 +11,9 @@ import {
     ARRANGEMENT_HYSTERESIS_PX,
     DEFAULT_ROUTE_RIDE_TILE_COUNT,
     WORKOUT_DASH_MIN_WIDTH,
+    RIDE_DASH_HEIGHT_RATIO,
+    SLOT_GAP,
+    belowSlotWidthOf,
 } from './useRideOverlayLayout'
 
 // Retuned by session 4.1 (the Wave 4 prototype) - see `RideOverlayPrototype.stories.tsx` and HLD
@@ -19,8 +22,13 @@ import {
 //    WorkoutDashboard height model, and the removal of the aspect ceiling);
 //  - the cascade's shape: the T no longer narrows WorkoutDashboard to its floor to buy ear width.
 //    Ears get their floor first and the dashboard takes the rest, so the T is shallow rather than
-//    narrow, and 'block-below'/'t-below' became a single 'column-only' that drops the corner widgets
-//    instead of relocating them under the column.
+//    narrow, and 'block-below'/'t-below' merged into one arrangement.
+//
+// Session 4.1 also made that merged arrangement DROP the corner widgets ('column-only') rather than
+// relocate them. That was wrong - it blanked map, elevation preview and nearby riders on any tablet
+// under the side-fit threshold - and is reverted: the merged arrangement is 'below', and it places
+// the widgets beneath the column. 'column-only' remains only as the terminal "no vertical room at
+// all" case, which no landscape non-compact frame reaches (see the spec suite at the end).
 
 const mockDimensions = { width: 1280, height: 800 }
 jest.mock('react-native/Libraries/Utilities/useWindowDimensions', () => ({
@@ -135,26 +143,32 @@ describe('computeRideOverlayLayout - the arrangements', () => {
     // Below the 't-side' floor: screenWidth < 2*(200+8) + 480 = 896. Every frame here is landscape
     // (width > height) - the app is orientation-locked to landscape (`Loader.tsx`), so a portrait
     // frame is not a state it can be in and must not be used to justify an arrangement.
-    it('640x430, N=7: column-only - no side arrangement fits, so the corner widgets are dropped', () => {
+    it('640x430, N=7: below - no side arrangement fits, so the widgets relocate under the column', () => {
         const result = computeRideOverlayLayout({ screenWidth: 640, screenHeight: 430, screenLayout: 'normal', itemCount: 7, mapVisible: true })
         expect(result.inputs.rideDashboardWidthEffective).toBe(640) // clamped (§5.7) - raw W_rd (895.6) would overflow
-        expect(result.arrangement).toBe('column-only')
+        expect(result.arrangement).toBe('below')
         expect(result.workoutDashboard?.width).toBe(640) // matches the (clamped) dashboard
-        expect(result.map).toBeNull()
-        expect(result.elevation).toBeNull() // dropped, NOT relocated below the column - the main view keeps the screen
+        // Relocated, NOT dropped: the widgets sit beneath the whole column, splitting the screen.
+        expect(result.map).not.toBeNull()
+        expect(result.elevation).not.toBeNull()
+        expect(result.map?.left).toBe(0)
+        expect(result.elevation?.right).toBe(0)
+        expect(result.elevation?.top).toBeGreaterThan(result.workoutDashboard!.top)
     })
 
-    it('860x480, N=7: column-only as well, just under the t-side floor', () => {
+    it('860x480, N=7: below as well, just under the t-side floor', () => {
         const result = computeRideOverlayLayout({ screenWidth: 860, screenHeight: 480, screenLayout: 'normal', itemCount: 7, mapVisible: true })
-        expect(result.arrangement).toBe('column-only')
+        expect(result.arrangement).toBe('below')
         expect(result.workoutDashboard?.width).toBeCloseTo(860, 5)
-        expect(result.elevation).toBeNull()
+        expect(result.elevation).not.toBeNull()
     })
 
-    it('column-only needs no fit test - it is what is left, so it never falls through to fallback', () => {
-        const tiny = computeRideOverlayLayout({ screenWidth: 500, screenHeight: 430, screenLayout: 'normal', itemCount: 7, mapVisible: true })
-        expect(tiny.arrangement).toBe('column-only')
-        expect(tiny.workoutDashboard).not.toBeNull()
+    it('the below row is bounded by half the screen, not by the leftover side region', () => {
+        const result = computeRideOverlayLayout({ screenWidth: 640, screenHeight: 430, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        // The column is clamped to the full 640, so there is no ear at all - yet the below row still
+        // has room, because it splits the screen rather than the remainder beside the column.
+        expect(result.inputs.earWidth).toBe(belowSlotWidthOf(640))
+        expect(result.elevation!.width).toBeLessThanOrEqual(belowSlotWidthOf(640))
     })
 
     it('844x390 (phone landscape), any N: fallback, because screenLayout is compact', () => {
@@ -276,7 +290,7 @@ describe('computeRideOverlayLayout - hysteresis (design doc §8.2)', () => {
         const warm = computeRideOverlayLayout({
             screenWidth: 870, screenHeight: 600, screenLayout: 'normal', itemCount: 7, mapVisible: true, previousArrangement: 't-side',
         })
-        expect(cold.arrangement).toBe('column-only')
+        expect(cold.arrangement).toBe('below')
         expect(warm.arrangement).toBe('t-side')
         expect(warm.workoutDashboard?.width).toBe(WORKOUT_DASH_MIN_WIDTH + 22) // 870 - 2*(176+8)
     })
@@ -401,11 +415,12 @@ describe('useRideOverlayLayout - the hook', () => {
 })
 
 // Sanity check the arrangement type union stays in sync with what the pure function actually
-// returns. Four values since session 4.1 replaced 'block-below'/'t-below' with 'column-only'.
+// returns. Five values: 'below' restores the relocated row session 4.1 had removed, and
+// 'column-only' stays on as the terminal "not even that fits" case.
 describe('RideOverlayArrangement', () => {
-    it('covers exactly the 4 arrangements the tuned algorithm produces', () => {
-        const all: RideOverlayArrangement[] = ['block-side', 't-side', 'column-only', 'fallback']
-        expect(all).toHaveLength(4)
+    it('covers exactly the 5 arrangements the algorithm produces', () => {
+        const all: RideOverlayArrangement[] = ['block-side', 't-side', 'below', 'column-only', 'fallback']
+        expect(all).toHaveLength(5)
     })
 })
 
@@ -438,29 +453,33 @@ describe('computeRideOverlayLayout - workoutAttached: false (one-member column)'
     // meaningful sense: `block-side` - the one arrangement that IS in both cascades - has an
     // identical, unworsened threshold (previous test); column-only is what a one-member column falls
     // to instead of needing a rescue mechanism it structurally cannot have.
-    it('1280x800, N=7: falls to column-only - there is no WorkoutDashboard to narrow for a t-side rescue', () => {
+    it('1280x800, N=7: falls to below - there is no WorkoutDashboard to narrow for a t-side rescue', () => {
         const combo = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true, workoutAttached: true })
         const routeOnly = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true, workoutAttached: false })
 
         expect(combo.arrangement).toBe('t-side')
-        expect(routeOnly.arrangement).toBe('column-only')
+        expect(routeOnly.arrangement).toBe('below')
         expect(routeOnly.workoutDashboard).toBeNull()
-        expect(routeOnly.map).toBeNull()
-        expect(routeOnly.elevation).toBeNull()
+        expect(routeOnly.map).not.toBeNull()
+        expect(routeOnly.elevation).not.toBeNull()
+        // Row 2 of the ride-only layout: directly under RideDashboard, no WorkoutDashboard band to clear.
+        expect(routeOnly.elevation!.top).toBeCloseTo(RIDE_DASH_HEIGHT_RATIO * 800 + SLOT_GAP, 5)
         // RideDashboard itself is never compromised either way - unlike combo's t-side, which narrows
         // WorkoutDashboard, a one-member column always renders RideDashboard at its own full width.
         expect(routeOnly.rideDashboard.width).toBe(combo.rideDashboard.width)
     })
 
-    it('640x430, N=7: column-only, same as the combo case - neither cascade has a side arrangement that fits here', () => {
+    it('640x430, N=7: below, same as the combo case - neither cascade has a side arrangement that fits here', () => {
         const combo = computeRideOverlayLayout({ screenWidth: 640, screenHeight: 430, screenLayout: 'normal', itemCount: 7, mapVisible: true, workoutAttached: true })
         const routeOnly = computeRideOverlayLayout({ screenWidth: 640, screenHeight: 430, screenLayout: 'normal', itemCount: 7, mapVisible: true, workoutAttached: false })
 
-        expect(combo.arrangement).toBe('column-only')
-        expect(routeOnly.arrangement).toBe('column-only') // at least as permissive: identical, not worse
+        expect(combo.arrangement).toBe('below')
+        expect(routeOnly.arrangement).toBe('below') // at least as permissive: identical, not worse
         expect(routeOnly.workoutDashboard).toBeNull()
-        expect(routeOnly.map).toBeNull()
-        expect(routeOnly.elevation).toBeNull()
+        expect(routeOnly.map).not.toBeNull()
+        expect(routeOnly.elevation).not.toBeNull()
+        // The ride-only below row sits higher than the combo one - no WorkoutDashboard band to clear.
+        expect(routeOnly.elevation!.top).toBeLessThan(combo.elevation!.top)
         expect(routeOnly.rideDashboard.width).toBe(combo.rideDashboard.width)
     })
 
@@ -497,5 +516,128 @@ describe('constants', () => {
     it('exposes ARRANGEMENT_HYSTERESIS_PX and SIDE_WIDGET_MIN_WIDTH as tunable named exports', () => {
         expect(typeof ARRANGEMENT_HYSTERESIS_PX).toBe('number')
         expect(typeof SIDE_WIDGET_MIN_WIDTH).toBe('number')
+    })
+})
+
+
+// -----------------------------------------------------------------------------------------------
+// The layout spec itself, as a property sweep rather than as per-size examples.
+//
+// Regression cover for the production bug where riding the same route on a second device blanked
+// every overlay on the iPad: `overlayActive` handed rendering to RideOverlay, whose layout returned
+// null rects, and the page had already unmounted its own standalone map/elevation preview.
+//
+// The invariant is the whole fix: on a landscape, non-compact frame the corner widgets are always
+// PLACED - beside the dashboard where they fit, below it where they don't - and never dropped.
+// -----------------------------------------------------------------------------------------------
+
+const LANDSCAPE_FRAMES = [
+    { name: 'iPad 9.7/10.2',     width: 1024, height: 768 },
+    { name: 'iPad 10.9',         width: 1180, height: 820 },
+    { name: 'iPad Pro 11',       width: 1194, height: 834 },
+    { name: 'iPad Pro 12.9',     width: 1366, height: 1024 },
+    { name: 'Galaxy Tab 1280',   width: 1280, height: 800 },
+    { name: 'Galaxy Tab 1000',   width: 1000, height: 625 },
+    { name: 'small 7in tablet',  width: 960,  height: 600 },
+]
+
+describe('layout spec - corner widgets are placed, never dropped', () => {
+    for (const frame of LANDSCAPE_FRAMES) {
+        for (const itemCount of [5, 6, 7, 8, 9]) {
+            for (const workoutAttached of [false, true]) {
+                const what = `${frame.name} ${frame.width}x${frame.height}, N=${itemCount}, ${workoutAttached ? 'ride+workout' : 'ride only'}`
+
+                it(`${what}: places both widgets`, () => {
+                    const result = computeRideOverlayLayout({
+                        screenWidth: frame.width, screenHeight: frame.height, screenLayout: 'normal',
+                        itemCount, mapVisible: true, workoutAttached,
+                    })
+
+                    expect(result.arrangement).not.toBe('column-only')
+                    expect(result.map).not.toBeNull()
+                    expect(result.elevation).not.toBeNull()
+                    // Readable at the tuned floor, and inside the slot it was placed in.
+                    expect(result.elevation!.width).toBeGreaterThanOrEqual(SIDE_WIDGET_MIN_WIDTH)
+                    expect(result.map!.width + result.elevation!.width).toBeLessThanOrEqual(frame.width)
+                    // Clear of the bottom bar.
+                    expect(result.elevation!.top + result.elevation!.height).toBeLessThanOrEqual(frame.height)
+                })
+            }
+        }
+    }
+
+    // The specific production case: a plain route ride on an iPad, which is what a second rider
+    // joining switches the page into. Before the fix this returned column-only with null rects.
+    it('iPad 1024x768, N=7, ride only: the widgets sit on their own row under RideDashboard', () => {
+        const result = computeRideOverlayLayout({
+            screenWidth: 1024, screenHeight: 768, screenLayout: 'normal',
+            itemCount: 7, mapVisible: true, workoutAttached: false,
+        })
+
+        expect(result.arrangement).toBe('below')
+        expect(result.map!.left).toBe(0)
+        expect(result.elevation!.right).toBe(0)
+        expect(result.map!.top).toBeCloseTo(RIDE_DASH_HEIGHT_RATIO * 768 + SLOT_GAP, 5)
+        expect(result.map!.top).toBe(result.elevation!.top) // one row, not staggered
+        expect(result.map!.height).toBe(result.elevation!.height)
+    })
+
+    // Ride+workout, row 2: where the narrowed WorkoutDashboard still leaves the widgets room beside
+    // it, they sit BESIDE it on the same row - the spec's "2nd line: WorkoutDashboard + the
+    // remainder of map & elevation" - rather than being pushed onto a row of their own.
+    it('iPad 1024x768, N=7, ride+workout: the widgets share row 2 with WorkoutDashboard', () => {
+        const result = computeRideOverlayLayout({
+            screenWidth: 1024, screenHeight: 768, screenLayout: 'normal',
+            itemCount: 7, mapVisible: true, workoutAttached: true,
+        })
+
+        expect(result.arrangement).toBe('t-side')
+        const wd = result.workoutDashboard!
+        // Same band as WorkoutDashboard (offset only by SLOT_GAP), not stacked beneath it.
+        expect(result.elevation!.top).toBeLessThan(wd.top + wd.height)
+        expect(result.elevation!.top).toBeCloseTo(wd.top + SLOT_GAP, 5)
+        expect(wd.left! + wd.width).toBeLessThanOrEqual(1024 - result.elevation!.width)
+    })
+
+    // Ride+workout, row 3: only once the widgets no longer fit beside the narrowed WorkoutDashboard
+    // do they move to a row of their own, clearing the whole column.
+    it('860x480, N=7, ride+workout: the below row clears the WorkoutDashboard band', () => {
+        const result = computeRideOverlayLayout({
+            screenWidth: 860, screenHeight: 480, screenLayout: 'normal',
+            itemCount: 7, mapVisible: true, workoutAttached: true,
+        })
+
+        expect(result.arrangement).toBe('below')
+        const wd = result.workoutDashboard!
+        expect(result.elevation!.top).toBeGreaterThanOrEqual(wd.top + wd.height)
+    })
+
+    // The Gear tile (N 7 -> 8) flips RideDashboard to icon-top, which makes it NARROWER. That used to
+    // decide whether the overlays existed at all on a 1280 tablet; now it only decides which row they
+    // land on, which is what made the bug present as "it works with virtual shifting on".
+    it('the 7<->8 tile flip changes the row, never whether the widgets exist', () => {
+        const frames = LANDSCAPE_FRAMES.map((f) => [7, 8].map((itemCount) =>
+            computeRideOverlayLayout({
+                screenWidth: f.width, screenHeight: f.height, screenLayout: 'normal',
+                itemCount, mapVisible: true, workoutAttached: false,
+            })))
+
+        for (const [at7, at8] of frames) {
+            expect(at7.map).not.toBeNull()
+            expect(at8.map).not.toBeNull()
+        }
+    })
+
+    // `mapVisible: false` is the normal state whenever the main view is itself a map. The elevation
+    // preview must still be placed - and the row it defines is what NearbyRiders anchors to.
+    it('mapVisible: false still places the elevation preview, on every frame', () => {
+        for (const frame of LANDSCAPE_FRAMES) {
+            const result = computeRideOverlayLayout({
+                screenWidth: frame.width, screenHeight: frame.height, screenLayout: 'normal',
+                itemCount: 7, mapVisible: false, workoutAttached: false,
+            })
+            expect(result.map).toBeNull()
+            expect(result.elevation).not.toBeNull()
+        }
     })
 })

--- a/src/hooks/render/useRideOverlayLayout.ts
+++ b/src/hooks/render/useRideOverlayLayout.ts
@@ -141,26 +141,37 @@ export const FALLBACK_ELEVATION_HEIGHT_RATIO = 0.12
 // -----------------------------------------------------------------------------------------------
 
 /**
- * HLD §5.3 names four arrangements. Session 4.1's prototype replaced both `-below` ones with a
- * single `'column-only'`, in two steps:
+ * HLD §5.3 names four arrangements. Session 4.1 collapsed `block-below`/`t-below` into a single
+ * terminal `'column-only'` that returned `map: null, elevation: null`, on the reasoning that a
+ * full-width row of map + elevation under a full-width dashboard column left the Video/GPX main
+ * view as a sliver, and that the corner widgets - being auxiliary - were better dropped than
+ * relocated.
  *
- *  - `block-below` and `t-below` rendered 10 px apart and were indistinguishable. `-below` is only
- *    reached when no side arrangement fits, i.e.
- *    `screenWidth < 2·(SIDE_WIDGET_MIN_WIDTH + SIDE_GUTTER) + WORKOUT_DASH_MIN_WIDTH`, and in that
- *    whole regime `WorkoutDashboard` takes `W_rd_eff` either way. `WORKOUT_DASH_MAX_ASPECT` - the
- *    only thing that made them differ - is gone with them (see the constant block above).
- *  - Dropping the corner widgets *below* the column was then rejected outright on review
- *    (repo owner, 2026-08-11): on the narrow screens this arrangement occurs on, a full-width row of
- *    map + elevation directly under a full-width dashboard column leaves the Video/GPX main view -
- *    which is the point of a route ride - as a sliver. The corner widgets are auxiliary, so on a
- *    screen with no room for them beside the column they are **dropped, not relocated**. HLD §5.3's
- *    "drop below the block/column, split left/right of the screen" is superseded.
+ * That is wrong, and it is the reason a plain route ride went completely blank (no map, no
+ * elevation preview, no nearby-riders list) on any tablet narrower than `W_rd + 416` px as soon as
+ * a second rider joined the route: `overlayActive` handed rendering to `RideOverlay`, which then
+ * had nothing to place. The corner widgets are **relocated below the dashboard row(s), never
+ * dropped**:
  *
- * `'column-only'` therefore renders the two dashboards over an unobstructed main view. It needs no
- * fit test - it is what is left when nothing else fits - so `'fallback'` is now reached only via
- * compact, which §6.1 already called its dominant path.
+ *   ride only     row 1  RideDashboard    + map & elevation if they fit beside it
+ *                 row 2  map & elevation, if they did not
+ *                 row 3  NearbyRiders & PrevRides
+ *
+ *   ride+workout  row 1  RideDashboard    + map & elevation if they fit beside it
+ *                 row 2  WorkoutDashboard + the remainder of map & elevation if they fit
+ *                 row 3  map & elevation, if they did not
+ *                 row 4  NearbyRiders & PrevRides
+ *
+ * `'below'` is that relocated row - the widgets split the full screen width (map left, elevation
+ * right) beneath the whole column, restoring HLD §5.3's original intent. `block-below`/`t-below`
+ * stay merged into the one name: they only ever differed by `WORKOUT_DASH_MAX_ASPECT`, which is
+ * gone, and §5.6 offered exactly this merge.
+ *
+ * `'column-only'` survives as the genuine terminal case - not enough vertical room for even the
+ * below row - which no tablet reaches in practice. `'fallback'` is still reached only via compact,
+ * which §6.1 already called its dominant path.
  */
-export type RideOverlayArrangement = 'block-side' | 't-side' | 'column-only' | 'fallback'
+export type RideOverlayArrangement = 'block-side' | 't-side' | 'below' | 'column-only' | 'fallback'
 
 export interface Rect {
     top: number
@@ -273,6 +284,33 @@ export const buildSideRects = (
  *  first, unlike the combo screen's t-side candidate). */
 export const fitsSideBySide = (screenWidth: number, screenHeight: number, columnWidth: number): boolean =>
     earWidthOf(screenWidth, columnWidth) >= SIDE_WIDGET_MIN_WIDTH && availableHeight(0, screenHeight) >= SIDE_WIDGET_MIN_HEIGHT
+
+/** §5.4 - the below row's half-screen slot. Unlike an ear, it is not bounded by the column's width:
+ *  the widgets split the full screen beneath the column, so the width test is against half the
+ *  screen rather than the leftover side region. */
+export const belowSlotWidthOf = (screenWidth: number): number => screenWidth / 2 - SIDE_GUTTER
+
+/** Whether the below row fits at the given vertical origin. Reached only once both side candidates
+ *  have failed, so it is deliberately permissive - a tablet never fails it. */
+export const fitsBelow = (screenWidth: number, screenHeight: number, top: number): boolean =>
+    belowSlotWidthOf(screenWidth) >= SIDE_WIDGET_MIN_WIDTH && availableHeight(top, screenHeight) >= SIDE_WIDGET_MIN_HEIGHT
+
+/** The below row's rects - map left, elevation right, both at the same origin and size, exactly as
+ *  `buildSideRects` does for an ear. Sized through the same `sideWidgetSize` the side arrangements
+ *  use, so a widget that relocates below does not also change size beyond what the wider slot
+ *  allows. */
+export const buildBelowRects = (
+    screenWidth: number,
+    screenHeight: number,
+    top: number,
+    mapVisible: boolean,
+): { map: Rect | null; elevation: Rect } => {
+    const { width, height } = sideWidgetSize(screenWidth, screenHeight, belowSlotWidthOf(screenWidth), top)
+    return {
+        map: mapVisible ? { top, left: 0, width, height } : null,
+        elevation: { top, right: 0, width, height },
+    }
+}
 
 // -----------------------------------------------------------------------------------------------
 // §5.5 - the cascade itself
@@ -431,6 +469,22 @@ export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): 
     // place left to land is `column-only` - dropping the ears rather than relocating them, exactly as
     // the combo screen's own column-only does.
     if (!workoutAttached) {
+        // Row 2 of the ride-only layout: the widgets move below RideDashboard rather than being
+        // dropped. The decision uses the estimated dashboard height, the rect the measured one
+        // (invariant 2), exactly as t-side does.
+        if (fitsBelow(screenWidth, screenHeight, hRdEstimate + SLOT_GAP)) {
+            const { map, elevation } = buildBelowRects(screenWidth, screenHeight, hRd + SLOT_GAP, mapVisible)
+            return {
+                arrangement: 'below',
+                rideDashboard: { width: rideDashboardWidth },
+                workoutDashboard: null,
+                map,
+                elevation,
+                cornerSlotIsToggle: false,
+                inputs: { ...baseInputs, earWidth: belowSlotWidthOf(screenWidth) },
+            }
+        }
+
         return {
             arrangement: 'column-only',
             rideDashboard: { width: rideDashboardWidth },
@@ -459,9 +513,23 @@ export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): 
         }
     }
 
-    // 3. column-only - the two dashboards, and nothing else on top of the main view. No fit test:
-    // this is what is left when neither side arrangement fits, and the corner widgets are dropped
-    // rather than relocated (see `RideOverlayArrangement`'s doc comment).
+    // 3. below - row 3 of the ride+workout layout: neither side candidate had room, so the widgets
+    // move beneath the whole column (RideDashboard + WorkoutDashboard) instead of being dropped.
+    if (fitsBelow(screenWidth, screenHeight, hRdEstimate + hWd + SLOT_GAP)) {
+        const { map, elevation } = buildBelowRects(screenWidth, screenHeight, hRd + hWd + SLOT_GAP, mapVisible)
+        return {
+            arrangement: 'below',
+            rideDashboard: { width: rideDashboardWidth },
+            workoutDashboard: buildWorkoutDashboardRect(screenWidth, rideDashboardWidthEffective, hRd, hWd),
+            map,
+            elevation,
+            cornerSlotIsToggle: false,
+            inputs: { ...baseInputs, earWidth: belowSlotWidthOf(screenWidth), workoutDashboardWidth: rideDashboardWidthEffective },
+        }
+    }
+
+    // 4. column-only - the genuine terminal case: not even the below row has vertical room. No fit
+    // test; it is what is left when nothing else fits.
     return {
         arrangement: 'column-only',
         rideDashboard: { width: rideDashboardWidth },


### PR DESCRIPTION
## Summary

On a tablet, a plain route ride lost its **map, elevation preview and nearby-riders list entirely** as soon as a second rider joined the same route, and got them all back when that rider stopped.

Reproduced in production on a 1024 pt iPad, and since confirmed on an Android tablet forced to iPad dimensions. It is not an iOS or an iPad problem — it affects any tablet narrower than `W_rd + 416` px, where `W_rd` is RideDashboard's rendered width.

## Root cause

A second rider makes `nearbyRidersEligible` true, which flips `overlayActive`, which unmounts the page's own standalone corner map and elevation preview and hands rendering to `RideOverlay`. `computeRideOverlayLayout` then returned `'column-only'` with `map: null` and `elevation: null` whenever the ear beside RideDashboard fell below `SIDE_WIDGET_MIN_WIDTH` — so there was nothing left to render.

The route-only cascade had no fallback between `block-side` and that terminal case. The combo cascade did (`t-side`), which is why a ride with a workout attached was never affected.

Why it looked device-specific: the fit threshold moves with the tile count, and crossing 7 tiles flips RideDashboard to the narrower `icon-top` columns, making the dashboard *narrower* at 8 tiles than at 7. A tablet with virtual shifting enabled therefore escaped; the same tablet with it disabled did not.

## What changed

**The corner widgets are relocated below the dashboard row(s), never dropped.**

| | ride only | ride + workout |
|---|---|---|
| row 1 | RideDashboard + map & elevation *if they fit beside it* | RideDashboard + map & elevation *if they fit beside it* |
| row 2 | map & elevation, *if they did not* | WorkoutDashboard + the *remainder* of map & elevation *if they fit* |
| row 3 | NearbyRiders & PrevRides | map & elevation, *if they did not* |
| row 4 | — | NearbyRiders & PrevRides |

- Restores that relocated row as a single `'below'` arrangement, wired into **both** cascades. The widgets split the full screen width beneath the column, so the fit test is against half the screen rather than the leftover region beside it.
- `'column-only'` stays on as the genuine "no vertical room at all" terminal case, which no landscape non-compact frame reaches.

**Second, independent defect fixed alongside it:** `NearbyRidersTabletList` was gated on the corner map's rect, which is `null` whenever the main view is itself a map (`rideView === 'map'`) — so the list was unreachable there at **any** screen size, workout or not. It now anchors on the widget row (`map ?? elevation`); the two are built as a pair at identical top and height, so the elevation preview is an exact stand-in when the left ear is empty.

## Test plan

- [x] Full suite green — 148 suites, 1290 tests
- [x] `tsc --noEmit` clean, no new lint warnings
- [x] Ten existing tests had pinned the dropped-widget behaviour (including one named *"does not render the nearby-riders list when the corner map itself is not rendered"*) — inverted, with the reason recorded
- [x] Added a property sweep over 7 device frames x 5 tile counts x workout/no-workout asserting the widgets are always placed
- [x] Added explicit cover that ride-only lands directly under RideDashboard, ride+workout shares row 2 with WorkoutDashboard where it fits and clears it where it does not, and that the 7<->8 tile flip only changes *which row*
- [x] **On device (repo owner):** the failure reproduced on an Android tablet forced to iPad dimensions with virtual shifting **off**, and the fix confirmed there
- [ ] On device: ride with `rideView: 'map'` and a second rider present — the nearby-riders list must now appear (second defect; previously invisible at every screen size)
- [ ] Control: a 1366 pt tablet side-fits and should look unchanged
