### PR TITLE
Show the elevation profile on route details

### DIFF
--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.stories.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.stories.tsx
@@ -3,6 +3,7 @@ import { View } from 'react-native';
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { fn } from 'storybook/test';
 import { RouteDetailsView } from './RouteDetailsView';
+import { MOCK_ROUTE_DATA, MOCK_ROUTE_POINTS } from './RouteDetailsView.mock';
 import { MainBackground } from '../../components';
 
 const mockRouteProps = (overrides = {}): any => ({
@@ -11,6 +12,8 @@ const mockRouteProps = (overrides = {}): any => ({
     hasGpx: false,
     points: undefined,
     previewUrl: undefined,
+    routeData: undefined,
+    isOnline: true,
     totalDistance: { value: 47.5, unit: 'km' },
     totalElevation: { value: 128, unit: 'm' },
     routeType: 'Video - Loop',
@@ -130,11 +133,52 @@ export const CompactWithMap: Story = {
     args: mockRouteProps({
         compact: true,
         hasGpx: true,
-        points: [
-            { lat: 51.9, lng: 4.5, routeDistance: 0, elevation: 0 },
-            { lat: 51.91, lng: 4.51, routeDistance: 1000, elevation: 5 },
-        ],
+        points: MOCK_ROUTE_POINTS,
+        routeData: MOCK_ROUTE_DATA,
     }),
+};
+
+// The three surfaces are gated separately: map needs a GPS track and a network, the profile
+// needs points alone, the still fills what is left. These four cover the combinations.
+export const WithMapAndProfile: Story = {
+    args: mockRouteProps({
+        hasGpx: true,
+        points: MOCK_ROUTE_POINTS,
+        routeData: MOCK_ROUTE_DATA,
+        previewUrl: 'https://incyclist.com/preview.jpg',
+    }),
+    parameters: { viewport: { defaultViewport: 'ipadAir' }, layout: 'fullscreen' },
+};
+
+export const ProfileWithoutGpsTrack: Story = {
+    args: mockRouteProps({
+        hasGpx: false,
+        points: MOCK_ROUTE_POINTS,
+        routeData: MOCK_ROUTE_DATA,
+        previewUrl: 'https://incyclist.com/preview.jpg',
+    }),
+    parameters: { viewport: { defaultViewport: 'ipadAir' }, layout: 'fullscreen' },
+};
+
+export const ProfileOffline: Story = {
+    args: mockRouteProps({
+        hasGpx: true,
+        isOnline: false,
+        points: MOCK_ROUTE_POINTS,
+        routeData: MOCK_ROUTE_DATA,
+        previewUrl: 'https://incyclist.com/preview.jpg',
+    }),
+    parameters: { viewport: { defaultViewport: 'ipadAir' }, layout: 'fullscreen' },
+};
+
+export const CompactProfileWithoutGpsTrack: Story = {
+    args: mockRouteProps({
+        compact: true,
+        hasGpx: false,
+        points: MOCK_ROUTE_POINTS,
+        routeData: MOCK_ROUTE_DATA,
+    }),
+    parameters: { viewport: { defaultViewport: 'iphone15Pro' }, layout: 'fullscreen' },
 };
 
 // FIXES_BACKLOG #27 - compact mode's info bar (route type/distance/elevation, plus
@@ -152,10 +196,8 @@ export const CompactWithMap: Story = {
 const tallestCompactFormProps = () => mockRouteProps({
     compact: true,
     hasGpx: true,
-    points: [
-        { lat: 51.9, lng: 4.5, routeDistance: 0, elevation: 0 },
-        { lat: 51.91, lng: 4.51, routeDistance: 1000, elevation: 5 },
-    ],
+    points: MOCK_ROUTE_POINTS,
+    routeData: MOCK_ROUTE_DATA,
     segments: [
         { name: 'Total Trip', start: 0, end: 47500 },
         { name: '1st Climb', start: 5200, end: 12800 },

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.test.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react-native';
 import { RouteDetailsDialog } from './RouteDetailsDialog';
+import { MOCK_ROUTE_POINTS } from './RouteDetailsView.mock';
 
 // workout-combo-service-design.md §3.5.1 "one source per state" - the whole point of this test
 // file is to prove the defect it warns about can't happen: `cardProps.showWorkoutOption` is
@@ -106,6 +107,16 @@ jest.mock('@maplibre/maplibre-react-native', () => ({
 jest.mock('../SecureImage', () => ({
     SecureImage: () => null,
 }));
+
+jest.mock('../FreeMap', () => {
+    const { Text } = require('react-native');
+    return { FreeMap: () => <Text>FreeMap</Text> };
+});
+
+jest.mock('../ElevationGraph', () => {
+    const { Text } = require('react-native');
+    return { ElevationGraph: () => <Text>ElevationGraph</Text> };
+});
 
 jest.mock('../DownloadModal', () => ({
     DownloadModalView: () => null,
@@ -327,5 +338,45 @@ describe('RouteDetailsDialog - settings captured before the route details are lo
         render(<RouteDetailsDialog routeId="r1" onStart={jest.fn()} />);
 
         expect(mockRouteListService.getRouteDetails).not.toHaveBeenCalled();
+    });
+});
+
+// The elevation profile is drawn from the card's own route record - no extra service call and no
+// new card prop. The points can come from the details or, for an older library entry, from the
+// description alone, and both have to reach the graph.
+describe('RouteDetailsDialog - elevation profile data', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockGetRouteDetailsProps.mockReturnValue(baseRouteDetailsProps());
+        mockCard.openSettings.mockReturnValue(mockCardProps);
+        mockOnlineStatusMonitor.onlineStatus = true;
+        mockRouteData.description.videoFormat = undefined;
+    });
+
+    afterEach(() => {
+        mockRouteData.details = { points: [] };
+        mockRouteData.points = [];
+        mockRouteData.description.hasGpx = true;
+    });
+
+    it('feeds the graph from the route details', () => {
+        mockRouteData.details = { points: MOCK_ROUTE_POINTS };
+        mockRouteData.points = MOCK_ROUTE_POINTS;
+        const { getByText } = render(<RouteDetailsDialog routeId="r1" onStart={jest.fn()} />);
+        expect(getByText('ElevationGraph')).toBeTruthy();
+    });
+
+    it('feeds the graph from the route description when there are no details', () => {
+        mockRouteData.details = undefined;
+        mockRouteData.points = MOCK_ROUTE_POINTS;
+        const { getByText } = render(<RouteDetailsDialog routeId="r1" onStart={jest.fn()} />);
+        expect(getByText('ElevationGraph')).toBeTruthy();
+    });
+
+    it('renders no graph for a route without points', () => {
+        mockRouteData.details = { points: [] };
+        mockRouteData.points = [];
+        const { queryByText } = render(<RouteDetailsDialog routeId="r1" onStart={jest.fn()} />);
+        expect(queryByText('ElevationGraph')).toBeNull();
     });
 });

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useWindowDimensions } from 'react-native';
 import { useRouteList, useActivityList, getRoutesPageService, useOnlineStatusMonitoring } from 'incyclist-services';
-import type { DownloadRowDisplayProps, UIRouteSettings, UIStartSettings, RouteDetailsProps } from 'incyclist-services';
+import type { DownloadRowDisplayProps, UIRouteSettings, UIStartSettings, RouteDetailsProps, RouteApiDetail } from 'incyclist-services';
 import { useLogging, useUnmountEffect } from '../../hooks';
 import { RouteDetailsView } from './RouteDetailsView';
 import { RouteDetailsDialogProps } from './types';
@@ -202,6 +202,18 @@ export const RouteDetailsDialog = ({ routeId, onStart }: RouteDetailsDialogProps
 
     const { hasVideo, hasGpx, isLoop, videoFormat, previewUrl, segments } = routeDescr;
     const points = route.details?.points ?? route.points;
+    // The elevation graph draws from the whole route record, not just the point array. The
+    // points can come from the description alone (details not loaded yet, or an older library
+    // entry), so fill them in rather than leaving the graph with nothing to draw.
+    const details: RouteApiDetail | undefined = route.details;
+    const routeData: RouteApiDetail | undefined = points?.length
+        ? {
+            ...details,
+            id: details?.id ?? routeDescr.id ?? '',
+            title: details?.title ?? routeDescr.title ?? '',
+            points,
+        }
+        : undefined;
     const routeType = `${hasVideo ? 'Video' : 'GPX'} - ${isLoop ? 'Loop' : 'Point to Point'}`;
     const isAvi = videoFormat?.toLowerCase() === 'avi';
     const downloadStatus = downloadRow?.status ?? 'none'
@@ -274,6 +286,8 @@ export const RouteDetailsDialog = ({ routeId, onStart }: RouteDetailsDialogProps
             hasGpx={hasGpx ?? false}
             points={points}
             previewUrl={previewUrl}
+            routeData={routeData}
+            isOnline={isOnline}
             totalDistance={totalDistance}
             totalElevation={totalElevation}
             routeType={routeType}

--- a/src/components/RouteDetailsDialog/RouteDetailsView.mock.ts
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.mock.ts
@@ -1,0 +1,23 @@
+import type { RouteApiDetail } from 'incyclist-services';
+import type { RoutePoint } from './types';
+
+/**
+ * A short climb - enough points, and enough elevation spread, for the profile to be a real
+ * curve rather than a flat line.
+ */
+export const MOCK_ROUTE_POINTS: RoutePoint[] = [
+    { lat: 51.90, lng: 4.50, routeDistance: 0, elevation: 12 },
+    { lat: 51.91, lng: 4.51, routeDistance: 500, elevation: 34 },
+    { lat: 51.92, lng: 4.52, routeDistance: 1000, elevation: 78 },
+    { lat: 51.93, lng: 4.53, routeDistance: 1500, elevation: 121 },
+    { lat: 51.94, lng: 4.54, routeDistance: 2000, elevation: 96 },
+    { lat: 51.95, lng: 4.55, routeDistance: 2500, elevation: 143 },
+];
+
+export const MOCK_ROUTE_DATA: RouteApiDetail = {
+    id: 'r1',
+    title: 'Col de Pennes',
+    distance: 2500,
+    elevation: 131,
+    points: MOCK_ROUTE_POINTS,
+};

--- a/src/components/RouteDetailsDialog/RouteDetailsView.test.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.test.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react-native';
 import { ScrollView } from 'react-native';
 import { RouteDetailsView } from './RouteDetailsView';
+import { MOCK_ROUTE_DATA, MOCK_ROUTE_POINTS } from './RouteDetailsView.mock';
 import type { UIRouteSettings, UIStartSettings } from 'incyclist-services';
 
 jest.mock('incyclist-services', () => ({
     useUnitConverter: () => ({ convert: (v: number) => v }),
     useRouteList: jest.fn(),
     useActivityList: jest.fn(),
+    getPosition: jest.fn(() => undefined),
 }));
 jest.mock('../../bindings/ui', () => ({}));
 jest.mock('../../hooks', () => ({
@@ -40,6 +42,18 @@ jest.mock('../SecureImage', () => ({
     },
 }));
 
+// Stand-ins so the gate tests below can assert which of the three surfaces is on screen without
+// depending on anything the real map/graph render.
+jest.mock('../FreeMap', () => {
+    const { Text } = require('react-native');
+    return { FreeMap: () => <Text>FreeMap</Text> };
+});
+
+jest.mock('../ElevationGraph', () => {
+    const { Text } = require('react-native');
+    return { ElevationGraph: () => <Text>ElevationGraph</Text> };
+});
+
 const MOCK_SETTINGS = {
     startPos: { value: 0, unit: 'km' },
     realityFactor: 100,
@@ -53,6 +67,8 @@ const MOCK_PROPS = {
     hasGpx: false,
     points: [],
     previewUrl: undefined,
+    routeData: undefined,
+    isOnline: true,
     totalDistance: { value: 50, unit: 'km' },
     totalElevation: { value: 800, unit: 'm' },
     routeType: 'Video - Point to Point',
@@ -195,6 +211,91 @@ describe('RouteDetailsView', () => {
         // Dialog itself renders the ScrollView here (scrollable defaults to true), RouteDetailsView
         // does not add its own on top of it.
         expect(UNSAFE_root.findAllByType(ScrollView).length).toBe(1);
+    });
+
+    // Route details showed no elevation profile at all, on either layout - the component existed
+    // and was already used on the route list, but this screen had no slot for it. The three
+    // surfaces are gated separately, matching web: the map needs a GPS track and a network, the
+    // profile needs points alone (taking the map's place when there is no track), and the still
+    // fills what is left.
+    describe('elevation profile / map / still gates', () => {
+        const withProfile = (overrides = {}) => ({
+            ...MOCK_PROPS,
+            points: MOCK_ROUTE_POINTS,
+            routeData: MOCK_ROUTE_DATA,
+            ...overrides,
+        });
+
+        it('renders the profile in the map slot when there are points but no GPS track (full)', () => {
+            const { getByText, queryByText } = render(
+                <RouteDetailsView {...withProfile({ hasGpx: false, compact: false })} />
+            );
+            expect(getByText('ElevationGraph')).toBeTruthy();
+            expect(queryByText('FreeMap')).toBeNull();
+        });
+
+        it('renders the profile in the map slot when there are points but no GPS track (compact)', () => {
+            const { getByText, queryByText } = render(
+                <RouteDetailsView {...withProfile({ hasGpx: false, compact: true })} />
+            );
+            expect(getByText('ElevationGraph')).toBeTruthy();
+            expect(queryByText('FreeMap')).toBeNull();
+        });
+
+        it('renders the profile alongside the map when the route has a GPS track (full)', () => {
+            const { getByText } = render(
+                <RouteDetailsView {...withProfile({ hasGpx: true, compact: false, previewUrl: 'https://example.com/p.jpg' })} />
+            );
+            expect(getByText('FreeMap')).toBeTruthy();
+            expect(getByText('ElevationGraph')).toBeTruthy();
+        });
+
+        it('renders the profile alongside the map when the route has a GPS track (compact)', () => {
+            const { getByText } = render(
+                <RouteDetailsView {...withProfile({ hasGpx: true, compact: true })} />
+            );
+            expect(getByText('FreeMap')).toBeTruthy();
+            expect(getByText('ElevationGraph')).toBeTruthy();
+        });
+
+        it('renders no profile and no map when the route has no points', () => {
+            const { queryByText } = render(
+                <RouteDetailsView {...MOCK_PROPS} hasGpx={true} points={[]} routeData={undefined} />
+            );
+            expect(queryByText('ElevationGraph')).toBeNull();
+            expect(queryByText('FreeMap')).toBeNull();
+        });
+
+        // Offline the map has no tiles to fetch, so it is dropped - but the profile is local data
+        // and still renders.
+        it('renders the profile but no map when offline', () => {
+            const { getByText, queryByText } = render(
+                <RouteDetailsView {...withProfile({ hasGpx: true, isOnline: false })} />
+            );
+            expect(queryByText('FreeMap')).toBeNull();
+            expect(getByText('ElevationGraph')).toBeTruthy();
+        });
+
+        it('renders no profile while the details are still loading', () => {
+            const { queryByText } = render(
+                <RouteDetailsView {...withProfile({ hasGpx: true, loading: true })} />
+            );
+            expect(queryByText('ElevationGraph')).toBeNull();
+        });
+
+        // Unactionable internal state - the map's absence is already visible, and naming it says
+        // nothing the user can act on.
+        it('never shows a "Map not available" placeholder', () => {
+            [
+                { ...MOCK_PROPS },
+                { ...MOCK_PROPS, compact: true },
+                withProfile({ hasGpx: true, isOnline: false }),
+                withProfile({ hasGpx: true, isOnline: false, compact: true }),
+            ].forEach(props => {
+                const { queryByText } = render(<RouteDetailsView {...props} />);
+                expect(queryByText('Map not available')).toBeNull();
+            });
+        });
     });
 
     describe('workout attachment (workout-mobile-hld-phase2.md §4.2)', () => {

--- a/src/components/RouteDetailsDialog/RouteDetailsView.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.tsx
@@ -21,12 +21,13 @@ import { SingleSelect } from '../SingleSelect';
 import { DownloadModalView } from '../DownloadModal';
 import { SecureImage } from '../SecureImage';
 import { AttachmentChip } from '../AttachmentChip';
+import { ElevationGraph } from '../ElevationGraph';
 
 const SEGMENT_CHIP_THRESHOLD = 5;
 
 export const RouteDetailsView = (props: RouteDetailsViewProps) => {
     const {
-        title, compact, hasGpx, points, previewUrl, totalDistance,
+        title, compact, hasGpx, points, previewUrl, routeData, isOnline, totalDistance,
         totalElevation, routeType, canStart, canNotStartReason,
         showLoopOverwrite, showNextOverwrite, loading,
         initialSettings, segments, prevRides, showPrev: initialShowPrev,
@@ -150,21 +151,48 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
     const mediaRowStyle = { ...styles.mediaRow, height: mediaRowHeight };
 
 
-    const renderMedia = () => {
+    // What each of the three surfaces needs, kept deliberately separate: a route can have a
+    // readable profile and no usable GPS track (so: graph, no map), or a GPS track and no
+    // network (so: profile only, and the map panel is dropped rather than left blank).
+    const hasProfile = !loading && !!points?.length && !!routeData?.points?.length;
+    const showMap = hasProfile && hasGpx && isOnline;
+    // No GPS track: the profile takes the map's place instead of the map slot going empty.
+    const showProfileInMapSlot = hasProfile && !hasGpx;
+    // With a map, the profile sits as a strip under the still, the way it does on web.
+    const showProfileStrip = hasProfile && hasGpx;
+    const showMapPanel = loading || showMap || showProfileInMapSlot;
+
+    const renderMap = () => (
+        <FreeMap
+            points={points ?? []}
+            startPos={0}
+            zoom={12}
+            draggable={true}
+            position={markerPosition}
+            onRoutePositionChanged={handleRoutePositionChanged}
+        />
+    );
+
+    // `showXAxis` is only worth the vertical space when the graph owns a whole panel; in the
+    // strip variant the axis would eat most of it.
+    const renderProfile = (showXAxis: boolean) => (
+        <ElevationGraph
+            routeData={routeData}
+            pctReality={data.realityFactor}
+            showLine={true}
+            showColors={true}
+            showXAxis={showXAxis}
+            showYAxis={false}
+            // The graph sizes itself from its own onLayout, so it needs explicit bounds: the
+            // media panel centres its child, which would otherwise collapse it to zero width.
+            style={styles.profileFill}
+        />
+    );
+
+    const renderMapSlot = () => {
         if (loading) return <ActivityIndicator color={colors.text} />;
-        if (hasGpx && points?.length) {
-            return (
-                <FreeMap
-                    points={points}
-                    startPos={0}
-                    zoom={12}
-                    draggable={true}
-                    position={markerPosition}
-                    onRoutePositionChanged={handleRoutePositionChanged}
-                />
-            );
-        }
-        return <Text style={styles.placeholderText}>Map not available</Text>;
+        if (showMap) return renderMap();
+        return renderProfile(true);
     };
 
     const renderPreview = () => {
@@ -305,8 +333,24 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
         <AttachmentChip label="Workout" name={attachedWorkout.title} onClear={onClearWorkout} />
     ) : null;
 
+    // The single compact panel holds the map with the profile beneath it, or - when there is no
+    // map to show - the profile on its own, falling back to the still.
+    const renderCompactPanel = () => {
+        if (loading) return <ActivityIndicator color={colors.text} />;
+        if (showMap) {
+            return (
+                <>
+                    <View style={styles.compactMapSlot}>{renderMap()}</View>
+                    <View style={styles.compactProfileSlot}>{renderProfile(false)}</View>
+                </>
+            );
+        }
+        if (hasProfile) return renderProfile(true);
+        return renderPreview();
+    };
+
     if (compact) {
-        const showCompactPanel = (hasGpx && !!points?.length) || !!previewUrl;
+        const showCompactPanel = loading || showMap || hasProfile || !!previewUrl;
 
         const infoBar = (
             <View style={styles.infoBar}>
@@ -338,7 +382,7 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
                     </View>
                     {showCompactPanel && (
                         <View style={styles.compactRight}>
-                            {hasGpx && points?.length ? renderMedia() : renderPreview()}
+                            {renderCompactPanel()}
                         </View>
                     )}
                 </View>
@@ -358,8 +402,17 @@ export const RouteDetailsView = (props: RouteDetailsViewProps) => {
         <Dialog title={title} variant="full" buttons={dialogButtons} onOutsideClick={onCancel}>
             {workoutChip && <View style={styles.chipWrapper}>{workoutChip}</View>}
             <View style={mediaRowStyle}>
-                <View style={styles.mediaContainer}>{renderMedia()}</View>
-                <View style={styles.mediaContainer}>{renderPreview()}</View>
+                {showMapPanel && (
+                    <View style={styles.mediaContainer}>{renderMapSlot()}</View>
+                )}
+                {showProfileStrip ? (
+                    <View style={styles.mediaColumn}>
+                        <View style={styles.previewSlot}>{renderPreview()}</View>
+                        <View style={styles.profileSlot}>{renderProfile(false)}</View>
+                    </View>
+                ) : (
+                    <View style={styles.mediaContainer}>{renderPreview()}</View>
+                )}
             </View>
             <View style={styles.statsRow}>
                 <View style={styles.statBox}>
@@ -396,7 +449,13 @@ const styles = StyleSheet.create({
     chipWrapper: { paddingHorizontal: 15 },
     mediaRow: { flexDirection: 'row', gap: 10, padding: 10 },
     mediaContainer: { flex: 1, backgroundColor: 'rgba(0,0,0,0.3)', borderRadius: 8, overflow: 'hidden', justifyContent: 'center', alignItems: 'center' },
+    // Same panel as mediaContainer, but stacking the still above the elevation strip - so the
+    // children own their alignment instead of the panel centring a single child.
+    mediaColumn: { flex: 1, backgroundColor: 'rgba(0,0,0,0.3)', borderRadius: 8, overflow: 'hidden' },
+    previewSlot: { height: '70%', justifyContent: 'center', alignItems: 'center' },
+    profileSlot: { height: '30%', backgroundColor: 'rgba(0,0,0,0.45)', paddingHorizontal: 8, paddingVertical: 6 },
     fullMedia: { width: '100%', height: '100%' },
+    profileFill: { width: '100%', height: '100%' },
     placeholderText: { color: colors.disabled, fontSize: 12 },
     formLoading: { alignItems: 'center', justifyContent: 'center', gap: 10, paddingVertical: 30 },
     statsRow: { flexDirection: 'row', paddingHorizontal: 15, paddingBottom: 10, borderBottomWidth: 1, borderBottomColor: 'rgba(255,255,255,0.1)' },
@@ -424,6 +483,10 @@ const styles = StyleSheet.create({
     compactLeftScroll: { flex: 1 },
     compactLeftScrollContent: { paddingBottom: 4 },
     compactRight: { width: '35%', backgroundColor: 'rgba(0,0,0,0.3)', borderRadius: 6, overflow: 'hidden' },
+    // Phone landscape has room for one panel only, so map and profile share it. Both halves are
+    // small; the alternative - profile on tablets only - is a worse answer to the same shortage.
+    compactMapSlot: { height: '65%' },
+    compactProfileSlot: { height: '35%', backgroundColor: 'rgba(0,0,0,0.45)', paddingHorizontal: 6, paddingVertical: 4 },
     infoBar: {
         paddingHorizontal: 15,
         paddingVertical: 10,

--- a/src/components/RouteDetailsDialog/types.ts
+++ b/src/components/RouteDetailsDialog/types.ts
@@ -1,4 +1,4 @@
-import type { UIRouteSettings, UIStartSettings, DownloadRowDisplayProps, AttachedWorkoutProps } from 'incyclist-services';
+import type { UIRouteSettings, UIStartSettings, DownloadRowDisplayProps, AttachedWorkoutProps, RouteApiDetail } from 'incyclist-services';
 
 export interface RouteDetailsDialogProps {
     routeId: string     
@@ -28,6 +28,16 @@ export interface RouteDetailsViewProps {
     hasGpx: boolean;
     points?: RoutePoint[];
     previewUrl?: string;
+    /**
+     * The route record the elevation profile is drawn from - `points` above only says whether
+     * there is a profile to draw, `ElevationGraph` needs the whole record.
+     */
+    routeData?: RouteApiDetail;
+    /**
+     * Map tiles are fetched on demand, so the map is only offered while there is a network.
+     * Mirrors the map gate on web, where the panel is left empty offline.
+     */
+    isOnline: boolean;
 
     // Info
     totalDistance: { value: number; unit: string };


### PR DESCRIPTION
Route details rendered no elevation profile at all, on either layout tier. This is a pre-existing defect, independent of any other work - the `ElevationGraph` component already exists and is used in eight other places including the route list item, and the card's own route record was already in hand. The screen simply had no slot for it.

**No `incyclist-services` change is needed and the pinned version is unchanged**, so this can merge on its own schedule.

## What changed

The three surfaces are now gated separately, matching the web UI rather than the coarser "map and graph together" rule:

| Surface | Renders when |
|---|---|
| Map | points + a GPS track + a network |
| Elevation profile | points alone - in the map's place when there is no GPS track, as a strip under the still when there is one |
| Static still | whatever is left; full width when there are no points |

So a route with a profile but no GPS track now shows the profile where the map would have been, instead of showing nothing.

Also drops the `Map not available` placeholder: it named internal state the user can do nothing about, and the map's absence is already visible. The web UI shows nothing there.

Layout: tablet landscape keeps two panels (map | still + profile strip); phone landscape splits its single panel between map and profile. When there is neither map nor profile the panel is dropped and the still takes the full width, matching what the compact layout already did.

## Test plan

- `npm test` - 148 suites, 1323 tests, all passing
- `npx tsc --noEmit` - clean

New tests cover the gate matrix on both layout tiers (`full` and `compact`), including the no-GPS-track and no-points cases, and assert the placeholder text is gone.