### PR TITLE
fix: honor all four safe-area insets in Dialog and ListPageShell

### DIFF
--- a/src/components/Dialog/Dialog.test.tsx
+++ b/src/components/Dialog/Dialog.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
-import { ScrollView, Text, View } from 'react-native';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import * as SafeAreaContext from 'react-native-safe-area-context';
 import { Dialog } from './Dialog';
 import { ButtonBar } from '../ButtonBar';
 
@@ -108,6 +109,55 @@ describe('Dialog', () => {
             const after = footerOf(UNSAFE_root);
             expect(after).toBeTruthy();
             expect(after).not.toBe(before);
+        });
+    });
+
+    // App is landscape-locked, so the notch sits on left/right (whichever edge the current
+    // rotation puts it on) and the home indicator sits at the bottom, not top.
+    describe('safe-area insets', () => {
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it('pads the dialog surface for the notch (left/right) and home indicator (bottom)', () => {
+            jest.spyOn(SafeAreaContext, 'useSafeAreaInsets').mockReturnValue({ top: 10, left: 24, right: 0, bottom: 34 });
+
+            const { UNSAFE_root } = render(
+                <Dialog title="Test Dialog">
+                    <Text>content</Text>
+                </Dialog>
+            );
+
+            const container = UNSAFE_root.findAllByType(View).find((v: any) => {
+                const flat = StyleSheet.flatten(v.props.style);
+                return flat?.overflow === 'hidden';
+            });
+
+            expect(container).toBeTruthy();
+            const flat = StyleSheet.flatten(container!.props.style);
+            expect(flat.paddingLeft).toBe(24);
+            expect(flat.paddingRight).toBe(0);
+            expect(flat.paddingBottom).toBe(34);
+        });
+
+        it('pads the full-variant content area for the notch/home indicator too', () => {
+            jest.spyOn(SafeAreaContext, 'useSafeAreaInsets').mockReturnValue({ top: 0, left: 0, right: 28, bottom: 21 });
+
+            const { UNSAFE_root } = render(
+                <Dialog title="Test Dialog" variant="full">
+                    <Text>content</Text>
+                </Dialog>
+            );
+
+            const fullContentArea = UNSAFE_root.findAllByType(View).find((v: any) => {
+                const flat = StyleSheet.flatten(v.props.style);
+                return flat?.maxHeight === '100%' && flat?.borderRadius === 0;
+            });
+
+            expect(fullContentArea).toBeTruthy();
+            const flat = StyleSheet.flatten(fullContentArea!.props.style);
+            expect(flat.paddingRight).toBe(28);
+            expect(flat.paddingBottom).toBe(21);
         });
     });
 });

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -105,7 +105,10 @@ export const Dialog = ({
     const refInitialized = useRef<boolean>(false);
     const layout = useScreenLayout();
     const { width: screenWidth, height: screenHeight } = useWindowDimensions();
-    const { top: safeAreaTop } = useSafeAreaInsets();
+    // App is landscape-locked, so left/right (the notch) and bottom (home indicator) are the
+    // edges that actually get obscured - not top. useSafeAreaInsets() already reports these
+    // relative to the current rotation, so no extra per-rotation logic is needed here.
+    const { top: safeAreaTop, left: safeAreaLeft, right: safeAreaRight, bottom: safeAreaBottom } = useSafeAreaInsets();
 
     const [isModalActive, setIsModalActive] = useState(false);
     const [isAnimating, setIsAnimating] = useState(false);
@@ -183,7 +186,7 @@ export const Dialog = ({
         }
     });
 
-    const styles = getStyles({ width, height, minWidth, minHeight, variant, isCompact, stripHeight,nested });
+    const styles = getStyles({ width, height, minWidth, minHeight, variant, isCompact, stripHeight, safeAreaLeft, safeAreaRight, safeAreaBottom, nested });
 
     // FIXES_BACKLOG #52 — workaround for a React Native new-architecture defect on iOS: when a
     // child view is added to an already-mounted subtree inside a <Modal>, Fabric calls
@@ -299,9 +302,9 @@ type StyleProps = {
     nested?: boolean
 }
 
-const getStyles = ({ width, height, minWidth, minHeight, variant = 'details', isCompact, nested=false }: StyleProps & { isCompact: boolean, stripHeight: number }) => {
+const getStyles = ({ width, height, minWidth, minHeight, variant = 'details', isCompact, safeAreaLeft, safeAreaRight, safeAreaBottom, nested=false }: StyleProps & { isCompact: boolean, stripHeight: number, safeAreaLeft: number, safeAreaRight: number, safeAreaBottom: number }) => {
     const isInfoVariant = variant === 'info';
-    
+
     return StyleSheet.create({
         overlay: {
             flex: 1,
@@ -318,6 +321,11 @@ const getStyles = ({ width, height, minWidth, minHeight, variant = 'details', is
             borderRadius: variant === 'full' ? 0 : 12,
             overflow: 'hidden',
             color: colors.text,
+            // Keep content clear of the notch (left/right in this landscape-locked app) and the
+            // home indicator (bottom).
+            paddingLeft: safeAreaLeft,
+            paddingRight: safeAreaRight,
+            paddingBottom: safeAreaBottom,
             // Shadow and thin white frame for info variant only
             ...( (isInfoVariant||nested) && {
                 borderWidth: 1,
@@ -369,6 +377,9 @@ const getStyles = ({ width, height, minWidth, minHeight, variant = 'details', is
             height: isCompact ? undefined : '100%',
             borderRadius: 0,
             maxHeight: '100%',
+            paddingLeft: safeAreaLeft,
+            paddingRight: safeAreaRight,
+            paddingBottom: safeAreaBottom,
         },
     });
 };

--- a/src/components/ListPageShell/ListPageShell.test.tsx
+++ b/src/components/ListPageShell/ListPageShell.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import { Text } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+import * as SafeAreaContext from 'react-native-safe-area-context';
 import { ListPageShell } from './ListPageShell';
 
 const mockNavigationBar = jest.fn();
@@ -81,5 +82,31 @@ describe('ListPageShell', () => {
             </ListPageShell>
         );
         expect(mockNavigationBar).toHaveBeenCalledWith(expect.objectContaining({ compact: true }));
+    });
+
+    // App is landscape-locked, so the notch sits on left/right (whichever edge the current
+    // rotation puts it on) and the home indicator sits at the bottom.
+    it('pads the shell for the notch and home indicator on all four edges', () => {
+        jest.spyOn(SafeAreaContext, 'useSafeAreaInsets').mockReturnValue({ top: 5, left: 24, right: 0, bottom: 34 });
+
+        const { UNSAFE_root } = render(
+            <ListPageShell {...baseProps}>
+                <Text>list-content</Text>
+            </ListPageShell>
+        );
+
+        const container = UNSAFE_root.findAllByType(View).find((v: any) => {
+            const flat = StyleSheet.flatten(v.props.style);
+            return typeof flat?.paddingTop === 'number';
+        });
+
+        expect(container).toBeTruthy();
+        const flat = StyleSheet.flatten(container!.props.style);
+        expect(flat.paddingTop).toBe(5);
+        expect(flat.paddingLeft).toBe(24);
+        expect(flat.paddingRight).toBe(0);
+        expect(flat.paddingBottom).toBe(34);
+
+        jest.restoreAllMocks();
     });
 });

--- a/src/components/ListPageShell/ListPageShell.tsx
+++ b/src/components/ListPageShell/ListPageShell.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MainBackground } from '../MainBackground';
 import { NavigationBar } from '../NavigationBar';
 import { colors, textSizes } from '../../theme';
@@ -23,9 +24,18 @@ export const ListPageShell = ({
     headerRight,
     belowHeader,
     children,
-}: ListPageShellProps) => (
+}: ListPageShellProps) => {
+    // App is landscape-locked, so the notch sits on left/right (whichever edge the current
+    // rotation puts it on) and the home indicator sits at the bottom.
+    const { top, left, right, bottom } = useSafeAreaInsets();
+
+    return (
     <MainBackground>
-        <View style={[styles.container, compact && styles.containerCompact]}>
+        <View style={[
+            styles.container,
+            compact && styles.containerCompact,
+            { paddingTop: top, paddingLeft: left, paddingRight: right, paddingBottom: bottom },
+        ]}>
             <View style={[styles.navColumn, compact ? styles.navColumnCompact : styles.navColumnNormal]}>
                 <NavigationBar
                     compact={compact}
@@ -49,7 +59,8 @@ export const ListPageShell = ({
             </View>
         </View>
     </MainBackground>
-);
+    );
+};
 
 const styles = StyleSheet.create({
     container: {


### PR DESCRIPTION
## Summary
- The app is landscape-locked on both platforms, so the edges that actually get obscured on a notched device are left/right (the notch, whichever side the current rotation puts it on) and bottom (home indicator) - not top
- `Dialog.tsx` only read the `top` inset; `ListPageShell.tsx` read no insets at all
- Both now read the full inset set via `useSafeAreaInsets()` and pad their outer content surface (`container`/`fullContentArea` in Dialog, the root row/column container in ListPageShell) accordingly

## What changed
- `src/components/Dialog/Dialog.tsx`: destructure `left`/`right`/`bottom` alongside the existing `top`, thread through to `getStyles`, apply as padding on `container` and `fullContentArea` (existing `top`-based `NAV_BAR_HEIGHT`/`stripHeight` calculation untouched)
- `src/components/ListPageShell/ListPageShell.tsx`: read all four insets, apply as padding on the outer container
- Tests added to both components' test files covering the new padding behavior

## Test plan
- [x] `npx jest src/components/Dialog src/components/ListPageShell` passes
- [x] `npx eslint` clean on all changed files
- [ ] Manual verification on a real notched device (iPhone with notch/Dynamic Island, or equivalent Android) in both landscape rotations - a simulator's safe-area values aren't always representative