### PR TITLE
fix: expand ButtonBar's compact touch target via hitSlop

### DIFF
--- a/src/components/ButtonBar/ButtonBar.test.tsx
+++ b/src/components/ButtonBar/ButtonBar.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { Button, ButtonBar } from './ButtonBar';
+import { useScreenLayout } from '../../hooks';
+
+jest.mock('../../hooks', () => ({
+    useLogging: () => ({ logEvent: jest.fn(), logError: jest.fn() }),
+    useScreenLayout: jest.fn(() => 'normal'),
+}));
+
+describe('Button', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('renders with no hitSlop in normal (non-compact) layout', () => {
+        (useScreenLayout as jest.Mock).mockReturnValue('normal');
+
+        const { getByText } = render(<Button id="a" label="OK" onClick={jest.fn()} />);
+        const touchable = getByText('OK').parent?.parent;
+
+        expect(touchable?.props.hitSlop).toBeUndefined();
+    });
+
+    // Compact mode's small visible size is intentional (saves vertical space in landscape on
+    // short phones) and must not change - the touch target is expanded via hitSlop instead of
+    // growing the button, and kept within the 8px marginHorizontal gap between buttons so
+    // neighboring buttons' tappable regions don't overlap.
+    it('expands the touchable region via hitSlop in compact layout, without growing the button', () => {
+        (useScreenLayout as jest.Mock).mockReturnValue('compact');
+
+        const { getByText } = render(<Button id="a" label="OK" onClick={jest.fn()} />);
+        const touchable = getByText('OK').parent?.parent;
+
+        expect(touchable?.props.hitSlop).toEqual(expect.objectContaining({
+            top: expect.any(Number),
+            bottom: expect.any(Number),
+        }));
+        expect(touchable?.props.hitSlop.top).toBeGreaterThan(0);
+        expect(touchable?.props.hitSlop.bottom).toBeGreaterThan(0);
+        // marginHorizontal between adjacent buttons is 8px each side (16px total gap) - the
+        // horizontal hitSlop must stay under that so two buttons' hit-slop regions can't overlap.
+        expect(touchable?.props.hitSlop.left).toBeLessThan(8);
+        expect(touchable?.props.hitSlop.right).toBeLessThan(8);
+    });
+
+    it('still fires onClick when compact', () => {
+        (useScreenLayout as jest.Mock).mockReturnValue('compact');
+        const onClick = jest.fn();
+
+        const { getByText } = render(<Button id="a" label="OK" onClick={onClick} />);
+        fireEvent.press(getByText('OK'));
+
+        expect(onClick).toHaveBeenCalled();
+    });
+});
+
+describe('ButtonBar', () => {
+    it('renders one Button per entry', () => {
+        (useScreenLayout as jest.Mock).mockReturnValue('normal');
+
+        const { getByText } = render(
+            <ButtonBar buttons={[
+                { id: 'a', label: 'A', onClick: jest.fn() },
+                { id: 'b', label: 'B', onClick: jest.fn() },
+            ]} />
+        );
+
+        expect(getByText('A')).toBeTruthy();
+        expect(getByText('B')).toBeTruthy();
+    });
+});

--- a/src/components/ButtonBar/ButtonBar.tsx
+++ b/src/components/ButtonBar/ButtonBar.tsx
@@ -4,11 +4,18 @@ import { colors } from '../../theme'
 import { ButtonBarProps, ButtonProps } from './types'
 import { useLogging, useScreenLayout } from '../../hooks'
 
+// Compact mode's ~34px visible button is under the 44px touch-target guideline, but its small
+// footprint is intentional (saves vertical space in landscape on phones as short as ~320px tall)
+// - expand the tappable region via hitSlop instead of growing the button. Horizontal slop must
+// stay under btnCompact's 8px marginHorizontal (styles.btn) so adjacent buttons' hit-slop
+// regions can't overlap and turn near-misses into taps on the wrong button.
+const COMPACT_HIT_SLOP = { top: 5, bottom: 5, left: 6, right: 6 }
+
 export const Button = ({ id,label, primary,attention, onClick }:ButtonProps) => {
     const {logEvent} = useLogging('Incyclist')
-    const layout  = useScreenLayout()        
+    const layout  = useScreenLayout()
     const isCompact = layout === 'compact'
-    
+
     const onPress=()=> {
         logEvent( {message:'button clicked', button:label??id, eventSource:'user'  })
         onClick()
@@ -19,6 +26,7 @@ export const Button = ({ id,label, primary,attention, onClick }:ButtonProps) => 
 
     return (
         <TouchableOpacity onPress={onPress}
+            hitSlop={isCompact ? COMPACT_HIT_SLOP : undefined}
             style={[styles.btn, bgStyle, isCompact && styles.btnCompact]}>
             <Text style={[ (primary||attention) ? styles.textPrimary : styles.textSecondary, isCompact && styles.textCompact]}>
                 {label}


### PR DESCRIPTION
## Summary
- The compact `ButtonBar` button variant (`btnCompact`) renders at roughly 34px tall - under the 44px minimum touch-target guideline (iOS HIG / Material Design)
- Compact mode's small visual footprint is intentional (saves vertical space in landscape on phones as short as ~320px tall), so the button is not made visually bigger
- Fix: `hitSlop` on the `TouchableOpacity`, expanding the tappable region without changing the rendered size

## What changed
- `src/components/ButtonBar/ButtonBar.tsx`: added `COMPACT_HIT_SLOP` (`top`/`bottom`: 5, `left`/`right`: 6) applied only when `isCompact`; horizontal values kept under the 8px `marginHorizontal` gap between buttons so adjacent hit-slop regions can't overlap
- `src/components/ButtonBar/ButtonBar.test.tsx`: new tests - no hitSlop in normal layout, hitSlop present and horizontally bounded in compact layout, onClick still fires

## Test plan
- [x] `npx jest src/components/ButtonBar/ButtonBar.test.tsx` passes
- [x] `npx eslint` clean
- [ ] Manual check on a real device: taps just outside the visible compact button register, and taps between two adjacent compact buttons don't produce ambiguous results