### PR TITLE
Build previous-rides criteria via RouteCard.getPrevRidesFilter()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "axios": "^1.17.0",
         "events": "^3.3.0",
         "gd-eventlog": "^0.1.27",
-        "incyclist-services": "^1.7.132",
+        "incyclist-services": "^1.7.133",
         "mqtt": "^5.15.2",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
@@ -11832,9 +11832,9 @@
       }
     },
     "node_modules/incyclist-services": {
-      "version": "1.7.132",
-      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.132.tgz",
-      "integrity": "sha512-0N2RXxLkRoGXEJzjgPoapjkKD3+PYgkiA7YIXf9u/hTBAURm73BJidSzSMLnom5+VDNn3XkoMY1lAUlgtTkH/Q==",
+      "version": "1.7.133",
+      "resolved": "https://registry.npmjs.org/incyclist-services/-/incyclist-services-1.7.133.tgz",
+      "integrity": "sha512-7YI4Dw7Me7HmOxS/SsLojAOfW1PI5699BTjs9I000y1pSW4e7se22lA0breotoD8EwMCwY8hxaGGoqjmylQKYQ==",
       "dependencies": {
         "@garmin/fitsdk": "^21.213.0",
         "axios": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "axios": "^1.17.0",
     "events": "^3.3.0",
     "gd-eventlog": "^0.1.27",
-    "incyclist-services": "^1.7.132",
+    "incyclist-services": "^1.7.133",
     "mqtt": "^5.15.2",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.test.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.test.tsx
@@ -65,9 +65,9 @@ const mockCard: any = {
     getCurrentDownload: jest.fn(() => null),
     changeSettings: jest.fn(),
     getSmoothingPreview: jest.fn(() => ({})),
-    // real behaviour mocked here, not re-tested: RouteCardSmoothing.unit.test.ts (services) covers
-    // the actual prediction rule (architecture.md §9.6.3). Reads openSettings() at call time, not
-    // at mock-definition time, so it respects whatever a test has reconfigured it to return.
+    // real behaviour mocked here, not re-tested: `services` covers the actual prediction rule for
+    // this. Reads openSettings() at call time, not at mock-definition time, so it respects
+    // whatever a test has reconfigured it to return.
     getPrevRidesFilter: jest.fn((settings: any) => ({
         routeHash: mockRouteData.description?.routeHash,
         startPos: settings?.startPos,
@@ -507,8 +507,8 @@ describe('RouteDetailsDialog - Terrain Smoothing', () => {
         expect(mockActivityListService.getPastActivitiesWithDetails).toHaveBeenCalledTimes(1);
     });
 
-    // architecture.md §9.5: the pre-ride prev-rides count is a prediction of the level
-    // buildRideRoute() would actually apply - the tapped level for an eligible route.
+    // the pre-ride prev-rides count is a prediction of the level buildRideRoute() would actually
+    // apply - the tapped level for an eligible route.
     it('predicts the tapped level when refreshing past activities', async () => {
         const { getByText } = render(<RouteDetailsDialog routeId="r1" onStart={jest.fn()} />);
         mockActivityListService.getPastActivitiesWithDetails.mockClear();

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.test.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.test.tsx
@@ -65,6 +65,16 @@ const mockCard: any = {
     getCurrentDownload: jest.fn(() => null),
     changeSettings: jest.fn(),
     getSmoothingPreview: jest.fn(() => ({})),
+    // real behaviour mocked here, not re-tested: RouteCardSmoothing.unit.test.ts (services) covers
+    // the actual prediction rule (architecture.md §9.6.3). Reads openSettings() at call time, not
+    // at mock-definition time, so it respects whatever a test has reconfigured it to return.
+    getPrevRidesFilter: jest.fn((settings: any) => ({
+        routeHash: mockRouteData.description?.routeHash,
+        startPos: settings?.startPos,
+        endPos: settings?.endPos,
+        realityFactor: settings?.realityFactor,
+        smoothingLevel: mockCard.openSettings()?.smoothingAvailable ? (settings?.smoothingLevel ?? 0) : 0,
+    })),
     start: jest.fn(),
     cancel: jest.fn(),
     addWorkout: jest.fn(),

--- a/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsDialog.tsx
@@ -68,27 +68,13 @@ export const RouteDetailsDialog = ({ routeId, onStart }: RouteDetailsDialogProps
         return null
     });
 
+    // The criteria (including the smoothing-level eligibility prediction) are built by the card,
+    // not re-derived here - see RouteCard.getPrevRidesFilter().
     const refreshPrevRides = useCallback(async (settings: UIRouteSettings) => {
         if (!card) return { prevRides: undefined, showPrev: false };
-        const data = card.getData();
-        const routeHash = data.description.routeHash;
-        const rId = !routeHash ? data.description.id : undefined;
 
-        // a prediction, not yet a fact: no ride copy exists before Start, so this mirrors what
-        // buildRideRoute() would actually apply - unsmoothed unless the route is genuinely
-        // eligible. Read fresh from the card rather than component state, matching getData()
-        // above. See design/features/route-smoothing/architecture.md §9.5.
-        const smoothingAvailable = card.openSettings()?.smoothingAvailable;
-        const smoothingLevel = smoothingAvailable ? (settings.smoothingLevel ?? 0) : 0;
-
-        const prev = await activities.getPastActivitiesWithDetails({
-            routeHash,
-            routeId: rId,
-            startPos: settings.startPos?.value,
-            endPos: settings.endPos?.value,
-            realityFactor: settings.realityFactor,
-            smoothingLevel
-        });
+        const filter = card.getPrevRidesFilter(settings);
+        const prev = await activities.getPastActivitiesWithDetails(filter);
 
         if (!refMounted.current) return { prevRides: undefined, showPrev: false };
 

--- a/src/components/RouteDetailsDialog/RouteDetailsView.tsx
+++ b/src/components/RouteDetailsDialog/RouteDetailsView.tsx
@@ -83,8 +83,9 @@ const MEDIA_ROW_GAP = 10;
  * so this is the same shape a ride fills full-screen) rather than stretched to whatever the row's
  * height cap leaves. Uncapped, containerWidth*(H/W) resolves to roughly half the screen height on
  * every device - on the `full` layout that starves the settings form below it regardless of
- * aspect ratio, so it's capped to 30% of screen height first (ux.md §13.8's measured budget), and
- * each box is then fitted within that cap, never driving it.
+ * aspect ratio, so it's capped to 30% of screen height first (a budget measured against real
+ * on-device layouts so the form below always has room), and each box is then fitted within that
+ * cap, never driving it.
  *
  * The graph reads as a chart, not a full-screen surface, so it doesn't need that same aspect
  * ratio - it takes whatever width is left over once the map/still boxes are placed, which is
@@ -252,9 +253,9 @@ const RouteDetailsSettingsForm = (props: SettingsFormProps) => {
                     )}
                 </>
             ) : (
-                // full: Start / End / Reality share one row (ux.md §13.8) - End renders as an
-                // empty cell rather than being absent when there is no segment, so Reality's
-                // column never shifts depending on whether a segment is picked.
+                // full: Start / End / Reality share one row - End renders as an empty cell rather
+                // than being absent when there is no segment, so Reality's column never shifts
+                // depending on whether a segment is picked.
                 <View style={styles.inputRow}>
                     <View style={styles.editNumberWrapper}>
                         <EditNumber
@@ -823,9 +824,9 @@ const styles = StyleSheet.create({
     smoothingCopy: { color: colors.text, fontSize: 12, opacity: 0.8 },
     smoothingCopyMuted: { color: colors.disabled, fontSize: 11, marginTop: 2 },
     switchGrid: { gap: 4 },
-    // full only (ux.md §13.8): each toggle is a full labelled ChipSelect at ~46px, not the ~26px
-    // iOS-style switch the mockups assumed - stacked, three of them cost 138px this form doesn't
-    // have. Wrapping lets 2-3 share a row on any real tablet width instead of stacking or clipping.
+    // full only: each toggle is a full labelled ChipSelect at ~46px, not the ~26px iOS-style
+    // switch the mockups assumed - stacked, three of them cost 138px this form doesn't have.
+    // Wrapping lets 2-3 share a row on any real tablet width instead of stacking or clipping.
     switchGridFull: { flexDirection: 'row', flexWrap: 'wrap', columnGap: 28, rowGap: 4 },
     // flex: 1 lets compactRoot fill whatever's left of Dialog's definite-height content area
     // (scrollable=false -> View with flexGrow: 1, instead of a height-agnostic ScrollView) after


### PR DESCRIPTION
## Summary

Follow-up to `#447`. Replaces the hand-built previous-rides criteria object in
`refreshPrevRides()` with a call to the new `RouteCard.getPrevRidesFilter()`
(`incyclist/services#587`), matching the same change in `web-ui`.

Depends on `incyclist/services#587` (not yet published) - typecheck against the
currently-published `incyclist-services` won't have this method until that ships.

## What changed

- `refreshPrevRides()` now calls `card.getPrevRidesFilter(settings)` and passes the result
  straight to `activities.getPastActivitiesWithDetails()`.
- **Side effect worth flagging**: this also fixes a latent `startPos`/`endPos` unit bug. The old
  code passed `settings.startPos?.value` as a bare number - whatever unit the UI happened to be
  displaying in (e.g. km) - into a criterion that `services`' `db.ts` compares directly against
  activities' `startPos` (stored in metres) with **no unit conversion** when given a raw number.
  The shared builder passes the whole `{value, unit}` object instead, which `db.ts`'s existing
  branch already converts correctly - matching how `web-ui` always did it. Previously this would
  have silently under-matched previous rides on mobile whenever the display unit wasn't already
  metres.

## Test plan

- `npx jest src/components/RouteDetailsDialog` - 81 passing, unchanged count (mock updated to
  reproduce the same prediction rule, now via `getPrevRidesFilter` instead of inline logic)
- `npx tsc --noEmit` - one new error (`getPrevRidesFilter` not on the published `RouteCard` type),
  same category as every other unpublished-`services`-API gap on this feature; everything else
  that used to show as pre-existing here is now clean, since `services@1.7.132` (the whole
  smoothing feature) is published and this repo is pinned to it
