### PR TITLE
feat: choose the RideDashboard layout mode for fit, not by tile count

### DIFF
--- a/src/components/RideOverlay/RideOverlay.stories.tsx
+++ b/src/components/RideOverlay/RideOverlay.stories.tsx
@@ -4,6 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { RideOverlay } from './RideOverlay';
 import { MOCK_DASHBOARD_MID_INTERVAL } from '../WorkoutDashboard/WorkoutDashboard.mock';
 import { MOCK_ROWS } from '../PrevRides/PrevRidesRow.mock';
+import { MOCK_ROWS as MOCK_NEARBY_ROWS } from '../NearbyRiders/NearbyRiderRow.mock';
 import { colors } from '../../theme';
 
 /**
@@ -96,3 +97,17 @@ const styles = StyleSheet.create({
         backgroundColor: colors.background,
     },
 });
+
+/**
+ * Combo ride (route + workout) with a group ride in progress, i.e. both list panels populated at
+ * once. WorkoutDashboard is centred and wide enough to reach under BOTH side columns, and in
+ * `block-side` it ends deeper than either corner widget does - so this is the story that shows the
+ * nearby-riders list (left) and previous-rides list (right) clearing it rather than running through
+ * it. View it at a 1180x820 viewport (iPad 10 / Air 11), where the combo ride reaches `block-side`.
+ */
+export const ComboWithNearbyRiders: Story = {
+    args: {
+        prevRides: MOCK_ROWS,
+        nearbyRiders: MOCK_NEARBY_ROWS,
+    },
+};

--- a/src/components/RideOverlay/RideOverlay.test.tsx
+++ b/src/components/RideOverlay/RideOverlay.test.tsx
@@ -511,6 +511,48 @@ describe('RideOverlay — nearby-riders overlay wiring', () => {
         expect(topOf(false)).toBe(topOf(true));
     });
 
+    // Combo (route + workout). WorkoutDashboard is centred and, at 1180x820/N=7, 652 px wide - so it
+    // reaches under the left column, and it ends DEEPER than the corner map does (205 vs 164 in
+    // block-side). Anchoring this list on the map alone put it straight through the WorkoutDashboard.
+    // Mirrors the identical Math.max the previous-rides list on the right has always done.
+    it('combo: anchors the nearby-riders list below WorkoutDashboard when that ends deeper than the corner map', () => {
+        setDimensions(1180, 820);
+        const comboProps: RideOverlayProps = {
+            ...nearbyRidersProps,
+            graph: baseProps.graph,
+            steps: baseProps.steps,
+            dashboard: baseProps.dashboard,
+        };
+        const { getByTestId } = render(<RideOverlay {...comboProps} />);
+
+        const flat = (id: string) => Object.assign({}, ...[getByTestId(id).props.style].flat());
+        const list = flat('nearby-riders-tablet-list');
+        const wd = flat('ride-overlay-dashboard');
+        const map = flat('ride-overlay-map');
+
+        // The premise: WorkoutDashboard really does end deeper than the map here.
+        expect(wd.top + wd.maxHeight).toBeGreaterThan(map.top + map.height);
+        // ...so the list must clear it, not the map.
+        expect(list.top).toBeGreaterThanOrEqual(wd.top + wd.maxHeight);
+    });
+
+    it('combo: still anchors on the widget row where that is the deeper of the two', () => {
+        setDimensions(1024, 768); // t-side here - the map sits below RideDashboard and ends deeper
+        const comboProps: RideOverlayProps = {
+            ...nearbyRidersProps,
+            graph: baseProps.graph,
+            steps: baseProps.steps,
+            dashboard: baseProps.dashboard,
+        };
+        const { getByTestId } = render(<RideOverlay {...comboProps} />);
+
+        const flat = (id: string) => Object.assign({}, ...[getByTestId(id).props.style].flat());
+        const list = flat('nearby-riders-tablet-list');
+        const map = flat('ride-overlay-map');
+
+        expect(list.top).toBeCloseTo(map.top + map.height + SLOT_GAP, 5);
+    });
+
     it('below: relocates the nearby-riders list under the column along with the other side-region occupants', () => {
         setDimensions(860, 480);
         const { getByTestId } = render(<RideOverlay {...nearbyRidersProps} />);

--- a/src/components/RideOverlay/RideOverlay.tsx
+++ b/src/components/RideOverlay/RideOverlay.tsx
@@ -329,8 +329,13 @@ export const RideOverlay = (props: RideOverlayProps) => {
     // and height (both `buildSideRects` and `buildBelowRects` build them as a pair), so it is an
     // exact stand-in when the map is absent and the left ear is simply empty.
     const nearbyRidersRowOccupant = map ?? elevation;
+    // Anchored below whichever of the widget row and WorkoutDashboard actually extends further down,
+    // exactly as prevRidesAnchorBottom is on the right - WorkoutDashboard is centred and 652 px wide
+    // at 1180x820/N=7, so it reaches under the left column too, and the two do not end at the same
+    // depth. In block-side the map ends at 164 while WorkoutDashboard ends at 205, so anchoring on
+    // the map alone put this list straight through it.
     const nearbyRidersAnchorBottom = nearbyRidersRowOccupant
-        ? nearbyRidersRowOccupant.top + nearbyRidersRowOccupant.height
+        ? Math.max(nearbyRidersRowOccupant.top + nearbyRidersRowOccupant.height, workoutDashboardBottom)
         : undefined;
     const nearbyRidersFreeBand = nearbyRidersAnchorBottom !== undefined && !cornerSlotIsToggle
         ? inputs.screenHeight - BOTTOM_BAR_RATIO * inputs.screenHeight - nearbyRidersAnchorBottom - 2 * SLOT_GAP

--- a/src/hooks/render/useRideOverlayLayout.test.ts
+++ b/src/hooks/render/useRideOverlayLayout.test.ts
@@ -2,6 +2,7 @@ import { renderHook, act } from '@testing-library/react-native'
 import {
     useRideOverlayLayout,
     computeRideOverlayLayout,
+    computeRideOverlayLayoutForMode,
     getRideDashboardWidth,
     fitsSideBySide,
     buildSideRects,
@@ -31,6 +32,11 @@ import {
 // under the side-fit threshold - and is reverted: the merged arrangement is 'below', and it places
 // the widgets beneath the column. 'column-only' remains only as the terminal "no vertical room at
 // all" case, which no landscape non-compact frame reaches (see the spec suite at the end).
+
+// The cascade's own mechanics (arrangement shapes, §8 hysteresis) are per-mode, and are exercised
+// through computeRideOverlayLayoutForMode so they stay independent of which mode chooseDashboardLayout
+// would pick for a given screen. The choice itself is covered by the `chooseDashboardLayout` suite.
+const computeIconLeft = (input: ComputeRideOverlayLayoutInput) => computeRideOverlayLayoutForMode(input, 'icon-left')
 
 const mockDimensions = { width: 1280, height: 800 }
 jest.mock('react-native/Libraries/Utilities/useWindowDimensions', () => ({
@@ -97,11 +103,11 @@ describe('fitsSideBySide / buildSideRects - exported for route-only reuse', () =
     })
 })
 
-describe('computeRideOverlayLayout - the arrangements', () => {
+describe('the cascade (icon-left) - the arrangements', () => {
     // `block-side` needs the ears to clear their floor beside the FULL-width dashboard, i.e.
     // screenWidth >= W_rd_eff + 2*(200 + 8): 1311.6 at 7 tiles, 1159.0 at 8.
     it('1400x900, N=7: block-side - the ears clear their floor beside the whole block', () => {
-        const result = computeRideOverlayLayout({ screenWidth: 1400, screenHeight: 900, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const result = computeIconLeft({ screenWidth: 1400, screenHeight: 900, screenLayout: 'normal', itemCount: 7, mapVisible: true })
         expect(result.arrangement).toBe('block-side')
         expect(result.workoutDashboard?.width).toBeCloseTo(895.6, 5)
         expect(result.inputs.earWidth).toBeCloseTo(244.2, 5)
@@ -111,7 +117,7 @@ describe('computeRideOverlayLayout - the arrangements', () => {
     })
 
     it('1280x800, N=7: t-side - a SHALLOW T (864 wide), not the old narrow 320 one', () => {
-        const result = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const result = computeIconLeft({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true })
         expect(result.arrangement).toBe('t-side')
         expect(result.workoutDashboard?.width).toBe(864) // 1280 - 2*(200+8)
         expect(result.inputs.earWidth).toBe(200) // exactly the floor, by construction
@@ -119,7 +125,7 @@ describe('computeRideOverlayLayout - the arrangements', () => {
     })
 
     it('1194x834 (iPad Air), N=7: t-side at 778 wide, ears at their floor', () => {
-        const result = computeRideOverlayLayout({ screenWidth: 1194, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const result = computeIconLeft({ screenWidth: 1194, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true })
         expect(result.arrangement).toBe('t-side')
         expect(result.workoutDashboard?.width).toBe(778)
         expect(result.inputs.earWidth).toBe(200)
@@ -127,8 +133,8 @@ describe('computeRideOverlayLayout - the arrangements', () => {
     })
 
     it('1024x768, N=7 and N=8: both t-side, and at the same geometry - the tile count cannot reach it', () => {
-        const at7 = computeRideOverlayLayout({ screenWidth: 1024, screenHeight: 768, screenLayout: 'normal', itemCount: 7, mapVisible: true })
-        const at8 = computeRideOverlayLayout({ screenWidth: 1024, screenHeight: 768, screenLayout: 'normal', itemCount: 8, mapVisible: true })
+        const at7 = computeIconLeft({ screenWidth: 1024, screenHeight: 768, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const at8 = computeIconLeft({ screenWidth: 1024, screenHeight: 768, screenLayout: 'normal', itemCount: 8, mapVisible: true })
         expect(at7.arrangement).toBe('t-side')
         expect(at8.arrangement).toBe('t-side')
         expect(at7.workoutDashboard?.width).toBe(608)
@@ -136,7 +142,7 @@ describe('computeRideOverlayLayout - the arrangements', () => {
     })
 
     it('932x430 (large phone landscape), N=7: t-side - the old aspect ceiling no longer forces anything', () => {
-        const result = computeRideOverlayLayout({ screenWidth: 932, screenHeight: 430, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const result = computeIconLeft({ screenWidth: 932, screenHeight: 430, screenLayout: 'normal', itemCount: 7, mapVisible: true })
         expect(result.arrangement).toBe('t-side')
         expect(result.workoutDashboard?.width).toBe(516)
         expect(result.inputs.earWidth).toBe(200)
@@ -146,7 +152,7 @@ describe('computeRideOverlayLayout - the arrangements', () => {
     // (width > height) - the app is orientation-locked to landscape (`Loader.tsx`), so a portrait
     // frame is not a state it can be in and must not be used to justify an arrangement.
     it('640x430, N=7: below - no side arrangement fits, so the widgets relocate under the column', () => {
-        const result = computeRideOverlayLayout({ screenWidth: 640, screenHeight: 430, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const result = computeIconLeft({ screenWidth: 640, screenHeight: 430, screenLayout: 'normal', itemCount: 7, mapVisible: true })
         expect(result.inputs.rideDashboardWidthEffective).toBe(640) // clamped (§5.7) - raw W_rd (895.6) would overflow
         expect(result.arrangement).toBe('below')
         expect(result.workoutDashboard?.width).toBe(640) // matches the (clamped) dashboard
@@ -159,14 +165,14 @@ describe('computeRideOverlayLayout - the arrangements', () => {
     })
 
     it('860x480, N=7: below as well, just under the t-side floor', () => {
-        const result = computeRideOverlayLayout({ screenWidth: 860, screenHeight: 480, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const result = computeIconLeft({ screenWidth: 860, screenHeight: 480, screenLayout: 'normal', itemCount: 7, mapVisible: true })
         expect(result.arrangement).toBe('below')
         expect(result.workoutDashboard?.width).toBeCloseTo(860, 5)
         expect(result.elevation).not.toBeNull()
     })
 
     it('the below row is bounded by half the screen, not by the leftover side region', () => {
-        const result = computeRideOverlayLayout({ screenWidth: 640, screenHeight: 430, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const result = computeIconLeft({ screenWidth: 640, screenHeight: 430, screenLayout: 'normal', itemCount: 7, mapVisible: true })
         // The column is clamped to the full 640, so there is no ear at all - yet the below row still
         // has room, because it splits the screen rather than the remainder beside the column.
         expect(result.inputs.earWidth).toBe(belowSlotWidthOf(640))
@@ -174,7 +180,7 @@ describe('computeRideOverlayLayout - the arrangements', () => {
     })
 
     it('844x390 (phone landscape), any N: fallback, because screenLayout is compact', () => {
-        const result = computeRideOverlayLayout({ screenWidth: 844, screenHeight: 390, screenLayout: 'compact', itemCount: 7, mapVisible: true })
+        const result = computeIconLeft({ screenWidth: 844, screenHeight: 390, screenLayout: 'compact', itemCount: 7, mapVisible: true })
         expect(result.arrangement).toBe('fallback')
         expect(result.rideDashboard.width).toBe(844) // W_rd === screenWidth exactly in compact (§1.1)
         expect(result.workoutDashboard).toBeNull()
@@ -189,25 +195,25 @@ describe('computeRideOverlayLayout - widget sizing (session 4.1)', () => {
     // Before the retune every ear occupant rendered at exactly SIDE_WIDGET_MIN_*, which made the
     // elevation preview visibly smaller than on today's route-only screen (96 px tall vs 160).
     it('renders ear occupants at today`s route-only proportions when the ear allows it', () => {
-        const result = computeRideOverlayLayout({ screenWidth: 1400, screenHeight: 900, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const result = computeIconLeft({ screenWidth: 1400, screenHeight: 900, screenLayout: 'normal', itemCount: 7, mapVisible: true })
         expect(result.elevation?.width).toBeCloseTo(210, 5) // 0.15 * 1400
         expect(result.elevation?.height).toBeCloseTo(180, 5) // 0.20 * 900
     })
 
     it('never renders an ear occupant below its floor, or wider than the ear it sits in', () => {
-        const result = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const result = computeIconLeft({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true })
         expect(result.elevation?.width).toBe(SIDE_WIDGET_MIN_WIDTH) // 0.15*1280 = 192 would be below the floor
         expect(result.elevation?.width as number).toBeLessThanOrEqual(result.inputs.earWidth as number)
     })
 
     it('keeps WorkoutDashboard`s height budget at ~1.5x RideDashboard`s, not 3x (HLD §6.2)', () => {
-        const result = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const result = computeIconLeft({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true })
         expect(result.workoutDashboard?.height).toBe(120) // 0.15 * 800, against RideDashboard's 0.10 * 800 = 80
     })
 
     it('clamps WorkoutDashboard`s height on very short and very tall screens', () => {
-        const short = computeRideOverlayLayout({ screenWidth: 1024, screenHeight: 430, screenLayout: 'normal', itemCount: 7, mapVisible: true })
-        const tall = computeRideOverlayLayout({ screenWidth: 1400, screenHeight: 1200, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const short = computeIconLeft({ screenWidth: 1024, screenHeight: 430, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const tall = computeIconLeft({ screenWidth: 1400, screenHeight: 1200, screenLayout: 'normal', itemCount: 7, mapVisible: true })
         expect(short.workoutDashboard?.height).toBe(100) // floor - the widget's own intrinsic height
         expect(tall.workoutDashboard?.height).toBe(160) // ceiling - its content does not grow with the screen
     })
@@ -215,8 +221,8 @@ describe('computeRideOverlayLayout - widget sizing (session 4.1)', () => {
 
 describe('computeRideOverlayLayout - invariants (design doc §4)', () => {
     it('invariant 2: arrangement is identical with and without measuredRideDashboardHeight - only positions move', () => {
-        const withoutMeasured = computeRideOverlayLayout({ screenWidth: 1194, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true })
-        const withMeasured = computeRideOverlayLayout({
+        const withoutMeasured = computeIconLeft({ screenWidth: 1194, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const withMeasured = computeIconLeft({
             screenWidth: 1194, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true,
             measuredRideDashboardHeight: 60, // deliberately far from the 83.4 estimate (0.10 * 834)
         })
@@ -229,8 +235,8 @@ describe('computeRideOverlayLayout - invariants (design doc §4)', () => {
     })
 
     it('a compact screenLayout always resolves to fallback, regardless of itemCount/mapVisible', () => {
-        const a = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 390, screenLayout: 'compact', itemCount: 7, mapVisible: true })
-        const b = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 390, screenLayout: 'compact', itemCount: 8, mapVisible: false })
+        const a = computeIconLeft({ screenWidth: 1280, screenHeight: 390, screenLayout: 'compact', itemCount: 7, mapVisible: true })
+        const b = computeIconLeft({ screenWidth: 1280, screenHeight: 390, screenLayout: 'compact', itemCount: 8, mapVisible: false })
         expect(a.arrangement).toBe('fallback')
         expect(b.arrangement).toBe('fallback')
     })
@@ -241,8 +247,8 @@ describe('computeRideOverlayLayout - invariants (design doc §4)', () => {
     // `mapVisible` from the fit test entirely (behaviour-identical) - it now only decides whether
     // the `map` rect is populated.
     it('mapVisible does not change the arrangement decision in v1 - only whether `map` is populated', () => {
-        const withMap = computeRideOverlayLayout({ screenWidth: 1194, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true })
-        const withoutMap = computeRideOverlayLayout({ screenWidth: 1194, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: false })
+        const withMap = computeIconLeft({ screenWidth: 1194, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const withoutMap = computeIconLeft({ screenWidth: 1194, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: false })
 
         expect(withMap.arrangement).toBe(withoutMap.arrangement)
         expect(withMap.map).not.toBeNull()
@@ -251,13 +257,13 @@ describe('computeRideOverlayLayout - invariants (design doc §4)', () => {
     })
 })
 
-describe('computeRideOverlayLayout - hysteresis (design doc §8.2)', () => {
+describe('the cascade (icon-left) - hysteresis (design doc §8.2)', () => {
     // N=7 => W_rd_eff = 895.6, so the unrelaxed block-side boundary is at
     // 895.6 + 2*(200+8) = 1311.6 (ear === 200 exactly).
     const BOUNDARY_SCREEN_WIDTH = 1311.6
 
     it('a small width change that crosses the normal boundary does NOT flip out of the active arrangement', () => {
-        const result = computeRideOverlayLayout({
+        const result = computeIconLeft({
             screenWidth: BOUNDARY_SCREEN_WIDTH - 12, // ear = 194, below the normal 200 floor
             screenHeight: 900, screenLayout: 'normal', itemCount: 7, mapVisible: true,
             previousArrangement: 'block-side',
@@ -269,7 +275,7 @@ describe('computeRideOverlayLayout - hysteresis (design doc §8.2)', () => {
     it('a large width change that exceeds the hysteresis cushion DOES flip', () => {
         // earWidthOf moves at half the rate of screenWidth, so clearing the 24 px ear cushion needs
         // >= 48 px of screenWidth; 60 is comfortably past it.
-        const result = computeRideOverlayLayout({
+        const result = computeIconLeft({
             screenWidth: BOUNDARY_SCREEN_WIDTH - 60, // block-side's ear would be 170, below even the relaxed 176
             screenHeight: 900, screenLayout: 'normal', itemCount: 7, mapVisible: true,
             previousArrangement: 'block-side',
@@ -278,7 +284,7 @@ describe('computeRideOverlayLayout - hysteresis (design doc §8.2)', () => {
     })
 
     it('with no previous arrangement (first render), the normal (unrelaxed) floor applies', () => {
-        const result = computeRideOverlayLayout({
+        const result = computeIconLeft({
             screenWidth: BOUNDARY_SCREEN_WIDTH - 12, // would stay under hysteresis, but there is no "previous" to relax for
             screenHeight: 900, screenLayout: 'normal', itemCount: 7, mapVisible: true,
             previousArrangement: null,
@@ -288,8 +294,8 @@ describe('computeRideOverlayLayout - hysteresis (design doc §8.2)', () => {
 
     it('relaxes the t-side/below boundary too, not just block-side/t-side', () => {
         // t-side needs screenWidth >= 2*(floor+8) + WORKOUT_DASH_MIN_WIDTH: 896 unrelaxed, 848 relaxed.
-        const cold = computeRideOverlayLayout({ screenWidth: 870, screenHeight: 600, screenLayout: 'normal', itemCount: 7, mapVisible: true })
-        const warm = computeRideOverlayLayout({
+        const cold = computeIconLeft({ screenWidth: 870, screenHeight: 600, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const warm = computeIconLeft({
             screenWidth: 870, screenHeight: 600, screenLayout: 'normal', itemCount: 7, mapVisible: true, previousArrangement: 't-side',
         })
         expect(cold.arrangement).toBe('below')
@@ -300,8 +306,8 @@ describe('computeRideOverlayLayout - hysteresis (design doc §8.2)', () => {
     // Session 4.1's headline OQ5 finding: on most screens the Gear tile can no longer change the
     // arrangement at all, because in a T the geometry is derived from screenWidth, not from W_rd.
     it('the 1112px 7<->8 tile flip no longer changes anything (it flipped t-side<->block-side before)', () => {
-        const at7 = computeRideOverlayLayout({ screenWidth: 1112, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true })
-        const at8 = computeRideOverlayLayout({ screenWidth: 1112, screenHeight: 834, screenLayout: 'normal', itemCount: 8, mapVisible: true })
+        const at7 = computeIconLeft({ screenWidth: 1112, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const at8 = computeIconLeft({ screenWidth: 1112, screenHeight: 834, screenLayout: 'normal', itemCount: 8, mapVisible: true })
         expect(at7.arrangement).toBe('t-side')
         expect(at8.arrangement).toBe('t-side')
         expect(at8.workoutDashboard?.width).toBe(at7.workoutDashboard?.width)
@@ -309,18 +315,46 @@ describe('computeRideOverlayLayout - hysteresis (design doc §8.2)', () => {
 
     // It is not gone everywhere though - the settle window still earns its keep in the band where
     // the 8-tile dashboard clears the block-side boundary and the 7-tile one doesn't (1159..1311.6).
-    it('a tile-count flip can still change the arrangement inside the 1159-1311.6 band', () => {
+    // Per-mode, the Gear tile cannot reach the arrangement here at all - both tile counts land on
+    // t-side at the same geometry, since in a T the width is derived from screenWidth, not W_rd.
+    it('a tile-count flip does not change the icon-left cascade inside this band', () => {
+        const at7 = computeIconLeft({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const at8 = computeIconLeft({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 8, mapVisible: true })
+        expect(at7.arrangement).toBe('t-side')
+        expect(at8.arrangement).toBe('t-side')
+        expect(at8.workoutDashboard?.width).toBe(at7.workoutDashboard?.width)
+    })
+
+    // ...but not once the mode is chosen for fit: at 1280 the 7-tile screen takes icon-top and
+    // reaches block-side on its own, so the Gear tile no longer moves the layout at all here. This is
+    // the behaviour that made the production bug present as "it works with virtual shifting on".
+    it('the chooser absorbs that same flip - both tile counts reach block-side at 1280', () => {
         const at7 = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true })
         const at8 = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 8, mapVisible: true })
-        expect(at7.arrangement).toBe('t-side')
+        expect(at7.arrangement).toBe('block-side')
         expect(at8.arrangement).toBe('block-side')
+        expect(at7.dashboardLayout).toBe('icon-top')
+    })
+
+    // Not absorbed everywhere: at 1112 the 8-tile icon-top column (743) is too wide for the ears but
+    // the 7-tile one (652) is not, so the Gear tile still moves the layout - which is what the
+    // settle timer is for.
+    it('a tile-count flip still changes the arrangement at 1112, where only the 7-tile column fits', () => {
+        const at7 = computeRideOverlayLayout({ screenWidth: 1112, screenHeight: 834, screenLayout: 'normal', itemCount: 7, mapVisible: true })
+        const at8 = computeRideOverlayLayout({ screenWidth: 1112, screenHeight: 834, screenLayout: 'normal', itemCount: 8, mapVisible: true })
+        expect(at7.arrangement).toBe('block-side')
+        expect(at8.arrangement).toBe('t-side')
     })
 })
 
 describe('useRideOverlayLayout - the hook', () => {
     beforeEach(() => {
         jest.useFakeTimers()
-        setDimensions(1280, 800)
+        // 1090 rather than 1280: with the mode chosen for fit, 1280 reaches block-side at BOTH 7 and
+        // 8 tiles, so a Gear-tile flip has nothing to debounce there any more. 1090 is inside the
+        // narrow band where only the 7-tile icon-top column (652) clears the ears and the 8-tile one
+        // (743) misses them even after §8's 24 px relaxation - so the flip is genuinely observable.
+        setDimensions(1090, 834)
     })
 
     afterEach(() => {
@@ -329,7 +363,7 @@ describe('useRideOverlayLayout - the hook', () => {
 
     it('resolves synchronously on first render using the itemCount passed in - no settle delay on mount', () => {
         const { result } = renderHook(() => useRideOverlayLayout({ itemCount: 8, workoutAttached: true, mapVisible: true }))
-        expect(result.current.arrangement).toBe('block-side')
+        expect(result.current.arrangement).toBe('t-side')
     })
 
     it('defaults itemCount to DEFAULT_ROUTE_RIDE_TILE_COUNT when not supplied (§3.2 first-frame value)', () => {
@@ -342,16 +376,16 @@ describe('useRideOverlayLayout - the hook', () => {
             (props: { itemCount: number }) => useRideOverlayLayout({ itemCount: props.itemCount, workoutAttached: true, mapVisible: true }),
             { initialProps: { itemCount: 7 } },
         )
-        expect(result.current.arrangement).toBe('t-side')
+        expect(result.current.arrangement).toBe('block-side')
 
         rerender({ itemCount: 8 })
-        expect(result.current.arrangement).toBe('t-side') // unchanged immediately after the prop flips
+        expect(result.current.arrangement).toBe('block-side') // unchanged immediately after the prop flips
 
         act(() => { jest.advanceTimersByTime(TILE_COUNT_SETTLE_MS - 100) })
-        expect(result.current.arrangement).toBe('t-side') // still not settled
+        expect(result.current.arrangement).toBe('block-side') // still not settled
 
         act(() => { jest.advanceTimersByTime(200) })
-        expect(result.current.arrangement).toBe('block-side') // settled past 2000ms total
+        expect(result.current.arrangement).toBe('t-side') // settled past 2000ms total
     })
 
     it('resets the settle timer on a flappy itemCount change - a brief drop of the Gear tile must not re-flow the screen', () => {
@@ -365,10 +399,10 @@ describe('useRideOverlayLayout - the hook', () => {
         rerender({ itemCount: 7 }) // reverts before settling - timer must restart, not fire the stale 8
 
         act(() => { jest.advanceTimersByTime(1500) })
-        expect(result.current.arrangement).toBe('t-side') // never settled on 8
+        expect(result.current.arrangement).toBe('block-side') // never settled on 8
 
         act(() => { jest.advanceTimersByTime(600) })
-        expect(result.current.arrangement).toBe('t-side') // settling back onto its own starting value is a no-op
+        expect(result.current.arrangement).toBe('block-side') // settling back onto its own starting value is a no-op
     })
 
     it('recomputes immediately on a mapVisible change - no settle window (§8.2)', () => {
@@ -383,8 +417,10 @@ describe('useRideOverlayLayout - the hook', () => {
         expect(result.current.map).toBeNull() // flips on the very next render, no timer advance needed
     })
 
+    // itemCount 8 pins the mode (RideDashboard's own >7 override), so this exercises the resize path
+    // alone rather than the resize plus a mode change.
     it('recomputes immediately on a screen rotation/resize - no settle window', () => {
-        const { result, rerender } = renderHook(() => useRideOverlayLayout({ itemCount: 7, workoutAttached: true, mapVisible: true }), { initialProps: {} })
+        const { result, rerender } = renderHook(() => useRideOverlayLayout({ itemCount: 8, workoutAttached: true, mapVisible: true }), { initialProps: {} })
         expect(result.current.arrangement).toBe('t-side')
 
         act(() => { setDimensions(1400, 900) })
@@ -392,13 +428,17 @@ describe('useRideOverlayLayout - the hook', () => {
         expect(result.current.arrangement).toBe('block-side')
     })
 
+    // itemCount 8 again pins the mode, so the hysteresis cushion is observable on its own. At 7 tiles
+    // it would not be: whenever icon-left drops out of block-side (below 1311.6), icon-top picks the
+    // screen straight back up (its own boundary is 1068), so the arrangement simply never flips and
+    // there is nothing for the cushion to absorb. The mode changes instead - see the note in the
+    // chooser about that boundary having no hysteresis of its own.
     it('applies hysteresis end-to-end: once settled into an arrangement, a small resize does not flip it back out', () => {
-        const { result, rerender } = renderHook(() => useRideOverlayLayout({ itemCount: 7, workoutAttached: true, mapVisible: true }), { initialProps: {} })
+        const { result, rerender } = renderHook(() => useRideOverlayLayout({ itemCount: 8, workoutAttached: true, mapVisible: true }), { initialProps: {} })
         expect(result.current.arrangement).toBe('t-side')
 
-        // Settle a few px past the exact 1311.6 block-side boundary first (a small margin avoids
-        // floating-point noise right at the boundary - 124.8 * 7 does not land on an exact double).
-        const SETTLED_WIDTH = 1311.6 + 4
+        // A few px past the 8-tile block-side boundary (W_rd 743 + 2*(200+8) = 1159).
+        const SETTLED_WIDTH = 1159 + 4
         act(() => { setDimensions(SETTLED_WIDTH, 900) })
         rerender({})
         expect(result.current.arrangement).toBe('block-side')
@@ -459,12 +499,11 @@ describe('computeRideOverlayLayout - workoutAttached: false (one-member column)'
         const combo = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true, workoutAttached: true })
         const routeOnly = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true, workoutAttached: false })
 
-        // The combo screen keeps icon-left: t-side already places the widgets beside the column.
-        expect(combo.arrangement).toBe('t-side')
-        expect(combo.dashboardLayout).toBe('icon-left')
-
-        // The route-only screen has no t-side rescue, so icon-left would drop the widgets to the row
-        // below. icon-top's narrower column frees the ears instead.
+        // Both take icon-top here, for different reasons: the combo screen to lift its widgets off
+        // row 2 (t-side) onto row 1, the route-only screen because it has no t-side to fall back on
+        // at all and icon-left would drop the widgets to a row of their own.
+        expect(combo.arrangement).toBe('block-side')
+        expect(combo.dashboardLayout).toBe('icon-top')
         expect(routeOnly.dashboardLayout).toBe('icon-top')
         expect(routeOnly.arrangement).toBe('block-side')
         expect(routeOnly.workoutDashboard).toBeNull()
@@ -686,15 +725,30 @@ describe('chooseDashboardLayout', () => {
         }).arrangement).toBe('below')
     })
 
-    it('does not restyle a combo screen that already reaches t-side - t-side places the widgets beside the column, and block-side beside an icon-top column would be a NARROWER WorkoutDashboard', () => {
-        expect(at({ screenWidth: 1280, screenHeight: 800, itemCount: 7, workoutAttached: true })).toBe('icon-left')
+    it('rescues a combo screen off t-side too - t-side is a fallback (widgets on row 2), not a success', () => {
+        expect(at({ screenWidth: 1280, screenHeight: 800, itemCount: 7, workoutAttached: true })).toBe('icon-top')
 
-        const tSide = computeRideOverlayLayout({
+        const chosen = computeRideOverlayLayout({
             screenWidth: 1280, screenHeight: 800, screenLayout: 'normal',
             itemCount: 7, mapVisible: true, workoutAttached: true,
         })
-        expect(tSide.arrangement).toBe('t-side')
-        expect(tSide.workoutDashboard!.width).toBe(864)
+        expect(chosen.arrangement).toBe('block-side')
+        expect(chosen.elevation!.top).toBe(0) // row 1, beside RideDashboard - not row 2
+
+        // The WorkoutDashboard does narrow (864 in the T, 652 beside an icon-top column), but stays
+        // well clear of WORKOUT_DASH_MIN_WIDTH, and now matches RideDashboard's own width exactly.
+        expect(chosen.workoutDashboard!.width).toBe(652)
+        expect(chosen.workoutDashboard!.width).toBeGreaterThan(WORKOUT_DASH_MIN_WIDTH)
+        expect(chosen.workoutDashboard!.width).toBe(chosen.inputs.rideDashboardWidthEffective)
+    })
+
+    it('leaves a combo screen alone when icon-left already reaches block-side', () => {
+        expect(at({ screenWidth: 1366, screenHeight: 1024, itemCount: 7, workoutAttached: true })).toBe('icon-left')
+    })
+
+    it('leaves a combo screen alone when neither mode beats t-side', () => {
+        // 1024x768: icon-top's ear (178) is still under the floor, so both modes reach t-side.
+        expect(at({ screenWidth: 1024, screenHeight: 768, itemCount: 7, workoutAttached: true })).toBe('icon-left')
     })
 
     it('mirrors RideDashboard\'s own >7-tile override, so the assumed and rendered widths agree', () => {

--- a/src/hooks/render/useRideOverlayLayout.test.ts
+++ b/src/hooks/render/useRideOverlayLayout.test.ts
@@ -11,6 +11,8 @@ import {
     ARRANGEMENT_HYSTERESIS_PX,
     DEFAULT_ROUTE_RIDE_TILE_COUNT,
     WORKOUT_DASH_MIN_WIDTH,
+    chooseDashboardLayout,
+    ComputeRideOverlayLayoutInput,
     RIDE_DASH_HEIGHT_RATIO,
     SLOT_GAP,
     belowSlotWidthOf,
@@ -453,20 +455,21 @@ describe('computeRideOverlayLayout - workoutAttached: false (one-member column)'
     // meaningful sense: `block-side` - the one arrangement that IS in both cascades - has an
     // identical, unworsened threshold (previous test); column-only is what a one-member column falls
     // to instead of needing a rescue mechanism it structurally cannot have.
-    it('1280x800, N=7: falls to below - there is no WorkoutDashboard to narrow for a t-side rescue', () => {
+    it('1280x800, N=7: rescued to block-side via icon-top - a one-member column has no t-side to fall back on, so the dashboard mode buys the ears instead', () => {
         const combo = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true, workoutAttached: true })
         const routeOnly = computeRideOverlayLayout({ screenWidth: 1280, screenHeight: 800, screenLayout: 'normal', itemCount: 7, mapVisible: true, workoutAttached: false })
 
+        // The combo screen keeps icon-left: t-side already places the widgets beside the column.
         expect(combo.arrangement).toBe('t-side')
-        expect(routeOnly.arrangement).toBe('below')
+        expect(combo.dashboardLayout).toBe('icon-left')
+
+        // The route-only screen has no t-side rescue, so icon-left would drop the widgets to the row
+        // below. icon-top's narrower column frees the ears instead.
+        expect(routeOnly.dashboardLayout).toBe('icon-top')
+        expect(routeOnly.arrangement).toBe('block-side')
         expect(routeOnly.workoutDashboard).toBeNull()
         expect(routeOnly.map).not.toBeNull()
         expect(routeOnly.elevation).not.toBeNull()
-        // Row 2 of the ride-only layout: directly under RideDashboard, no WorkoutDashboard band to clear.
-        expect(routeOnly.elevation!.top).toBeCloseTo(RIDE_DASH_HEIGHT_RATIO * 800 + SLOT_GAP, 5)
-        // RideDashboard itself is never compromised either way - unlike combo's t-side, which narrows
-        // WorkoutDashboard, a one-member column always renders RideDashboard at its own full width.
-        expect(routeOnly.rideDashboard.width).toBe(combo.rideDashboard.width)
     })
 
     it('640x430, N=7: below, same as the combo case - neither cascade has a side arrangement that fits here', () => {
@@ -638,6 +641,81 @@ describe('layout spec - corner widgets are placed, never dropped', () => {
             })
             expect(result.map).toBeNull()
             expect(result.elevation).not.toBeNull()
+        }
+    })
+})
+
+
+// -----------------------------------------------------------------------------------------------
+// chooseDashboardLayout - the dashboard's own layout mode is picked for fit, not derived from the
+// tile count.
+//
+// This started as a real-device observation: with virtual shifting ON the rider had 8 tiles, was
+// forced into icon-top by RideDashboard's own >7 rule, and the corner widgets fitted beside the
+// dashboard. With shifting OFF they had 7 tiles, icon-left, and the widgets dropped to the row
+// below - the tile count was deciding the layout quality by accident.
+// -----------------------------------------------------------------------------------------------
+
+describe('chooseDashboardLayout', () => {
+    const at = (o: Partial<ComputeRideOverlayLayoutInput> = {}) => chooseDashboardLayout({
+        screenWidth: 1180, screenHeight: 820, screenLayout: 'normal',
+        itemCount: 7, mapVisible: true, workoutAttached: false, ...o,
+    })
+
+    it('keeps icon-left wherever it already fits the widgets beside the column', () => {
+        expect(at({ screenWidth: 1366, screenHeight: 1024 })).toBe('icon-left')
+        expect(at({ itemCount: 5 })).toBe('icon-left')
+    })
+
+    it('switches to icon-top when icon-left would push the widgets to the row below', () => {
+        // iPad 10 / Air 11, the frame the production bug was reported on.
+        expect(at({ itemCount: 6 })).toBe('icon-top')
+        expect(at({ itemCount: 7 })).toBe('icon-top')
+        expect(computeRideOverlayLayout({
+            screenWidth: 1180, screenHeight: 820, screenLayout: 'normal',
+            itemCount: 7, mapVisible: true, workoutAttached: false,
+        }).arrangement).toBe('block-side')
+    })
+
+    it('keeps icon-left when neither mode fits - there is nothing to buy, so the default stands', () => {
+        // 1024x768 at 7 tiles: icon-left W_rd 896, icon-top 652, both leave the ear under its floor.
+        expect(at({ screenWidth: 1024, screenHeight: 768, itemCount: 7 })).toBe('icon-left')
+        expect(computeRideOverlayLayout({
+            screenWidth: 1024, screenHeight: 768, screenLayout: 'normal',
+            itemCount: 7, mapVisible: true, workoutAttached: false,
+        }).arrangement).toBe('below')
+    })
+
+    it('does not restyle a combo screen that already reaches t-side - t-side places the widgets beside the column, and block-side beside an icon-top column would be a NARROWER WorkoutDashboard', () => {
+        expect(at({ screenWidth: 1280, screenHeight: 800, itemCount: 7, workoutAttached: true })).toBe('icon-left')
+
+        const tSide = computeRideOverlayLayout({
+            screenWidth: 1280, screenHeight: 800, screenLayout: 'normal',
+            itemCount: 7, mapVisible: true, workoutAttached: true,
+        })
+        expect(tSide.arrangement).toBe('t-side')
+        expect(tSide.workoutDashboard!.width).toBe(864)
+    })
+
+    it('mirrors RideDashboard\'s own >7-tile override, so the assumed and rendered widths agree', () => {
+        expect(at({ itemCount: 8 })).toBe('icon-top')
+        expect(at({ itemCount: 9, screenWidth: 1366, screenHeight: 1024 })).toBe('icon-top')
+    })
+
+    it('is a no-op in compact, where RideDashboard stretches to the full screen width anyway', () => {
+        expect(at({ screenLayout: 'compact', screenWidth: 844, screenHeight: 390 })).toBe('icon-left')
+    })
+
+    // The bug this rule removes: with shifting on (8 tiles) the widgets fitted, with it off (7) they
+    // did not, purely because of the forced mode. Both must now land beside the column.
+    it('makes the virtual-shifting Gear tile stop deciding whether the widgets fit', () => {
+        for (const itemCount of [7, 8]) {
+            const l = computeRideOverlayLayout({
+                screenWidth: 1180, screenHeight: 820, screenLayout: 'normal',
+                itemCount, mapVisible: true, workoutAttached: false,
+            })
+            expect(l.dashboardLayout).toBe('icon-top')
+            expect(l.arrangement).toBe('block-side')
         }
     })
 })

--- a/src/hooks/render/useRideOverlayLayout.ts
+++ b/src/hooks/render/useRideOverlayLayout.ts
@@ -372,11 +372,12 @@ const buildFallback = (
     }
 }
 
-/** The cascade itself, for one given dashboard layout mode. Not exported: callers go through
+/** The cascade itself, for one given dashboard layout mode. Production callers go through
  *  `computeRideOverlayLayout()`, which picks the mode first (`chooseDashboardLayout()`). Kept
- *  mode-parameterised rather than mode-deriving so the chooser can evaluate both without
- *  recursing into itself. */
-const computeForMode = (input: ComputeRideOverlayLayoutInput, dashboardLayout: DashboardLayoutMode): RideOverlayLayout => {
+ *  mode-parameterised rather than mode-deriving so the chooser can evaluate both without recursing
+ *  into itself - and exported so the cascade's own mechanics (arrangement shapes, §8 hysteresis) can
+ *  be tested per mode, independently of which mode the chooser would pick for a given screen. */
+export const computeRideOverlayLayoutForMode = (input: ComputeRideOverlayLayoutInput, dashboardLayout: DashboardLayoutMode): RideOverlayLayout => {
     const {
         screenWidth,
         screenHeight,
@@ -548,14 +549,28 @@ const computeForMode = (input: ComputeRideOverlayLayoutInput, dashboardLayout: D
     }
 }
 
-/** Whether an arrangement places the corner widgets BESIDE the dashboard column (row 1 for
- *  `block-side`, row 2 alongside WorkoutDashboard for `t-side`) rather than relegating them to a row
- *  of their own. This is the whole test the mode choice turns on - deliberately binary, not a
- *  ranking of the side arrangements against each other: `t-side` already places the widgets beside
- *  the column, so "rescuing" it into `block-side` would buy no fit and would cost WorkoutDashboard
- *  width (at 1280x800/N=7 it is 864 px wide in the T, but only 652 px beside an icon-top column). */
-const placesWidgetsBeside = (arrangement: RideOverlayArrangement): boolean =>
-    arrangement === 'block-side' || arrangement === 't-side'
+/** Preference order over the arrangements, best first - the layout spec's own row preference made
+ *  comparable. Row 1 (`block-side`: widgets beside RideDashboard, from the top of the screen) beats
+ *  row 2 (`t-side`: widgets beside WorkoutDashboard, below RideDashboard), which beats a row of
+ *  their own (`below`), which beats not placing them at all.
+ *
+ *  `t-side` is a FALLBACK, not a success: it is what the cascade reaches when the widgets did not
+ *  fit beside RideDashboard. So a combo ride sitting on `t-side` must still get the icon-top rescue
+ *  - denying it there was a real defect, and left a ride+workout on a 1180 pt tablet stuck on row 2
+ *  when row 1 was reachable. The WorkoutDashboard does narrow as a result (864 -> 652 px at
+ *  1280x800/N=7, where it matches RideDashboard's own width), but `WORKOUT_DASH_MIN_WIDTH` is 480 -
+ *  the width at which both of its rows were tuned to read cleanly - so that is not a cost.
+ *
+ *  `'fallback'` is not meaningfully ranked: it is reached only through `screenLayout === 'compact'`,
+ *  where the mode is irrelevant (RideDashboard is `alignSelf: 'stretch'` and RideDashboardView
+ *  forces `icon-left`), and `chooseDashboardLayout` returns before ever comparing it. */
+const ARRANGEMENT_RANK: Record<RideOverlayArrangement, number> = {
+    'block-side': 0,
+    't-side': 1,
+    'below': 2,
+    'column-only': 3,
+    'fallback': 4,
+}
 
 /**
  * Which layout mode `RideDashboard` should render in.
@@ -568,10 +583,11 @@ const placesWidgetsBeside = (arrangement: RideOverlayArrangement): boolean =>
  * 7 tiles, `'icon-left'`, and the widgets dropped to a row below. The tile count decided the
  * layout quality, which is backwards.
  *
- * So the mode is chosen for fit instead: if `'icon-left'` already places the widgets beside the
- * column, keep it; otherwise switch to `'icon-top'` if THAT places them beside; otherwise keep
- * `'icon-left'` and let them take the row below. The test is binary - "beside or not" - not a
- * ranking of `block-side` against `t-side` (see `placesWidgetsBeside`).
+ * So the mode is chosen for fit instead: run the cascade under both modes and keep whichever
+ * reaches the better-ranked arrangement (`ARRANGEMENT_RANK`), with `'icon-left'` winning ties so it
+ * stays the default wherever it already lays the screen out as well. This applies to ride+workout
+ * exactly as it does to a plain route ride - `t-side` is a fallback, not a success, so a combo ride
+ * that lands there is still a candidate for the rescue.
  *
  * Two constraints bound the choice:
  *  - above `RIDE_DASHBOARD_ICON_TOP_TILE_THRESHOLD` tiles `RideDashboard` forces `'icon-top'`
@@ -590,12 +606,12 @@ export const chooseDashboardLayout = (input: ComputeRideOverlayLayoutInput): Das
     if (itemCount > RIDE_DASHBOARD_ICON_TOP_TILE_THRESHOLD)
         return 'icon-top'
 
-    // icon-left keeps precedence wherever it already places the widgets beside the column, so
-    // icon-top is only ever reached as a rescue - never as a restyle of a screen that was fine.
-    if (placesWidgetsBeside(computeForMode(input, 'icon-left').arrangement))
-        return 'icon-left'
+    const left = ARRANGEMENT_RANK[computeRideOverlayLayoutForMode(input, 'icon-left').arrangement]
+    const top = ARRANGEMENT_RANK[computeRideOverlayLayoutForMode(input, 'icon-top').arrangement]
 
-    return placesWidgetsBeside(computeForMode(input, 'icon-top').arrangement) ? 'icon-top' : 'icon-left'
+    // Strictly better, or icon-left stands - so icon-top is only ever a rescue, never a restyle of a
+    // screen icon-left already lays out as well.
+    return top < left ? 'icon-top' : 'icon-left'
 }
 
 /**
@@ -606,7 +622,7 @@ export const chooseDashboardLayout = (input: ComputeRideOverlayLayoutInput): Das
  * testable without React rendering machinery.
  */
 export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): RideOverlayLayout =>
-    computeForMode(input, chooseDashboardLayout(input))
+    computeRideOverlayLayoutForMode(input, chooseDashboardLayout(input))
 
 // -----------------------------------------------------------------------------------------------
 // §9 - the hook

--- a/src/hooks/render/useRideOverlayLayout.ts
+++ b/src/hooks/render/useRideOverlayLayout.ts
@@ -210,6 +210,9 @@ export interface RideOverlayLayout {
     elevation: Rect | null
     /** True iff `arrangement === 'fallback'` (§6). */
     cornerSlotIsToggle: boolean
+    /** The layout mode `RideDashboard` must render in for this arrangement to hold - see
+     *  `chooseDashboardLayout()`. Callers pass it straight to `<RideDashboard layout=...>`. */
+    dashboardLayout: DashboardLayoutMode
     inputs: RideOverlayLayoutInputs
 }
 
@@ -341,6 +344,7 @@ const buildFallback = (
     mapVisible: boolean,
     rideDashboardWidth: number,
     measuredRideDashboardHeight: number | undefined,
+    dashboardLayout: DashboardLayoutMode,
 ): RideOverlayLayout => {
     const dashboardHeight = measuredRideDashboardHeight ?? RIDE_DASH_HEIGHT_RATIO * screenHeight
     return {
@@ -355,6 +359,7 @@ const buildFallback = (
             height: FALLBACK_ELEVATION_HEIGHT_RATIO * screenHeight,
         },
         cornerSlotIsToggle: true,
+        dashboardLayout,
         inputs: {
             screenWidth,
             screenHeight,
@@ -367,14 +372,11 @@ const buildFallback = (
     }
 }
 
-/**
- * Pure decision function - design doc §4 invariant 1: a pure function of
- * `(screenWidth, screenHeight, screenLayout, itemCount, mapVisible)`, all synchronous. No measured
- * value (besides the position-only refinement of invariant 2), no async value, no device query.
- * Exported separately from the hook (§9/`useRideOverlayLayout` below) so it is directly unit
- * testable without React rendering machinery.
- */
-export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): RideOverlayLayout => {
+/** The cascade itself, for one given dashboard layout mode. Not exported: callers go through
+ *  `computeRideOverlayLayout()`, which picks the mode first (`chooseDashboardLayout()`). Kept
+ *  mode-parameterised rather than mode-deriving so the chooser can evaluate both without
+ *  recursing into itself. */
+const computeForMode = (input: ComputeRideOverlayLayoutInput, dashboardLayout: DashboardLayoutMode): RideOverlayLayout => {
     const {
         screenWidth,
         screenHeight,
@@ -386,7 +388,6 @@ export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): 
     } = input
     const itemCount = input.itemCount ?? DEFAULT_ROUTE_RIDE_TILE_COUNT
 
-    const dashboardLayout: DashboardLayoutMode = itemCount > RIDE_DASHBOARD_ICON_TOP_TILE_THRESHOLD ? 'icon-top' : 'icon-left'
     const rideDashboardWidth = getRideDashboardWidth({
         itemCount,
         layout: dashboardLayout,
@@ -397,7 +398,7 @@ export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): 
     // §6.1 - compact is not a heuristic: RideDashboard is `alignSelf: 'stretch'` in compact, so
     // W_rd === screenWidth and there is no side region to arrange at all.
     if (screenLayout === 'compact') {
-        return buildFallback(screenWidth, screenHeight, screenLayout, itemCount, mapVisible, rideDashboardWidth, measuredRideDashboardHeight)
+        return buildFallback(screenWidth, screenHeight, screenLayout, itemCount, mapVisible, rideDashboardWidth, measuredRideDashboardHeight, dashboardLayout)
     }
 
     const rideDashboardWidthEffective = Math.min(rideDashboardWidth, screenWidth) // §5.7 clamp
@@ -457,6 +458,7 @@ export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): 
             map,
             elevation,
             cornerSlotIsToggle: false,
+            dashboardLayout,
             inputs: workoutAttached
                 ? { ...baseInputs, earWidth: blockEar, workoutDashboardWidth: rideDashboardWidthEffective }
                 : { ...baseInputs, earWidth: blockEar },
@@ -481,6 +483,7 @@ export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): 
                 map,
                 elevation,
                 cornerSlotIsToggle: false,
+                dashboardLayout,
                 inputs: { ...baseInputs, earWidth: belowSlotWidthOf(screenWidth) },
             }
         }
@@ -492,6 +495,7 @@ export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): 
             map: null,
             elevation: null,
             cornerSlotIsToggle: false,
+            dashboardLayout,
             inputs: baseInputs,
         }
     }
@@ -509,6 +513,7 @@ export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): 
             map,
             elevation,
             cornerSlotIsToggle: false,
+            dashboardLayout,
             inputs: { ...baseInputs, earWidth: earWidthOf(screenWidth, wWdT), workoutDashboardWidth: wWdT },
         }
     }
@@ -524,6 +529,7 @@ export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): 
             map,
             elevation,
             cornerSlotIsToggle: false,
+            dashboardLayout,
             inputs: { ...baseInputs, earWidth: belowSlotWidthOf(screenWidth), workoutDashboardWidth: rideDashboardWidthEffective },
         }
     }
@@ -537,9 +543,70 @@ export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): 
         map: null,
         elevation: null,
         cornerSlotIsToggle: false,
+        dashboardLayout,
         inputs: { ...baseInputs, workoutDashboardWidth: rideDashboardWidthEffective },
     }
 }
+
+/** Whether an arrangement places the corner widgets BESIDE the dashboard column (row 1 for
+ *  `block-side`, row 2 alongside WorkoutDashboard for `t-side`) rather than relegating them to a row
+ *  of their own. This is the whole test the mode choice turns on - deliberately binary, not a
+ *  ranking of the side arrangements against each other: `t-side` already places the widgets beside
+ *  the column, so "rescuing" it into `block-side` would buy no fit and would cost WorkoutDashboard
+ *  width (at 1280x800/N=7 it is 864 px wide in the T, but only 652 px beside an icon-top column). */
+const placesWidgetsBeside = (arrangement: RideOverlayArrangement): boolean =>
+    arrangement === 'block-side' || arrangement === 't-side'
+
+/**
+ * Which layout mode `RideDashboard` should render in.
+ *
+ * `RideDashboard` renders each tile far narrower in `'icon-top'` (90 dp) than in `'icon-left'`
+ * (~125 dp), so the same tiles occupy a much narrower row - narrow enough, on a mid-size tablet,
+ * to free the ears that `'icon-left'` denies. That was previously an accident of the
+ * `> 7 tiles` rule: a rider with virtual shifting on got 8 tiles, was forced into `'icon-top'`, and
+ * their map and elevation preview fitted beside the dashboard; the same rider with shifting off got
+ * 7 tiles, `'icon-left'`, and the widgets dropped to a row below. The tile count decided the
+ * layout quality, which is backwards.
+ *
+ * So the mode is chosen for fit instead: if `'icon-left'` already places the widgets beside the
+ * column, keep it; otherwise switch to `'icon-top'` if THAT places them beside; otherwise keep
+ * `'icon-left'` and let them take the row below. The test is binary - "beside or not" - not a
+ * ranking of `block-side` against `t-side` (see `placesWidgetsBeside`).
+ *
+ * Two constraints bound the choice:
+ *  - above `RIDE_DASHBOARD_ICON_TOP_TILE_THRESHOLD` tiles `RideDashboard` forces `'icon-top'`
+ *    regardless of the prop (`RideDashboard.tsx`), so there is nothing to choose - mirroring it here
+ *    keeps the layout's assumed width and the rendered width in agreement;
+ *  - in compact the dashboard stretches to the full screen width, so the mode cannot buy any room.
+ *
+ * Pure in exactly the inputs the arrangement is (§4, invariant 1) - `itemCount` does not depend on
+ * the mode, so there is no feedback loop between the choice and the thing it is chosen from.
+ */
+export const chooseDashboardLayout = (input: ComputeRideOverlayLayoutInput): DashboardLayoutMode => {
+    if (input.screenLayout === 'compact')
+        return 'icon-left'
+
+    const itemCount = input.itemCount ?? DEFAULT_ROUTE_RIDE_TILE_COUNT
+    if (itemCount > RIDE_DASHBOARD_ICON_TOP_TILE_THRESHOLD)
+        return 'icon-top'
+
+    // icon-left keeps precedence wherever it already places the widgets beside the column, so
+    // icon-top is only ever reached as a rescue - never as a restyle of a screen that was fine.
+    if (placesWidgetsBeside(computeForMode(input, 'icon-left').arrangement))
+        return 'icon-left'
+
+    return placesWidgetsBeside(computeForMode(input, 'icon-top').arrangement) ? 'icon-top' : 'icon-left'
+}
+
+/**
+ * Pure decision function - design doc §4 invariant 1: a pure function of
+ * `(screenWidth, screenHeight, screenLayout, itemCount, mapVisible)`, all synchronous. No measured
+ * value (besides the position-only refinement of invariant 2), no async value, no device query.
+ * Exported separately from the hook (§9/`useRideOverlayLayout` below) so it is directly unit
+ * testable without React rendering machinery.
+ */
+export const computeRideOverlayLayout = (input: ComputeRideOverlayLayoutInput): RideOverlayLayout =>
+    computeForMode(input, chooseDashboardLayout(input))
 
 // -----------------------------------------------------------------------------------------------
 // §9 - the hook

--- a/src/pages/RidePage/GPX/View.tsx
+++ b/src/pages/RidePage/GPX/View.tsx
@@ -156,11 +156,12 @@ export const GPXTourPageView = (props: GPXTourPageViewProps) => {
         dashboardItemCount,
         updateDashboardDimensions,
         onDashboardMetrics,
+        dashboardLayoutMode,
         dashboardDynamicStyle,
         elevationPreviewDynamicStyle,
         mapOverlayDynamicStyle,
         bottomBarStyle,
-    } = useRouteOnlyRideGeometry({ isCompact, mapVisible });
+    } = useRouteOnlyRideGeometry({ isCompact, mapVisible, workoutAttached: comboActive });
 
     const transformPosition = useCallback((val: any): LatLng|RoutePoint | undefined|IPosition => {
         if (!val) return undefined;
@@ -300,7 +301,7 @@ export const GPXTourPageView = (props: GPXTourPageViewProps) => {
                         dashboardDynamicStyle,
                     ]}>
                         <View onLayout={updateDashboardDimensions}>
-                            <RideDashboard layout='icon-left' onMetrics={onDashboardMetrics} />
+                            <RideDashboard layout={dashboardLayoutMode} onMetrics={onDashboardMetrics} />
                         </View>
                     </View>
 

--- a/src/pages/RidePage/Video/View.tsx
+++ b/src/pages/RidePage/Video/View.tsx
@@ -144,11 +144,12 @@ export const VideoRidePageView = (props: VideoRidePageViewProps) => {
         dashboardItemCount,
         updateDashboardDimensions,
         onDashboardMetrics,
+        dashboardLayoutMode,
         dashboardDynamicStyle,
         elevationPreviewDynamicStyle,
         mapOverlayDynamicStyle,
         bottomBarStyle,
-    } = useRouteOnlyRideGeometry({ isCompact, mapVisible });
+    } = useRouteOnlyRideGeometry({ isCompact, mapVisible, workoutAttached: comboActive });
 
     const transformPosition = useCallback((val: any): LatLng | undefined => {
         if (!val) return undefined;
@@ -293,7 +294,7 @@ export const VideoRidePageView = (props: VideoRidePageViewProps) => {
                     dashboardDynamicStyle
                 ]}>
                     <View onLayout={updateDashboardDimensions}>
-                        <RideDashboard layout='icon-left' onMetrics={onDashboardMetrics} />
+                        <RideDashboard layout={dashboardLayoutMode} onMetrics={onDashboardMetrics} />
                     </View>
                 </View>
             </View>}

--- a/src/pages/RidePage/hooks/useRouteOnlyRideGeometry.test.ts
+++ b/src/pages/RidePage/hooks/useRouteOnlyRideGeometry.test.ts
@@ -17,7 +17,7 @@ describe('useRouteOnlyRideGeometry', () => {
     });
 
     it('places the corner widgets side-by-side when there is room beside the dashboard (isCompact=false)', () => {
-        const { result } = renderHook(() => useRouteOnlyRideGeometry({ isCompact: false, mapVisible: true }));
+        const { result } = renderHook(() => useRouteOnlyRideGeometry({ isCompact: false, mapVisible: true, workoutAttached: false }));
 
         // Very wide screen, default 7-tile dashboard - side-by-side should fit, so the elevation
         // preview style comes from the analytic sideRects rather than the stacked-below fallback.
@@ -32,7 +32,7 @@ describe('useRouteOnlyRideGeometry', () => {
 
     it('falls back to the stacked-below layout in compact mode', () => {
         setDimensions(400, 700);
-        const { result } = renderHook(() => useRouteOnlyRideGeometry({ isCompact: true, mapVisible: false }));
+        const { result } = renderHook(() => useRouteOnlyRideGeometry({ isCompact: true, mapVisible: false, workoutAttached: false }));
 
         expect(result.current.elevationPreviewDynamicStyle).toMatchObject({
             width: 400 * 0.20,
@@ -40,7 +40,7 @@ describe('useRouteOnlyRideGeometry', () => {
     });
 
     it('tracks dashboard height reported via updateDashboardDimensions', () => {
-        const { result } = renderHook(() => useRouteOnlyRideGeometry({ isCompact: false, mapVisible: false }));
+        const { result } = renderHook(() => useRouteOnlyRideGeometry({ isCompact: false, mapVisible: false, workoutAttached: false }));
 
         act(() => {
             result.current.updateDashboardDimensions({ nativeEvent: { layout: { height: 123 } } });
@@ -50,7 +50,7 @@ describe('useRouteOnlyRideGeometry', () => {
     });
 
     it('tracks the dashboard item count reported via onDashboardMetrics', () => {
-        const { result } = renderHook(() => useRouteOnlyRideGeometry({ isCompact: false, mapVisible: false }));
+        const { result } = renderHook(() => useRouteOnlyRideGeometry({ isCompact: false, mapVisible: false, workoutAttached: false }));
 
         expect(result.current.dashboardItemCount).toBeUndefined();
 

--- a/src/pages/RidePage/hooks/useRouteOnlyRideGeometry.ts
+++ b/src/pages/RidePage/hooks/useRouteOnlyRideGeometry.ts
@@ -4,7 +4,7 @@ import {
     getRideDashboardWidth,
     fitsSideBySide,
     buildSideRects,
-    RIDE_DASHBOARD_ICON_TOP_TILE_THRESHOLD,
+    chooseDashboardLayout,
     DEFAULT_ROUTE_RIDE_TILE_COUNT,
 } from '../../../hooks/render/useRideOverlayLayout';
 
@@ -15,6 +15,9 @@ interface UseRouteOnlyRideGeometryParams {
     /** Whether the corner map widget would be visible - differs slightly between GPX (also gates
      *  on the main view already being a map) and Video, so it stays a caller input. */
     mapVisible: boolean;
+    /** Feeds the dashboard-mode choice: a workout-attached ride has a second "beside" arrangement
+     *  (t-side) available, so the two modes can rank differently than on a route-only ride. */
+    workoutAttached: boolean;
 }
 
 /**
@@ -25,7 +28,7 @@ interface UseRouteOnlyRideGeometryParams {
  * heuristic - both call sites already carried a comment pointing at "the other file" for the full
  * rationale, which now lives here instead.
  */
-export function useRouteOnlyRideGeometry({ isCompact, mapVisible }: UseRouteOnlyRideGeometryParams) {
+export function useRouteOnlyRideGeometry({ isCompact, mapVisible, workoutAttached }: UseRouteOnlyRideGeometryParams) {
     const { width: screenWidth, height: screenHeight } = useWindowDimensions();
 
     const ELEVATION_FULL_HEIGHT = screenHeight * 0.12;
@@ -46,8 +49,17 @@ export function useRouteOnlyRideGeometry({ isCompact, mapVisible }: UseRouteOnly
     const [dashboardItemCount, setDashboardItemCount] = useState<number | undefined>(undefined);
     const onDashboardMetrics = useCallback((m: { itemCount: number }) => setDashboardItemCount(m.itemCount), []);
 
-    const dashboardLayoutMode = (dashboardItemCount ?? DEFAULT_ROUTE_RIDE_TILE_COUNT) > RIDE_DASHBOARD_ICON_TOP_TILE_THRESHOLD
-        ? 'icon-top' : 'icon-left';
+    // Chosen for fit, not derived from the tile count - see chooseDashboardLayout(). Shared with
+    // RideOverlay's own useRideOverlayLayout() call so the overlay and non-overlay paths cannot
+    // disagree about how wide RideDashboard is about to render.
+    const dashboardLayoutMode = chooseDashboardLayout({
+        screenWidth,
+        screenHeight,
+        screenLayout: isCompact ? 'compact' : 'normal',
+        itemCount: dashboardItemCount ?? DEFAULT_ROUTE_RIDE_TILE_COUNT,
+        mapVisible,
+        workoutAttached,
+    });
     const rideDashboardWidthEffective = Math.min(
         getRideDashboardWidth({
             itemCount: dashboardItemCount ?? DEFAULT_ROUTE_RIDE_TILE_COUNT,
@@ -99,6 +111,7 @@ export function useRouteOnlyRideGeometry({ isCompact, mapVisible }: UseRouteOnly
         dashboardItemCount,
         updateDashboardDimensions,
         onDashboardMetrics,
+        dashboardLayoutMode,
         dashboardDynamicStyle,
         elevationPreviewDynamicStyle,
         mapOverlayDynamicStyle,


### PR DESCRIPTION
> **Re-targeting PR #443.** #443 was stacked on `feat/fix-tablet-overlay-below-row` and was merged into *that branch* rather than into `main`, so its three commits never reached `main` — only #442's single commit did. This PR carries them the rest of the way. Same content as #443, already reviewed and validated on device; nothing needs re-reviewing.
>
> Merges cleanly (verified). The branch is behind `main` by #441 and the services bump, but a merge takes both sides, so nothing is reverted.

## Summary

RideDashboard renders each tile at ~125 dp in `icon-left` but only 90 dp in `icon-top`, so the same tiles occupy a far narrower row. Which mode was used had nothing to do with fit: RideDashboard forces `icon-top` above 7 tiles and takes the caller's `icon-left` below that.

The consequence was visible on a 1180 pt tablet. A rider with **virtual shifting on** had 8 tiles, was forced into `icon-top`, and their map and elevation preview fitted beside the dashboard. The same rider with **shifting off** had 7 tiles, `icon-left`, a row 153 px wider, and the widgets dropped to the row below.

The tile count was deciding the layout quality by accident — and `icon-top`, the mode reached only by accident, is the better-looking result.

## What changed

The mode is now chosen for fit: run the cascade under both modes and keep whichever reaches the better-ranked arrangement, with `icon-left` winning ties so it stays the default wherever it already lays the screen out as well. `icon-top` is therefore only ever a rescue, never a restyle of a screen that was already fine.

"Beside" is ranked, not binary: `block-side` (widgets on row 1, beside RideDashboard) > `t-side` (row 2, beside WorkoutDashboard) > `below` (a row of their own) > `column-only`. That is the layout's own row preference made comparable.

This applies to **ride+workout exactly as to a plain route ride**. `t-side` is what the cascade reaches when the widgets did *not* fit beside RideDashboard — a fallback, not a success — so a combo ride sitting there is still a candidate for the rescue. On a 1180 pt tablet that moves its widgets from top=90 to top=0.

The WorkoutDashboard does narrow as a result (864 → 652 px at 1280x800/N=7), but `WORKOUT_DASH_MIN_WIDTH` is 480 — the width at which both of its rows were tuned to read cleanly — and in `block-side` it matches RideDashboard's own width exactly, which is the cleaner shape.

### Also fixed here

Moving the combo screen to `block-side` exposed a latent overlap: the nearby-riders list ran into the bottom of WorkoutDashboard. WorkoutDashboard is centred and 652 px wide at 1180x820/N=7, so it reaches under both side columns and does not end at the same depth as the corner widgets — the map ends at y=180, it ends at y=190, and the 340 px list against its left edge at x=280 overlapped by 76 px.

The previous-rides list on the right has always taken `Math.max(widget row bottom, workoutDashboardBottom)`; the nearby-riders list took the widget row alone. It now does the same. Latent before this PR because on `t-side` the map ends at y=254, well past the dashboard.

`chooseDashboardLayout()` is shared by `useRideOverlayLayout` and `useRouteOnlyRideGeometry` so the overlay and non-overlay paths cannot disagree about how wide RideDashboard is about to render, and the chosen mode is passed down to `<RideDashboard layout=...>` at the GPX and Video call sites.

### Outcome, N=7

| frame | ride only | ride + workout |
|---|---|---|
| **1180 (iPad 10 / Air 11)** | **top → block-side, row 1** (was `below`) | **top → block-side, row 1** (was `t-side`, row 2) |
| 1280 (Galaxy Tab) | **top → block-side** (was `below`) | **top → block-side** (was `t-side`) |
| 1024 (iPad 10.2) | left → `below` (neither fits) | left → `t-side` (neither mode beats it) |
| 1366 (iPad Pro 12.9) | left → block-side, unchanged | left → block-side, unchanged |

On a 1180 frame every tile count from 5 to 8 now places the widgets on row 1, so adding or dropping the Gear tile mid-ride no longer re-flows the screen at all.

## Notes for review

- **No feedback loop.** The choice stays a pure function of the inputs the arrangement already depends on — `itemCount` does not depend on the mode. The existing purity invariant holds.
- **The `> 7 tiles -> icon-top` override stays a hard constraint**, mirrored in the chooser so the width the layout assumes and the width that renders agree.
- **Accepted consequence:** the dashboard's appearance now varies with screen width, not only tile count. The same ride at 6 tiles renders `icon-top` on a 1180 tablet and `icon-left` on a 1280 one. Inherent to the approach and signed off.
- **The mode boundary has no hysteresis of its own.** The arrangement boundaries do (24 px), but the icon-left/icon-top choice does not, so a width straddling it could in principle flap the dashboard style. Not reachable on a landscape-locked tablet where width only changes on rotation; it would become reachable under iPad Stage Manager / split-screen resizing. Flagged rather than fixed — say the word if you want a cushion there too.
- **A side effect on the settle timer, worth knowing:** because the chooser absorbs most Gear-tile changes, the 7↔8 flip no longer moves the arrangement on the majority of frames. The timer still earns its keep in a narrow band (~1068–1111), which is where its tests now live.
- **Known adjacent issue, deliberately out of scope:** long remaining-time values (`-1:51:53`) can wrap in `icon-top`'s fixed 90 dp column. The existing mitigation (a 0.75 font shrink on the Time column) is not tile-count-gated, so it already covers the newly reachable 5-7 tile cases. Capping the string instead would be a `services` change, tracked separately.

## Test plan

- [x] Full suite green — 148 suites, 1301 tests
- [x] `tsc --noEmit` clean, no lint warnings
- [x] `computeRideOverlayLayoutForMode` exported so the cascade's own mechanics stay testable per mode, independently of what the chooser picks — existing arrangement/hysteresis cover is preserved rather than retuned around the new behaviour
- [x] Added a `chooseDashboardLayout` suite: icon-left kept where it already reaches the best arrangement, icon-top only as a strict improvement, icon-left kept where neither mode wins, combo rescued off `t-side` onto row 1, the `>7` override mirrored, compact a no-op
- [x] Pinned that the Gear tile no longer decides whether the widgets fit
- [x] Storybook at a 1180x820 viewport, verified via measured DOM boxes rather than by eye — nearby-riders list before: `y=188..586` against a dashboard ending at `y=190`; after: `y=229..627`, level with the previous-rides list
- [x] **Validated on an Android tablet at iPad dimensions** (repo owner) — the original failure reproduced there with virtual shifting off, and the fix confirmed
- [ ] Eyeball `icon-top` at 5-7 tiles for Time-column wrapping (see note above) — the one case this change newly makes reachable
