### PR TITLE
Fix background battery drain: accelerometer, BLE scan, wifi multicast lock

### DIFF
--- a/android/app/src/main/java/com/incyclist/app/MainApplication.kt
+++ b/android/app/src/main/java/com/incyclist/app/MainApplication.kt
@@ -13,6 +13,7 @@ import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.soloader.SoLoader
 import java.io.File
+import org.wonday.orientation.OrientationActivityLifecycle
 
 
 
@@ -133,6 +134,14 @@ class MainApplication : Application(), ReactApplication {
     override fun onCreate() {
         super.onCreate()
         loadReactNative(this)
+
+        // react-native-orientation-locker ships an ActivityLifecycleCallbacks implementation
+        // (OrientationActivityLifecycle) but never attaches it to the Application. Without it,
+        // the module's OrientationEventListener is enabled once at construction and never
+        // disabled, so the accelerometer keeps sampling at SENSOR_DELAY_UI (15Hz) while the app
+        // is in the background. Attaching it lets the library stop the sensor once no activity
+        // is running. Orientation locking itself does not depend on the sensor.
+        registerActivityLifecycleCallbacks(OrientationActivityLifecycle.getInstance())
 
         // super.onCreate()        
         // SoLoader.init(this, false)

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "axios": "^1.17.0",
         "events": "^3.3.0",
         "gd-eventlog": "^0.1.27",
-        "incyclist-services": "^1.7.129",
+        "incyclist-services": "^1.7.130",
         "mqtt": "^5.15.2",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
@@ -11814,9 +11814,9 @@
       }
     },
     "node_modules/incyclist-devices": {
-      "version": "3.0.34",
-      "resolved": "https://registry.npmjs.org/incyclist-devices/-/incyclist-devices-3.0.34.tgz",
-      "integrity": "sha512-E23D7zerezoCkTBx37sR7nO0sD1LkHoADT333xjtheAjXUYJ8v9Pm2KoNg+1gPnWhj1SY46uMqwO8czhpIeQ+A==",
+      "version": "3.0.35",
+      "resolved": "https://registry.npmjs.org/incyclist-devices/-/incyclist-devices-3.0.35.tgz",
+      "integrity": "sha512-ys+FRdki8+nHaRoMi4phlC9IuPAGiiBfqqvDXJXTzPsIM6ADdSUiLAzRA/KwEUnpFXJ2tWaKWtkkb1cqIqbybA==",
       "dependencies": {
         "@protobuf-ts/runtime": "^2.11.1",
         "@serialport/bindings-interface": "^1.2.2",
@@ -11832,13 +11832,13 @@
       }
     },
     "node_modules/incyclist-services": {
-      "version": "1.7.129",
-      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.129.tgz",
-      "integrity": "sha512-QWtWBnDCNvyw3Pg04nmNwdS/2rv+sdrEVAdB7gJhAQ8sRxDRwJQzuLZjGPU3O/5GT0ruBWWWzfeYtnUhwEAoGA==",
+      "version": "1.7.130",
+      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.130.tgz",
+      "integrity": "sha512-vg65S97SOQkPTY2B5qSnXnIhTPt+9ZllcQ/QunAx/xa1yWaE4ORl5lnwGvXuz5yBQBOU2K2a7BH1Yi8BiwsMlw==",
       "dependencies": {
         "@garmin/fitsdk": "^21.213.0",
         "axios": "^1.19.0",
-        "incyclist-devices": "^3.0.34",
+        "incyclist-devices": "^3.0.35",
         "promise.any": "^2.0.6",
         "semver": "^7.7.4",
         "tcx-builder": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "axios": "^1.17.0",
     "events": "^3.3.0",
     "gd-eventlog": "^0.1.27",
-    "incyclist-services": "^1.7.129",
+    "incyclist-services": "^1.7.130",
     "mqtt": "^5.15.2",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",


### PR DESCRIPTION
## Summary
The app was measurably draining battery in the background — confirmed on a physical device via `dumpsys batterystats`/`sensorservice`/`bluetooth_manager`/`wifi`, with CPU usage over a 30s backgrounded window dropping from 6.9-10.7% of one core to ~0% after these fixes. Three independent causes, all fixed here or in a dependency bump:

1. **Accelerometer running continuously at 15Hz, background included** (this PR)
2. **Unfiltered BLE scan running indefinitely in the background** (`incyclist-devices` [#121](https://github.com/incyclist/devices/pull/121), wired up in `incyclist-services` [#577](https://github.com/incyclist/services/pull/577))
3. **Wifi multicast lock (DirectConnect mDNS) held indefinitely in the background** (same two PRs)

Depends on `incyclist-services` >= 1.7.130, which is already bumped in this branch.

## What changed
- `android/app/src/main/java/com/incyclist/app/MainApplication.kt`: `react-native-orientation-locker` ships `OrientationActivityLifecycle`, an `Application.ActivityLifecycleCallbacks` implementation that starts/stops the module's `OrientationEventListener` based on whether any activity is running — but nothing in the app ever called `registerActivityLifecycleCallbacks()` to attach it. As a result the listener was enabled once at module construction (`SENSOR_DELAY_UI` = 15Hz) and never disabled, so the accelerometer sampled continuously for the entire process lifetime, background included. One line activates the library's own dormant lifecycle handling. Orientation locking (`Orientation.lockToLandscape()` in `src/Loader.tsx`) uses `setRequestedOrientation()` and does not depend on the sensor, so this has no effect on locking behavior.
- `package.json`: bump `incyclist-services` to `^1.7.130` for the BLE scan / multicast lock fixes.

Deliberately did **not** add `android:screenOrientation="landscape"` to the manifest — it's already `sensorLandscape` there, and the task runs `translucent=true` with `minSdk 24`, which is the exact combination that throws `IllegalStateException: Only fullscreen opaque activities can request orientation` on Android 8.0/8.1.

## Test plan
- [x] `npm test` — 148 suites, 1312 tests, all passing
- [x] `npm run lint` — 0 errors (27 pre-existing warnings, unrelated to this change)
- [x] Verified on a physical device (Samsung SM-P610, Android):
  - `dumpsys sensorservice`: accelerometer registration now shows a `-` (unregister) event within seconds of backgrounding; previously stayed registered for 30+ minutes
  - `pool-8-thread-1` (the sensor event delivery thread) disappears from the per-thread CPU breakdown entirely
  - `mqt_v_js` (JS thread) CPU while backgrounded: 4.36% → 1.15% of one core from this fix alone; ~0% with the BLE/multicast fixes from the dependency bump also in place
  - Backgrounding stops the BLE scan within seconds (`dumpsys bluetooth_manager`) and releases the wifi multicast lock (`dumpsys wifi`); foregrounding restarts the scan and peripheral discovery resumes within ~5s
- [ ] On-battery `dumpsys batterystats` capture in progress at time of writing — will report once done