### PR TITLE
fix: cap ride-summary screenshot capture resolution

### DIFF
--- a/src/bindings/ui/index.test.ts
+++ b/src/bindings/ui/index.test.ts
@@ -1,0 +1,76 @@
+import { Dimensions, PixelRatio } from 'react-native';
+import RNFS from 'react-native-fs';
+import { captureScreen } from 'react-native-view-shot';
+import { UIBinding } from './index';
+
+jest.mock('react-native-fs', () => ({
+    __esModule: true,
+    default: {
+        DocumentDirectoryPath: '/docs',
+        exists: jest.fn().mockResolvedValue(true),
+        mkdir: jest.fn(),
+        unlink: jest.fn(),
+        moveFile: jest.fn().mockResolvedValue(undefined),
+    },
+}));
+
+jest.mock('react-native-view-shot', () => ({
+    captureScreen: jest.fn().mockResolvedValue('file:///tmp/shot.jpg'),
+}));
+
+jest.mock('../../services', () => ({
+    navigate: jest.fn(),
+}));
+
+jest.mock('react-native-share', () => ({
+    __esModule: true,
+    default: { open: jest.fn() },
+}));
+
+jest.mock('@react-native-documents/picker', () => ({
+    pickDirectory: jest.fn(),
+}));
+
+jest.mock('@sayem314/react-native-keep-awake', () => ({
+    activateKeepAwake: jest.fn(),
+    deactivateKeepAwake: jest.fn(),
+}));
+
+jest.mock('react-native-localize', () => ({
+    getLocales: jest.fn().mockReturnValue([]),
+}));
+
+describe('UIBinding.takeScreenshot', () => {
+    let ui: UIBinding;
+
+    beforeEach(() => {
+        ui = new UIBinding();
+        jest.clearAllMocks();
+        (RNFS.exists as jest.Mock).mockResolvedValue(true);
+        (RNFS.moveFile as jest.Mock).mockResolvedValue(undefined);
+    });
+
+    it('caps the capture to MAX_SCREENSHOT_DIMENSION on a high-resolution screen, preserving aspect ratio', async () => {
+        jest.spyOn(Dimensions, 'get').mockReturnValue({ width: 1280, height: 720, scale: 3, fontScale: 1 });
+        jest.spyOn(PixelRatio, 'get').mockReturnValue(3); // native pixels: 3840 x 2160
+
+        await ui.takeScreenshot({ fileName: 'shot.jpg' });
+
+        expect(captureScreen).toHaveBeenCalledWith(expect.objectContaining({
+            width: 1600,
+            height: 900, // 3840x2160 scaled so the longer edge is 1600, aspect ratio preserved
+        }));
+    });
+
+    it('does not upscale a screen already under MAX_SCREENSHOT_DIMENSION', async () => {
+        jest.spyOn(Dimensions, 'get').mockReturnValue({ width: 640, height: 360, scale: 2, fontScale: 1 });
+        jest.spyOn(PixelRatio, 'get').mockReturnValue(2); // native pixels: 1280 x 720
+
+        await ui.takeScreenshot({ fileName: 'shot.jpg' });
+
+        expect(captureScreen).toHaveBeenCalledWith(expect.objectContaining({
+            width: 1280,
+            height: 720,
+        }));
+    });
+});

--- a/src/bindings/ui/index.ts
+++ b/src/bindings/ui/index.ts
@@ -2,12 +2,33 @@ import { INativeUI, SelectDirectoryResult, TakeScreenshotProps } from "incyclist
 import { navigate } from "../../services";
 import RNFS from 'react-native-fs';
 import Share from 'react-native-share';
-import { BackHandler, Linking, NativeModules, Platform } from "react-native";
+import { BackHandler, Dimensions, Linking, NativeModules, PixelRatio, Platform } from "react-native";
 import {pickDirectory} from '@react-native-documents/picker';
 import { activateKeepAwake, deactivateKeepAwake } from '@sayem314/react-native-keep-awake';
 import { captureScreen } from 'react-native-view-shot';
 import { EventLogger } from "gd-eventlog";
 import {getLocales} from 'react-native-localize'
+
+// Ride-summary screenshot is neither displayed nor shared above this size today - cap the
+// captured bitmap's longer edge here rather than allocating at full native resolution and
+// only compressing afterward (Android Vitals "bitmap downsampling", FIXES_BACKLOG #76).
+const MAX_SCREENSHOT_DIMENSION = 1600;
+
+// captureScreen's width/height resize the final bitmap in native pixels - scale from the
+// device's actual pixel dimensions, not its dp size, and never upscale a smaller screen.
+function getCaptureSize(): { width: number, height: number } {
+    const { width: dpWidth, height: dpHeight } = Dimensions.get('screen');
+    const pixelRatio = PixelRatio.get();
+    const nativeWidth = dpWidth * pixelRatio;
+    const nativeHeight = dpHeight * pixelRatio;
+
+    const scale = Math.min(1, MAX_SCREENSHOT_DIMENSION / Math.max(nativeWidth, nativeHeight));
+
+    return {
+        width: Math.round(nativeWidth * scale),
+        height: Math.round(nativeHeight * scale),
+    };
+}
 
 export class UIBinding implements INativeUI {
 
@@ -53,10 +74,13 @@ export class UIBinding implements INativeUI {
             }  
 
             // Captures the screen and returns a local URI
+            const { width, height } = getCaptureSize();
             const tempUri = await captureScreen({
                 format: 'jpg',
                 quality: 0.7,
-                result: 'tmpfile'
+                result: 'tmpfile',
+                width,
+                height,
             });
 
             // Clean URI strings for RNFS (remove file:// prefix)


### PR DESCRIPTION
## Summary
- `UIBinding.takeScreenshot()` called `captureScreen()` with no `width`/`height`, allocating a full native-resolution bitmap before the `quality: 0.7` JPEG compression ran
- Caps the captured bitmap's longer edge to 1600px (computed from the device's actual pixel dimensions via `Dimensions`/`PixelRatio`, never upscaling a smaller screen)
- Addresses Play Console Android Vitals' "bitmap downsampling" recommendation (Memory usage)

## What changed
- `src/bindings/ui/index.ts`: added `getCaptureSize()` and passed `width`/`height` to `captureScreen()`
- `src/bindings/ui/index.test.ts`: new tests covering the cap-and-preserve-aspect-ratio behavior and the no-upscale case

## Test plan
- [x] `npx jest src/bindings/ui/index.test.ts` passes
- [x] `npx eslint src/bindings/ui/index.ts src/bindings/ui/index.test.ts` clean
- [ ] Manual verification on a real device (ideally high-resolution/tablet) that the end-of-ride summary screenshot still looks correct
- [ ] Play Console pre-launch report shows the bitmap-downsampling recommendation cleared on a subsequent release