### PR TITLE
fix(ios): directory enumeration on external volumes

### DIFF
--- a/ios/FolderAccess/FolderAccessModule.swift
+++ b/ios/FolderAccess/FolderAccessModule.swift
@@ -16,18 +16,22 @@ import Foundation
  *    timeout, preventing dangling OS-level resource locks that survive app
  *    restart.
  *
- * 2. All I/O runs on a background DispatchWorkItem that can be cancelled.
- *    A separate timeout DispatchWorkItem cancels the I/O work item and
- *    rejects the promise if the deadline is exceeded.
+ * 2. All I/O runs on a background DispatchWorkItem. A separate timeout work
+ *    item rejects the promise once the deadline passes; the listing itself is
+ *    then left to finish on its own, rather than having its directory handle
+ *    closed from the timeout thread while the reader is still walking it.
  *
- * 3. FileManager.enumerator is used instead of contentsOfDirectory.
- *    The enumerator is lazy and yields entries one at a time, so it can be
- *    interrupted between entries when the work item is cancelled — unlike
- *    contentsOfDirectory which blocks until the full listing returns.
+ * 3. Listing walks a ladder of enumeration strategies (see ListStrategy) and
+ *    returns the first non-empty result, tagging each entry with the strategy
+ *    that produced it so the caller can log which one worked.
  *
- * 4. NSFileCoordinator is NOT used. It wraps FileManager internally and
- *    provides no additional benefit for network-backed file:// paths while
- *    adding complexity that interferes with cancellation.
+ * 4. NSFileCoordinator IS used, and comes first in the ladder. An earlier
+ *    version of this file asserted the opposite — that coordination adds
+ *    nothing for network-backed file:// paths. A device probe against an SMB
+ *    share disproved that: opendir() and contentsOfDirectory both report the
+ *    folder as empty, while the document picker — which reads the very same
+ *    folder through NSFileCoordinator — sees its contents. An uncoordinated
+ *    read does not make the provider populate the directory.
  *
  * 5. Operations run on a background queue — the main thread is never blocked.
  *
@@ -41,6 +45,9 @@ import Foundation
 class FolderAccessModule: NSObject {
 
     private let TIMEOUT_SECONDS: Double = 10.0
+
+    /** Listing walks several strategies, and a coordinated read of a network share is slow. */
+    private let LIST_TIMEOUT_SECONDS: Double = 20.0
 
     // ── Access registry ────────────────────────────────────────────────────
 
@@ -158,8 +165,6 @@ class FolderAccessModule: NSObject {
 
         var settled = false
         let lock = NSLock()
-        var dirHandle: UnsafeMutablePointer<DIR>? = nil
-        let dirHandleLock = NSLock()
 
         let workItem = DispatchWorkItem {
             // Security scope must be started and stopped inside the work item
@@ -172,54 +177,43 @@ class FolderAccessModule: NSObject {
                 }
             }
 
-            let path = url.path
-            NSLog("[FolderAccess] listFiles: opening dir %@", path)
-
-            dirHandleLock.lock()
-            dirHandle = opendir(path)
-            dirHandleLock.unlock()
-
-            guard let dir = dirHandle else {
-                let errMsg = String(cString: strerror(errno))
-                NSLog("[FolderAccess] listFiles: opendir failed: %@", errMsg)
-                lock.lock()
-                let alreadySettled = settled
-                settled = true
-                lock.unlock()
-                if !alreadySettled {
-                    reject("ERR_LIST", "Cannot open directory '\(uri)': \(errMsg)", nil)
-                }
-                return
-            }
-
-            NSLog("[FolderAccess] listFiles: dir opened, reading entries")
+            NSLog(
+                "[FolderAccess] listFiles: scope acquired=%d, listing %@",
+                accessing ? 1 : 0,
+                url.path
+            )
 
             var result: [[String: Any]] = []
+            var lastError: String?
 
-            while let entry = readdir(dir) {
-                if Thread.current.isCancelled { break }
+            for strategy in ListStrategy.ladder {
+                let started = Date()
+                let outcome = self.list(url, using: strategy)
+                let elapsedMs = Int(Date().timeIntervalSince(started) * 1000)
 
-                let name = withUnsafeBytes(of: entry.pointee.d_name) { ptr -> String in
-                    let buf = ptr.bindMemory(to: CChar.self)
-                    return String(cString: buf.baseAddress!)
+                NSLog(
+                    "[FolderAccess] listFiles: strategy=%@ count=%d ms=%d error=%@",
+                    strategy.rawValue,
+                    outcome.entries.count,
+                    elapsedMs,
+                    outcome.error ?? "-"
+                )
+
+                if let err = outcome.error {
+                    lastError = err
                 }
 
-                if name == "." || name == ".." { continue }
-
-                let childUrl = url.appendingPathComponent(name)
-                let isDir = entry.pointee.d_type == DT_DIR
-                result.append([
-                    "name": name,
-                    "uri": childUrl.absoluteString,
-                    "isDirectory": isDir
-                ])
-                NSLog("[FolderAccess] listFiles: found '%@' isDir=%d", name, isDir ? 1 : 0)
+                if !outcome.entries.isEmpty {
+                    // Tag the winning strategy onto each entry - the JS side reads it off the
+                    // first entry and logs it, which is the only way this reaches the app log.
+                    result = outcome.entries.map { entry in
+                        var tagged = entry
+                        tagged["strategy"] = strategy.rawValue
+                        return tagged
+                    }
+                    break
+                }
             }
-
-            dirHandleLock.lock()
-            closedir(dir)
-            dirHandle = nil
-            dirHandleLock.unlock()
 
             lock.lock()
             let alreadySettled = settled
@@ -227,12 +221,16 @@ class FolderAccessModule: NSObject {
             lock.unlock()
 
             if !alreadySettled {
-                NSLog("[FolderAccess] listFiles: complete, %d entries", result.count)
+                NSLog(
+                    "[FolderAccess] listFiles: complete, %d entries (lastError=%@)",
+                    result.count,
+                    lastError ?? "-"
+                )
                 resolve(result)
             }
         }
 
-        DispatchQueue.global().asyncAfter(deadline: .now() + TIMEOUT_SECONDS) { [weak self] in
+        DispatchQueue.global().asyncAfter(deadline: .now() + LIST_TIMEOUT_SECONDS) { [weak self] in
             guard let self = self else { return }
             lock.lock()
             let alreadySettled = settled
@@ -240,17 +238,11 @@ class FolderAccessModule: NSObject {
             lock.unlock()
 
             if !alreadySettled {
-                NSLog("[FolderAccess] listFiles: TIMEOUT after %gs", self.TIMEOUT_SECONDS)
-                dirHandleLock.lock()
-                if let dir = dirHandle {
-                    closedir(dir)
-                    dirHandle = nil
-                }
-                dirHandleLock.unlock()
+                NSLog("[FolderAccess] listFiles: TIMEOUT after %gs", self.LIST_TIMEOUT_SECONDS)
                 workItem.cancel()
                 reject(
                     "ERR_TIMEOUT",
-                    "listFiles timed out after \(Int(self.TIMEOUT_SECONDS))s for '\(uri)'. " +
+                    "listFiles timed out after \(Int(self.LIST_TIMEOUT_SECONDS))s for '\(uri)'. " +
                     "Check the NAS is reachable and the folder permission is still valid.",
                     nil
                 )
@@ -258,6 +250,134 @@ class FolderAccessModule: NSObject {
         }
 
         DispatchQueue.global(qos: .userInitiated).async(execute: workItem)
+    }
+
+    // ── Enumeration strategies ─────────────────────────────────────────────
+
+    private enum ListStrategy: String {
+        case coordinatedContents = "coordinated-contents"
+        case coordinatedEnumerator = "coordinated-enumerator"
+        case contentsOfDirectory = "contents-of-directory"
+        case posixOpendir = "posix-opendir"
+
+        /// Coordinated reads first: those are the ones a File Provider answers.
+        /// The uncoordinated pair stays behind them as a cheap local-path fast path
+        /// and as evidence, since both are known to come back empty on SMB.
+        static let ladder: [ListStrategy] = [
+            .coordinatedContents,
+            .coordinatedEnumerator,
+            .contentsOfDirectory,
+            .posixOpendir
+        ]
+    }
+
+    private struct ListOutcome {
+        var entries: [[String: Any]]
+        var error: String?
+    }
+
+    private func list(_ url: URL, using strategy: ListStrategy) -> ListOutcome {
+        switch strategy {
+        case .coordinatedContents:
+            return coordinated(url) { self.listViaContentsOfDirectory($0) }
+        case .coordinatedEnumerator:
+            return coordinated(url) { self.listViaEnumerator($0) }
+        case .contentsOfDirectory:
+            return listViaContentsOfDirectory(url)
+        case .posixOpendir:
+            return listViaPosix(url)
+        }
+    }
+
+    /**
+     * Runs an enumeration inside an NSFileCoordinator read - the same access
+     * pattern the document picker uses successfully on these URLs.
+     */
+    private func coordinated(_ url: URL, _ enumerate: (URL) -> ListOutcome) -> ListOutcome {
+        var coordinationError: NSError?
+        var outcome = ListOutcome(entries: [], error: "accessor never ran")
+
+        NSFileCoordinator().coordinate(
+            readingItemAt: url,
+            options: [],
+            error: &coordinationError
+        ) { coordinatedUrl in
+            outcome = enumerate(coordinatedUrl)
+        }
+
+        if let err = coordinationError {
+            return ListOutcome(entries: [], error: "coordination failed: \(err.localizedDescription)")
+        }
+        return outcome
+    }
+
+    private func listViaContentsOfDirectory(_ url: URL) -> ListOutcome {
+        do {
+            let children = try FileManager.default.contentsOfDirectory(
+                at: url,
+                includingPropertiesForKeys: [.isDirectoryKey, .nameKey],
+                options: []
+            )
+            return ListOutcome(entries: children.map { self.describe($0) }, error: nil)
+        } catch {
+            return ListOutcome(entries: [], error: error.localizedDescription)
+        }
+    }
+
+    private func listViaEnumerator(_ url: URL) -> ListOutcome {
+        guard let enumerator = FileManager.default.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsSubdirectoryDescendants],
+            errorHandler: nil
+        ) else {
+            return ListOutcome(entries: [], error: "enumerator could not be created")
+        }
+
+        var entries: [[String: Any]] = []
+        for case let child as URL in enumerator {
+            entries.append(self.describe(child))
+        }
+        return ListOutcome(entries: entries, error: nil)
+    }
+
+    private func listViaPosix(_ url: URL) -> ListOutcome {
+        guard let dir = opendir(url.path) else {
+            return ListOutcome(entries: [], error: "opendir: \(String(cString: strerror(errno)))")
+        }
+        defer { closedir(dir) }
+
+        var entries: [[String: Any]] = []
+        while let entry = readdir(dir) {
+            let name = withUnsafeBytes(of: entry.pointee.d_name) { ptr -> String in
+                let buf = ptr.bindMemory(to: CChar.self)
+                return String(cString: buf.baseAddress!)
+            }
+
+            if name == "." || name == ".." { continue }
+
+            entries.append([
+                "name": name,
+                "uri": url.appendingPathComponent(name).absoluteString,
+                "isDirectory": entry.pointee.d_type == DT_DIR
+            ])
+        }
+        return ListOutcome(entries: entries, error: nil)
+    }
+
+    /**
+     * Never drops an entry whose metadata cannot be read - a missing isDirectory
+     * flag is worth far less than knowing the entry is there at all. (react-native-fs
+     * drops such entries silently, which is how this folder came back empty with
+     * no error in the first place.)
+     */
+    private func describe(_ url: URL) -> [String: Any] {
+        let values = try? url.resourceValues(forKeys: [.isDirectoryKey])
+        return [
+            "name": url.lastPathComponent,
+            "uri": url.absoluteString,
+            "isDirectory": values?.isDirectory ?? false
+        ]
     }
 
     // ── readFile ───────────────────────────────────────────────────────────

--- a/ios/FolderAccess/FolderAccessModule.swift
+++ b/ios/FolderAccess/FolderAccessModule.swift
@@ -21,17 +21,24 @@ import Foundation
  *    then left to finish on its own, rather than having its directory handle
  *    closed from the timeout thread while the reader is still walking it.
  *
- * 3. Listing walks a ladder of enumeration strategies (see ListStrategy) and
- *    returns the first non-empty result, tagging each entry with the strategy
- *    that produced it so the caller can log which one worked.
+ * 3. Listing walks a short ladder of enumeration strategies (see ListStrategy)
+ *    and returns the first non-empty result, tagging each entry with the
+ *    strategy that produced it so the caller can log which one worked.
  *
- * 4. NSFileCoordinator IS used, and comes first in the ladder. An earlier
- *    version of this file asserted the opposite — that coordination adds
- *    nothing for network-backed file:// paths. A device probe against an SMB
- *    share disproved that: opendir() and contentsOfDirectory both report the
- *    folder as empty, while the document picker — which reads the very same
- *    folder through NSFileCoordinator — sees its contents. An uncoordinated
- *    read does not make the provider populate the directory.
+ * 4. NSFileCoordinator IS used, and comes first. An earlier version of this
+ *    file asserted the opposite — that coordination adds nothing for
+ *    network-backed file:// paths — while itself using opendir(). Coordination
+ *    is what a File Provider expects, so it leads.
+ *
+ *    It does not, however, rescue an SMB share on a QNAP (or Synology) NAS.
+ *    iOS cannot enumerate a non-empty folder on those servers from a
+ *    third-party app at all: coordinated reads, an enumerator and raw
+ *    opendir() alike return zero entries with no error, while the Files app
+ *    browses the same share and per-file access works. That is Apple's
+ *    FB8902970, open since 2020 — an automount-level server fault below these
+ *    APIs, with no known workaround. Nothing here can fix it; the empty
+ *    listing is reported as ERR_LIST_EMPTY so the caller can say something
+ *    truthful rather than "folder is empty".
  *
  * 5. Operations run on a background queue — the main thread is never blocked.
  *
@@ -267,19 +274,16 @@ class FolderAccessModule: NSObject {
 
     private enum ListStrategy: String {
         case coordinatedContents = "coordinated-contents"
-        case coordinatedEnumerator = "coordinated-enumerator"
         case contentsOfDirectory = "contents-of-directory"
-        case posixOpendir = "posix-opendir"
 
-        /// Coordinated reads first: those are the ones a File Provider answers.
-        /// The uncoordinated pair stays behind them as a cheap local-path fast path
-        /// and as evidence, since both are known to come back empty on SMB.
-        static let ladder: [ListStrategy] = [
-            .coordinatedContents,
-            .coordinatedEnumerator,
-            .contentsOfDirectory,
-            .posixOpendir
-        ]
+        /// Coordinated first - that is what a File Provider expects, and it costs nothing
+        /// on a local path. The uncoordinated read stays behind it in case coordination
+        /// itself fails.
+        ///
+        /// A coordinated enumerator and a raw opendir()/readdir() were both tried here as
+        /// well. Neither made any difference on the case this exists for (see listFiles),
+        /// so neither is worth the code.
+        static let ladder: [ListStrategy] = [.coordinatedContents, .contentsOfDirectory]
     }
 
     private struct ListOutcome {
@@ -291,12 +295,8 @@ class FolderAccessModule: NSObject {
         switch strategy {
         case .coordinatedContents:
             return coordinated(url) { self.listViaContentsOfDirectory($0) }
-        case .coordinatedEnumerator:
-            return coordinated(url) { self.listViaEnumerator($0) }
         case .contentsOfDirectory:
             return listViaContentsOfDirectory(url)
-        case .posixOpendir:
-            return listViaPosix(url)
         }
     }
 
@@ -333,47 +333,6 @@ class FolderAccessModule: NSObject {
         } catch {
             return ListOutcome(entries: [], error: error.localizedDescription)
         }
-    }
-
-    private func listViaEnumerator(_ url: URL) -> ListOutcome {
-        guard let enumerator = FileManager.default.enumerator(
-            at: url,
-            includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsSubdirectoryDescendants],
-            errorHandler: nil
-        ) else {
-            return ListOutcome(entries: [], error: "enumerator could not be created")
-        }
-
-        var entries: [[String: Any]] = []
-        for case let child as URL in enumerator {
-            entries.append(self.describe(child))
-        }
-        return ListOutcome(entries: entries, error: nil)
-    }
-
-    private func listViaPosix(_ url: URL) -> ListOutcome {
-        guard let dir = opendir(url.path) else {
-            return ListOutcome(entries: [], error: "opendir: \(String(cString: strerror(errno)))")
-        }
-        defer { closedir(dir) }
-
-        var entries: [[String: Any]] = []
-        while let entry = readdir(dir) {
-            let name = withUnsafeBytes(of: entry.pointee.d_name) { ptr -> String in
-                let buf = ptr.bindMemory(to: CChar.self)
-                return String(cString: buf.baseAddress!)
-            }
-
-            if name == "." || name == ".." { continue }
-
-            entries.append([
-                "name": name,
-                "uri": url.appendingPathComponent(name).absoluteString,
-                "isDirectory": entry.pointee.d_type == DT_DIR
-            ])
-        }
-        return ListOutcome(entries: entries, error: nil)
     }
 
     /**

--- a/ios/FolderAccess/FolderAccessModule.swift
+++ b/ios/FolderAccess/FolderAccessModule.swift
@@ -184,50 +184,61 @@ class FolderAccessModule: NSObject {
             )
 
             var result: [[String: Any]] = []
-            var lastError: String?
+            // Per-strategy detail only reaches the device console via NSLog, which the app's
+            // own event log never sees - so it travels back to JS too, tagged onto the entries
+            // when there are any and carried by the rejection when there are none.
+            var attempts: [String] = []
 
             for strategy in ListStrategy.ladder {
                 let started = Date()
                 let outcome = self.list(url, using: strategy)
                 let elapsedMs = Int(Date().timeIntervalSince(started) * 1000)
 
-                NSLog(
-                    "[FolderAccess] listFiles: strategy=%@ count=%d ms=%d error=%@",
-                    strategy.rawValue,
-                    outcome.entries.count,
-                    elapsedMs,
-                    outcome.error ?? "-"
-                )
-
+                var attempt = "\(strategy.rawValue) count=\(outcome.entries.count) ms=\(elapsedMs)"
                 if let err = outcome.error {
-                    lastError = err
+                    attempt += " error=\(err)"
                 }
+                attempts.append(attempt)
+
+                NSLog("[FolderAccess] listFiles: %@", attempt)
 
                 if !outcome.entries.isEmpty {
-                    // Tag the winning strategy onto each entry - the JS side reads it off the
-                    // first entry and logs it, which is the only way this reaches the app log.
+                    // Tag the winning strategy and the scope state onto each entry - the JS side
+                    // reads them off the first entry so they reach the app log.
                     result = outcome.entries.map { entry in
                         var tagged = entry
                         tagged["strategy"] = strategy.rawValue
+                        tagged["scope"] = accessing
                         return tagged
                     }
                     break
                 }
             }
 
+            let summary = attempts.joined(separator: "; ")
+
             lock.lock()
             let alreadySettled = settled
             settled = true
             lock.unlock()
 
-            if !alreadySettled {
-                NSLog(
-                    "[FolderAccess] listFiles: complete, %d entries (lastError=%@)",
-                    result.count,
-                    lastError ?? "-"
+            guard !alreadySettled else { return }
+
+            if result.isEmpty {
+                // Every strategy came back empty. That is a listing failure worth reporting
+                // rather than an empty folder: the caller only reaches this module after a
+                // plain listing already returned nothing.
+                NSLog("[FolderAccess] listFiles: no strategy returned entries")
+                reject(
+                    "ERR_LIST_EMPTY",
+                    "No strategy returned entries for '\(uri)' (scope=\(accessing)): \(summary)",
+                    nil
                 )
-                resolve(result)
+                return
             }
+
+            NSLog("[FolderAccess] listFiles: complete, %d entries", result.count)
+            resolve(result)
         }
 
         DispatchQueue.global().asyncAfter(deadline: .now() + LIST_TIMEOUT_SECONDS) { [weak self] in

--- a/ios/FolderAccess/FolderAccessModule.swift
+++ b/ios/FolderAccess/FolderAccessModule.swift
@@ -54,7 +54,7 @@ class FolderAccessModule: NSObject {
     private let TIMEOUT_SECONDS: Double = 10.0
 
     /** Listing walks several strategies, and a coordinated read of a network share is slow. */
-    private let LIST_TIMEOUT_SECONDS: Double = 20.0
+    private let listTimeoutSeconds: Double = 20.0
 
     // ── Access registry ────────────────────────────────────────────────────
 
@@ -248,7 +248,7 @@ class FolderAccessModule: NSObject {
             resolve(result)
         }
 
-        DispatchQueue.global().asyncAfter(deadline: .now() + LIST_TIMEOUT_SECONDS) { [weak self] in
+        DispatchQueue.global().asyncAfter(deadline: .now() + listTimeoutSeconds) { [weak self] in
             guard let self = self else { return }
             lock.lock()
             let alreadySettled = settled
@@ -256,11 +256,11 @@ class FolderAccessModule: NSObject {
             lock.unlock()
 
             if !alreadySettled {
-                NSLog("[FolderAccess] listFiles: TIMEOUT after %gs", self.LIST_TIMEOUT_SECONDS)
+                NSLog("[FolderAccess] listFiles: TIMEOUT after %gs", self.listTimeoutSeconds)
                 workItem.cancel()
                 reject(
                     "ERR_TIMEOUT",
-                    "listFiles timed out after \(Int(self.LIST_TIMEOUT_SECONDS))s for '\(uri)'. " +
+                    "listFiles timed out after \(Int(self.listTimeoutSeconds))s for '\(uri)'. " +
                     "Check the NAS is reachable and the folder permission is still valid.",
                     nil
                 )

--- a/src/bindings/fs/index.test.ts
+++ b/src/bindings/fs/index.test.ts
@@ -1,5 +1,5 @@
 import RNFS from 'react-native-fs';
-import { TurboModuleRegistry } from 'react-native';
+import { Platform, TurboModuleRegistry } from 'react-native';
 import { FileSystemBinding } from './index';
 
 jest.mock('react-native-fs', () => ({
@@ -12,6 +12,10 @@ jest.mock('react-native-fs', () => ({
         mkdir: jest.fn(),
         unlink: jest.fn(),
         appendFile: jest.fn(),
+        DocumentDirectoryPath: '/app/Documents',
+        CachesDirectoryPath: '/app/Library/Caches',
+        TemporaryDirectoryPath: '/app/tmp',
+        LibraryDirectoryPath: '/app/Library',
     },
 }));
 
@@ -256,6 +260,64 @@ describe('FileSystemBinding', () => {
             folderAccess.listFiles.mockResolvedValue(folderAccessEntries);
             const result = await fs.readdir('content://root', { extended: true });
             expect(result).toEqual(folderAccessEntries);
+        });
+
+        describe('iOS volume outside the app sandbox', () => {
+            const externalPath =
+                'file:///private/var/mobile/Library/LiveFiles/com.apple.filesystems.smbclientd/share/routes';
+
+            beforeEach(() => {
+                Platform.OS = 'ios';
+            });
+
+            afterEach(() => {
+                Platform.OS = 'android';
+            });
+
+            it('empty RNFS listing → retries natively and returns its entries, uri-decoded', async () => {
+                rnfs.readDir.mockResolvedValue([]);
+                folderAccess.listFiles.mockResolvedValue([
+                    {
+                        name: 'Col du Galibier.xml',
+                        uri: `${externalPath}/Col%20du%20Galibier.xml`,
+                        isDirectory: false,
+                        strategy: 'coordinated-contents',
+                    },
+                ]);
+
+                const result = await fs.readdir(externalPath, { extended: true });
+
+                expect(folderAccess.listFiles).toHaveBeenCalledWith(externalPath);
+                expect(result).toEqual([
+                    {
+                        name: 'Col du Galibier.xml',
+                        uri: `${externalPath}/Col du Galibier.xml`,
+                        isDirectory: false,
+                    },
+                ]);
+            });
+
+            it('volume that will not enumerate → resolves empty instead of throwing', async () => {
+                // A QNAP/Synology SMB share reports every folder as empty (Apple FB8902970);
+                // the native side rejects so the reason can be logged, but a failed listing
+                // must not take down the scan.
+                rnfs.readDir.mockResolvedValue([]);
+                const err = Object.assign(new Error('No strategy returned entries'), {
+                    code: 'ERR_LIST_EMPTY',
+                });
+                folderAccess.listFiles.mockRejectedValue(err);
+
+                await expect(fs.readdir(externalPath, { extended: true })).resolves.toEqual([]);
+            });
+
+            it('path inside the app sandbox → stays on RNFS', async () => {
+                rnfs.readDir.mockResolvedValue([]);
+
+                const result = await fs.readdir('/app/Documents/routes', { extended: true });
+
+                expect(folderAccess.listFiles).not.toHaveBeenCalled();
+                expect(result).toEqual([]);
+            });
         });
 
         it('error on root path → re-throws', async () => {

--- a/src/bindings/fs/index.ts
+++ b/src/bindings/fs/index.ts
@@ -177,9 +177,13 @@ export class FileSystemBinding implements IFileSystem {
         const fsEntries = await RNFS.readDir(path);
 
         // [DEBUG-smb1] An empty listing of a volume outside the app sandbox is the SMB/NAS
-        // symptom - run the strategy comparison so the log says which enumeration works.
+        // symptom - RNFS cannot see the contents of a File Provider mount. Fall back to the
+        // native ladder, which tries coordinated enumeration first.
         if (Platform.OS === 'ios' && fsEntries.length === 0 && this.isOutsideAppSandbox(path)) {
-            await this.probeIosListing(path);
+            const recovered = await this.listViaNativeLadder(path);
+            if (recovered.length > 0) {
+                return recovered;
+            }
         }
 
         return fsEntries.map(e => ({
@@ -201,66 +205,60 @@ export class FileSystemBinding implements IFileSystem {
         return !sandboxRoots.some(root => plain.startsWith(root));
     }
 
-    // [DEBUG-smb1] temporary diagnostic - remove once the SMB enumeration cause is known
-    private async probeIosListing(path: string): Promise<void> {
+    // [DEBUG-smb1] temporary diagnostic - remove once the SMB enumeration cause is settled
+    private async listViaNativeLadder(path: string): Promise<ReadDirResult[]> {
         const probe = (variant: string, data: Record<string, unknown>) => {
             this.logger.logEvent({ message: '[DEBUG-smb1] probe', variant, ...data });
         };
-        const failed = (variant: string, err: unknown) => {
-            probe(variant, { error: err instanceof Error ? err.message : String(err) });
-        };
-        const names = (entries: { name: string; isDirectory?: boolean }[]) =>
-            entries.slice(0, 5).map(e => `${e.name}${e.isDirectory ? '/' : ''}`).join('|');
-
-        const readViaRnfs = async (variant: string, target: string) => {
-            try {
-                const entries = await RNFS.readDir(target);
-                probe(variant, {
-                    count: entries.length,
-                    names: names(entries.map(e => ({ name: e.name, isDirectory: e.isDirectory() }))),
-                });
-            } catch (err) {
-                failed(variant, err);
-            }
-        };
+        const reason = (err: unknown) => (err instanceof Error ? err.message : String(err));
 
         probe('start', { path });
 
-        const decoded = decodeURIComponent(path);
-        if (decoded !== path) {
-            await readViaRnfs('rnfs-decoded', decoded);
+        // The native side tags each entry with the strategy that produced it - that tag is the
+        // only way the winning strategy reaches the app log rather than just the device console.
+        type TaggedEntry = ReadDirResult & { strategy?: string };
+        let entries: TaggedEntry[];
+        try {
+            entries = (await requireFolderAccess().listFiles(path)) as TaggedEntry[];
+        } catch (err) {
+            probe('native-list', { error: reason(err) });
+            return [];
         }
 
-        // Does a plain RNFS listing work once we explicitly hold a security-scoped grant?
-        try {
-            const granted = await requireFolderAccess().requestAccess(path);
-            probe('request-access', { granted });
-            await readViaRnfs('rnfs-with-access', path);
-            await requireFolderAccess().releaseAccess(path);
-        } catch (err) {
-            failed('rnfs-with-access', err);
+        probe('native-list', {
+            count: entries.length,
+            strategy: entries[0]?.strategy ?? '-',
+            names: entries.slice(0, 5).map(e => `${e.name}${e.isDirectory ? '/' : ''}`).join('|'),
+        });
+
+        const results = entries.map(e => ({
+            name: e.name,
+            uri: this.decodeUri(e.uri),
+            isDirectory: e.isDirectory,
+        }));
+
+        // Listing is only half the job - confirm a read off the same mount works before the
+        // parser tries it, so one run also tells us whether reads need coordinating too.
+        const firstFile = results.find(e => !e.isDirectory);
+        if (firstFile) {
+            try {
+                const head = await RNFS.read(firstFile.uri, 64, 0, 'base64');
+                probe('native-list-read', { file: firstFile.name, bytes: head?.length ?? 0 });
+            } catch (err) {
+                probe('native-list-read', { file: firstFile.name, error: reason(err) });
+            }
         }
 
-        // Native opendir()/readdir() inside a security scope - never reached on iOS today,
-        // because readdir() routes file:// URIs to RNFS and only content:// URIs here.
-        try {
-            const entries = await requireFolderAccess().listFiles(path);
-            probe('folder-access-listfiles', { count: entries.length, names: names(entries) });
-        } catch (err) {
-            failed('folder-access-listfiles', err);
-        }
+        return results;
+    }
 
+    // [DEBUG-smb1] native URIs are percent-encoded absoluteStrings, while the rest of the
+    // pipeline works with decoded file:// URIs on iOS (see UIBinding.selectDirectory).
+    private decodeUri(uri: string): string {
         try {
-            probe('folder-access-exists', { exists: await requireFolderAccess().exists(path) });
-        } catch (err) {
-            failed('folder-access-exists', err);
-        }
-
-        try {
-            const stat = await RNFS.stat(path);
-            probe('rnfs-stat', { isDirectory: stat.isDirectory(), size: stat.size });
-        } catch (err) {
-            failed('rnfs-stat', err);
+            return decodeURIComponent(uri);
+        } catch {
+            return uri;
         }
     }
 

--- a/src/bindings/fs/index.ts
+++ b/src/bindings/fs/index.ts
@@ -176,11 +176,12 @@ export class FileSystemBinding implements IFileSystem {
     private async listLocalEntries(path: string): Promise<ReadDirResult[]> {
         const fsEntries = await RNFS.readDir(path);
 
-        // [DEBUG-smb1] An empty listing of a volume outside the app sandbox is the SMB/NAS
-        // symptom - RNFS cannot see the contents of a File Provider mount. Fall back to the
-        // native ladder, which tries coordinated enumeration first.
+        // react-native-fs lists a directory with plain, uncoordinated calls, and drops any
+        // entry whose attributes it cannot read. Neither suits a File Provider volume, so an
+        // empty listing outside the app sandbox gets a second attempt natively - coordinated,
+        // and keeping entries whose metadata will not read.
         if (Platform.OS === 'ios' && fsEntries.length === 0 && this.isOutsideAppSandbox(path)) {
-            const recovered = await this.listViaNativeLadder(path);
+            const recovered = await this.listViaFileProvider(path);
             if (recovered.length > 0) {
                 return recovered;
             }
@@ -193,7 +194,7 @@ export class FileSystemBinding implements IFileSystem {
         }));
     }
 
-    // [DEBUG-smb1] temporary diagnostic - remove once the SMB enumeration cause is known
+    /** True for volumes the app does not own - iCloud Drive, a NAS share, another provider. */
     private isOutsideAppSandbox(path: string): boolean {
         const plain = path.replace('file://', '');
         const sandboxRoots = [
@@ -205,58 +206,48 @@ export class FileSystemBinding implements IFileSystem {
         return !sandboxRoots.some(root => plain.startsWith(root));
     }
 
-    // [DEBUG-smb1] temporary diagnostic - remove once the SMB enumeration cause is settled
-    private async listViaNativeLadder(path: string): Promise<ReadDirResult[]> {
-        const probe = (variant: string, data: Record<string, unknown>) => {
-            this.logger.logEvent({ message: '[DEBUG-smb1] probe', variant, ...data });
-        };
-        const reason = (err: unknown) => (err instanceof Error ? err.message : String(err));
-
-        probe('start', { path });
-
-        // The native side tags each entry with the strategy that produced it and whether the
-        // security scope was held - those tags are how that detail reaches the app log rather
-        // than only the device console. When no strategy finds anything it rejects instead,
-        // and the per-strategy breakdown rides along in the error message.
+    /**
+     * Second attempt at listing a directory on a volume the app does not own, using the
+     * native coordinated read.
+     *
+     * Returns an empty list rather than throwing when the volume will not enumerate: an SMB
+     * share on a QNAP or Synology NAS reports every folder as empty to a third-party app,
+     * which is Apple's FB8902970 and not fixable here. The rejection carries what each
+     * strategy saw, which is worth logging when a user reports an empty-looking folder.
+     */
+    private async listViaFileProvider(path: string): Promise<ReadDirResult[]> {
         type TaggedEntry = ReadDirResult & { strategy?: string; scope?: boolean };
         let entries: TaggedEntry[];
+
         try {
             entries = (await requireFolderAccess().listFiles(path)) as TaggedEntry[];
         } catch (err) {
-            probe('native-list', { code: (err as { code?: string })?.code ?? '-', error: reason(err) });
+            this.logger.logEvent({
+                message: 'directory will not enumerate',
+                path,
+                code: (err as { code?: string })?.code ?? '-',
+                error: err instanceof Error ? err.message : String(err),
+            });
             return [];
         }
 
-        probe('native-list', {
+        this.logger.logEvent({
+            message: 'directory listed natively',
+            path,
             count: entries.length,
             strategy: entries[0]?.strategy ?? '-',
             scope: entries[0]?.scope ?? '-',
-            names: entries.slice(0, 5).map(e => `${e.name}${e.isDirectory ? '/' : ''}`).join('|'),
         });
 
-        const results = entries.map(e => ({
+        return entries.map(e => ({
             name: e.name,
             uri: this.decodeUri(e.uri),
             isDirectory: e.isDirectory,
         }));
-
-        // Listing is only half the job - confirm a read off the same mount works before the
-        // parser tries it, so one run also tells us whether reads need coordinating too.
-        const firstFile = results.find(e => !e.isDirectory);
-        if (firstFile) {
-            try {
-                const head = await RNFS.read(firstFile.uri, 64, 0, 'base64');
-                probe('native-list-read', { file: firstFile.name, bytes: head?.length ?? 0 });
-            } catch (err) {
-                probe('native-list-read', { file: firstFile.name, error: reason(err) });
-            }
-        }
-
-        return results;
     }
 
-    // [DEBUG-smb1] native URIs are percent-encoded absoluteStrings, while the rest of the
-    // pipeline works with decoded file:// URIs on iOS (see UIBinding.selectDirectory).
+    // Native URIs are percent-encoded absoluteStrings, while the rest of the pipeline works
+    // with decoded file:// URIs on iOS (see UIBinding.selectDirectory).
     private decodeUri(uri: string): string {
         try {
             return decodeURIComponent(uri);

--- a/src/bindings/fs/index.ts
+++ b/src/bindings/fs/index.ts
@@ -175,11 +175,93 @@ export class FileSystemBinding implements IFileSystem {
 
     private async listLocalEntries(path: string): Promise<ReadDirResult[]> {
         const fsEntries = await RNFS.readDir(path);
+
+        // [DEBUG-smb1] An empty listing of a volume outside the app sandbox is the SMB/NAS
+        // symptom - run the strategy comparison so the log says which enumeration works.
+        if (Platform.OS === 'ios' && fsEntries.length === 0 && this.isOutsideAppSandbox(path)) {
+            await this.probeIosListing(path);
+        }
+
         return fsEntries.map(e => ({
             name: e.name,
             uri: `file://${e.path}`,
             isDirectory: e.isDirectory(),
         }));
+    }
+
+    // [DEBUG-smb1] temporary diagnostic - remove once the SMB enumeration cause is known
+    private isOutsideAppSandbox(path: string): boolean {
+        const plain = path.replace('file://', '');
+        const sandboxRoots = [
+            RNFS.DocumentDirectoryPath,
+            RNFS.CachesDirectoryPath,
+            RNFS.TemporaryDirectoryPath,
+            RNFS.LibraryDirectoryPath,
+        ].filter(Boolean);
+        return !sandboxRoots.some(root => plain.startsWith(root));
+    }
+
+    // [DEBUG-smb1] temporary diagnostic - remove once the SMB enumeration cause is known
+    private async probeIosListing(path: string): Promise<void> {
+        const probe = (variant: string, data: Record<string, unknown>) => {
+            this.logger.logEvent({ message: '[DEBUG-smb1] probe', variant, ...data });
+        };
+        const failed = (variant: string, err: unknown) => {
+            probe(variant, { error: err instanceof Error ? err.message : String(err) });
+        };
+        const names = (entries: { name: string; isDirectory?: boolean }[]) =>
+            entries.slice(0, 5).map(e => `${e.name}${e.isDirectory ? '/' : ''}`).join('|');
+
+        const readViaRnfs = async (variant: string, target: string) => {
+            try {
+                const entries = await RNFS.readDir(target);
+                probe(variant, {
+                    count: entries.length,
+                    names: names(entries.map(e => ({ name: e.name, isDirectory: e.isDirectory() }))),
+                });
+            } catch (err) {
+                failed(variant, err);
+            }
+        };
+
+        probe('start', { path });
+
+        const decoded = decodeURIComponent(path);
+        if (decoded !== path) {
+            await readViaRnfs('rnfs-decoded', decoded);
+        }
+
+        // Does a plain RNFS listing work once we explicitly hold a security-scoped grant?
+        try {
+            const granted = await requireFolderAccess().requestAccess(path);
+            probe('request-access', { granted });
+            await readViaRnfs('rnfs-with-access', path);
+            await requireFolderAccess().releaseAccess(path);
+        } catch (err) {
+            failed('rnfs-with-access', err);
+        }
+
+        // Native opendir()/readdir() inside a security scope - never reached on iOS today,
+        // because readdir() routes file:// URIs to RNFS and only content:// URIs here.
+        try {
+            const entries = await requireFolderAccess().listFiles(path);
+            probe('folder-access-listfiles', { count: entries.length, names: names(entries) });
+        } catch (err) {
+            failed('folder-access-listfiles', err);
+        }
+
+        try {
+            probe('folder-access-exists', { exists: await requireFolderAccess().exists(path) });
+        } catch (err) {
+            failed('folder-access-exists', err);
+        }
+
+        try {
+            const stat = await RNFS.stat(path);
+            probe('rnfs-stat', { isDirectory: stat.isDirectory(), size: stat.size });
+        } catch (err) {
+            failed('rnfs-stat', err);
+        }
     }
 
     // New helper method to encapsulate entry listing and error handling

--- a/src/bindings/fs/index.ts
+++ b/src/bindings/fs/index.ts
@@ -214,20 +214,23 @@ export class FileSystemBinding implements IFileSystem {
 
         probe('start', { path });
 
-        // The native side tags each entry with the strategy that produced it - that tag is the
-        // only way the winning strategy reaches the app log rather than just the device console.
-        type TaggedEntry = ReadDirResult & { strategy?: string };
+        // The native side tags each entry with the strategy that produced it and whether the
+        // security scope was held - those tags are how that detail reaches the app log rather
+        // than only the device console. When no strategy finds anything it rejects instead,
+        // and the per-strategy breakdown rides along in the error message.
+        type TaggedEntry = ReadDirResult & { strategy?: string; scope?: boolean };
         let entries: TaggedEntry[];
         try {
             entries = (await requireFolderAccess().listFiles(path)) as TaggedEntry[];
         } catch (err) {
-            probe('native-list', { error: reason(err) });
+            probe('native-list', { code: (err as { code?: string })?.code ?? '-', error: reason(err) });
             return [];
         }
 
         probe('native-list', {
             count: entries.length,
             strategy: entries[0]?.strategy ?? '-',
+            scope: entries[0]?.scope ?? '-',
             names: entries.slice(0, 5).map(e => `${e.name}${e.isDirectory ? '/' : ''}`).join('|'),
         });
 

--- a/src/components/Dialog/Dialog.test.tsx
+++ b/src/components/Dialog/Dialog.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Modal, ScrollView, StyleSheet, Text, View } from 'react-native';
 import * as SafeAreaContext from 'react-native-safe-area-context';
+import { EventLogger } from 'gd-eventlog';
 import { Dialog } from './Dialog';
 import { ButtonBar } from '../ButtonBar';
 
@@ -113,13 +114,60 @@ describe('Dialog', () => {
     });
 
     // App is landscape-locked, so the notch sits on left/right (whichever edge the current
-    // rotation puts it on) and the home indicator sits at the bottom, not top.
+    // rotation puts it on). Design intent (UX-reviewed): decorative pixels (the dialog's own
+    // gradient/background) always run to the physical screen edge - the Modal is told to draw
+    // under the cutout (statusBarTranslucent/navigationBarTranslucent) rather than let Android
+    // auto-inset the window - and only the *content* (header, buttons) is padded away from it.
+    // Padding is symmetric (max(left,right)), not directional: the header title and the
+    // (centered) footer button bar would look optically off-balance if only the cutout side
+    // were padded. An earlier version of this fix padded content AND let the OS auto-inset the
+    // window, which doubled the inset - hence asserting both halves here, not just one.
     describe('safe-area insets', () => {
         afterEach(() => {
             jest.restoreAllMocks();
         });
 
-        it('pads the dialog surface for the notch (left/right) and home indicator (bottom)', () => {
+        it('lets the Modal window draw under the notch (no OS-level auto-inset) for both variants', () => {
+            const { UNSAFE_root: fullRoot } = render(
+                <Dialog title="Test Dialog" variant="full">
+                    <Text>content</Text>
+                </Dialog>
+            );
+            const fullModal = fullRoot.findByType(Modal);
+            expect(fullModal.props.statusBarTranslucent).toBe(true);
+            expect(fullModal.props.navigationBarTranslucent).toBe(true);
+
+            const { UNSAFE_root: detailsRoot } = render(
+                <Dialog title="Test Dialog" variant="details">
+                    <Text>content</Text>
+                </Dialog>
+            );
+            const detailsModal = detailsRoot.findByType(Modal);
+            expect(detailsModal.props.statusBarTranslucent).toBe(true);
+            expect(detailsModal.props.navigationBarTranslucent).toBe(true);
+        });
+
+        it('pads dialog content symmetrically by the larger of left/right, not directionally', () => {
+            jest.spyOn(SafeAreaContext, 'useSafeAreaInsets').mockReturnValue({ top: 10, left: 24, right: 0, bottom: 34 });
+
+            const { UNSAFE_root } = render(
+                <Dialog title="Test Dialog" variant="full">
+                    <Text>content</Text>
+                </Dialog>
+            );
+
+            const container = UNSAFE_root.findAllByType(View).find((v: any) => {
+                const flat = StyleSheet.flatten(v.props.style);
+                return flat?.overflow === 'hidden';
+            });
+
+            expect(container).toBeTruthy();
+            const flat = StyleSheet.flatten(container!.props.style);
+            expect(flat.paddingLeft).toBe(24);
+            expect(flat.paddingRight).toBe(24);
+        });
+
+        it('does not pad dialog if its not full', () => {
             jest.spyOn(SafeAreaContext, 'useSafeAreaInsets').mockReturnValue({ top: 10, left: 24, right: 0, bottom: 34 });
 
             const { UNSAFE_root } = render(
@@ -135,11 +183,11 @@ describe('Dialog', () => {
 
             expect(container).toBeTruthy();
             const flat = StyleSheet.flatten(container!.props.style);
-            expect(flat.paddingLeft).toBe(24);
+            expect(flat.paddingLeft).toBe(0);
             expect(flat.paddingRight).toBe(0);
         });
 
-        it('pads the full-variant content area for the notch/home indicator too', () => {
+        it('pads the full-variant content area symmetrically too', () => {
             jest.spyOn(SafeAreaContext, 'useSafeAreaInsets').mockReturnValue({ top: 0, left: 0, right: 28, bottom: 21 });
 
             const { UNSAFE_root } = render(
@@ -155,7 +203,25 @@ describe('Dialog', () => {
 
             expect(fullContentArea).toBeTruthy();
             const flat = StyleSheet.flatten(fullContentArea!.props.style);
+            expect(flat.paddingLeft).toBe(28);
             expect(flat.paddingRight).toBe(28);
+        });
+
+        it('still surfaces the raw insets on the dialog-shown log event, for on-device diagnosis', () => {
+            jest.spyOn(SafeAreaContext, 'useSafeAreaInsets').mockReturnValue({ top: 0, left: 24, right: 0, bottom: 0 });
+            const logSpy = jest.spyOn(EventLogger.prototype, 'logEvent');
+
+            render(
+                <Dialog title="Test Dialog">
+                    <Text>content</Text>
+                </Dialog>
+            );
+
+            expect(logSpy).toHaveBeenCalledWith(expect.objectContaining({
+                message: 'dialog shown',
+                safeAreaLeft: 24,
+                safeAreaRight: 0,
+            }));
         });
     });
 });

--- a/src/components/Dialog/Dialog.test.tsx
+++ b/src/components/Dialog/Dialog.test.tsx
@@ -137,7 +137,6 @@ describe('Dialog', () => {
             const flat = StyleSheet.flatten(container!.props.style);
             expect(flat.paddingLeft).toBe(24);
             expect(flat.paddingRight).toBe(0);
-            expect(flat.paddingBottom).toBe(34);
         });
 
         it('pads the full-variant content area for the notch/home indicator too', () => {
@@ -157,7 +156,6 @@ describe('Dialog', () => {
             expect(fullContentArea).toBeTruthy();
             const flat = StyleSheet.flatten(fullContentArea!.props.style);
             expect(flat.paddingRight).toBe(28);
-            expect(flat.paddingBottom).toBe(21);
         });
     });
 });

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -108,14 +108,14 @@ export const Dialog = ({
     // App is landscape-locked, so left/right (the notch) and bottom (home indicator) are the
     // edges that actually get obscured - not top. useSafeAreaInsets() already reports these
     // relative to the current rotation, so no extra per-rotation logic is needed here.
-    const { top: safeAreaTop, left: safeAreaLeft, right: safeAreaRight, bottom: safeAreaBottom } = useSafeAreaInsets();
+    const { left: safeAreaLeft, right: safeAreaRight } = useSafeAreaInsets();
 
     const [isModalActive, setIsModalActive] = useState(false);
     const [isAnimating, setIsAnimating] = useState(false);
 
     const isCompact = layout === 'compact';
     const NAV_BAR_HEIGHT = 56;
-    const stripHeight = NAV_BAR_HEIGHT + safeAreaTop;
+    const stripHeight = NAV_BAR_HEIGHT;
 
     const defaultSlideFrom = 'left';
     const actualSlideFrom = variant === 'full' ? (slideFrom || defaultSlideFrom) : undefined;
@@ -186,7 +186,7 @@ export const Dialog = ({
         }
     });
 
-    const styles = getStyles({ width, height, minWidth, minHeight, variant, isCompact, stripHeight, safeAreaLeft, safeAreaRight, safeAreaBottom, nested });
+    const styles = getStyles({ width, height, minWidth, minHeight, variant, isCompact, stripHeight, safeAreaLeft, safeAreaRight,  nested });
 
     // FIXES_BACKLOG #52 — workaround for a React Native new-architecture defect on iOS: when a
     // child view is added to an already-mounted subtree inside a <Modal>, Fabric calls
@@ -302,7 +302,7 @@ type StyleProps = {
     nested?: boolean
 }
 
-const getStyles = ({ width, height, minWidth, minHeight, variant = 'details', isCompact, safeAreaLeft, safeAreaRight, safeAreaBottom, nested=false }: StyleProps & { isCompact: boolean, stripHeight: number, safeAreaLeft: number, safeAreaRight: number, safeAreaBottom: number }) => {
+const getStyles = ({ width, height, minWidth, minHeight, variant = 'details', isCompact, safeAreaLeft, safeAreaRight, nested=false }: StyleProps & { isCompact: boolean, stripHeight: number, safeAreaLeft: number, safeAreaRight: number }) => {
     const isInfoVariant = variant === 'info';
 
     return StyleSheet.create({
@@ -325,7 +325,6 @@ const getStyles = ({ width, height, minWidth, minHeight, variant = 'details', is
             // home indicator (bottom).
             paddingLeft: safeAreaLeft,
             paddingRight: safeAreaRight,
-            paddingBottom: safeAreaBottom,
             // Shadow and thin white frame for info variant only
             ...( (isInfoVariant||nested) && {
                 borderWidth: 1,
@@ -379,7 +378,6 @@ const getStyles = ({ width, height, minWidth, minHeight, variant = 'details', is
             maxHeight: '100%',
             paddingLeft: safeAreaLeft,
             paddingRight: safeAreaRight,
-            paddingBottom: safeAreaBottom,
         },
     });
 };

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -376,8 +376,6 @@ const getStyles = ({ width, height, minWidth, minHeight, variant = 'details', is
             height: isCompact ? undefined : '100%',
             borderRadius: 0,
             maxHeight: '100%',
-            paddingLeft: safeAreaLeft,
-            paddingRight: safeAreaRight,
         },
     });
 };

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -186,7 +186,14 @@ export const Dialog = ({
         }
     });
 
-    const styles = getStyles({ width, height, minWidth, minHeight, variant, isCompact, stripHeight, safeAreaLeft, safeAreaRight,  nested });
+    // Symmetric, not directional: the header title and the (centered) footer button bar would
+    // look optically off-balance if only the cutout side were padded. The dialog's own
+    // background always runs to the physical edge (see statusBarTranslucent/
+    // navigationBarTranslucent on the Modals below) - only this content-side padding keeps text
+    // and controls clear of the cutout.
+    const safeAreaPad = variant === 'full' ? Math.max(safeAreaLeft, safeAreaRight) : 0;
+
+    const styles = getStyles({ width, height, minWidth, minHeight, variant, isCompact, stripHeight, safeAreaPad, nested });
 
     // FIXES_BACKLOG #52 — workaround for a React Native new-architecture defect on iOS: when a
     // child view is added to an already-mounted subtree inside a <Modal>, Fabric calls
@@ -219,10 +226,12 @@ export const Dialog = ({
             <Modal
                 transparent={true}
                 visible={isModalActive}
-                supportedOrientations={['landscape']} 
+                supportedOrientations={['landscape']}
                 animationType="none"
-                presentationStyle="overFullScreen"                              
+                presentationStyle="overFullScreen"
                 onRequestClose={onOutsideClick}
+                statusBarTranslucent
+                navigationBarTranslucent
             >
                 <GestureHandlerRootView style={styles.fullScreenWrapper}>
                     <Animated.View style={[
@@ -263,8 +272,10 @@ export const Dialog = ({
             visible={isModalActive}
             animationType="fade"
             onRequestClose={onOutsideClick}
-            presentationStyle="overFullScreen"              
+            presentationStyle="overFullScreen"
             supportedOrientations={['landscape']}
+            statusBarTranslucent
+            navigationBarTranslucent
         >
             <GestureHandlerRootView style={styles.fullScreenWrapper}>
                 <TouchableWithoutFeedback onPress={onOutsideClick}>
@@ -302,7 +313,7 @@ type StyleProps = {
     nested?: boolean
 }
 
-const getStyles = ({ width, height, minWidth, minHeight, variant = 'details', isCompact, safeAreaLeft, safeAreaRight, nested=false }: StyleProps & { isCompact: boolean, stripHeight: number, safeAreaLeft: number, safeAreaRight: number }) => {
+const getStyles = ({ width, height, minWidth, minHeight, variant = 'details', isCompact, safeAreaPad, nested=false }: StyleProps & { isCompact: boolean, stripHeight: number, safeAreaPad: number }) => {
     const isInfoVariant = variant === 'info';
 
     return StyleSheet.create({
@@ -321,10 +332,13 @@ const getStyles = ({ width, height, minWidth, minHeight, variant = 'details', is
             borderRadius: variant === 'full' ? 0 : 12,
             overflow: 'hidden',
             color: colors.text,
-            // Keep content clear of the notch (left/right in this landscape-locked app) and the
-            // home indicator (bottom).
-            paddingLeft: safeAreaLeft,
-            paddingRight: safeAreaRight,
+            // The dialog's own gradient/background always runs to the physical screen edge
+            // (statusBarTranslucent/navigationBarTranslucent on the Modals below let the window
+            // draw under the notch/cutout) - this padding only keeps the *content* (header,
+            // buttons) clear of it. Content-only, so it's on `container` (the element
+            // DialogContent's children sit inside), not on the background surface itself.
+            paddingLeft: safeAreaPad,
+            paddingRight: safeAreaPad,
             // Shadow and thin white frame for info variant only
             ...( (isInfoVariant||nested) && {
                 borderWidth: 1,

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -376,6 +376,8 @@ const getStyles = ({ width, height, minWidth, minHeight, variant = 'details', is
             height: isCompact ? undefined : '100%',
             borderRadius: 0,
             maxHeight: '100%',
+            paddingLeft: safeAreaLeft,
+            paddingRight: safeAreaRight,
         },
     });
 };

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -133,7 +133,7 @@ export const Dialog = ({
 
             if (visible && !refInitialized.current) {
                 refInitialized.current = true;
-                logEvent({ message: 'dialog shown', dialog: title });
+                logEvent({ message: 'dialog shown', dialog: title, variant, safeAreaLeft, safeAreaRight });
                 EventLogger.setGlobalConfig('dialog', title);
             } else if (!visible && refInitialized.current) {
                 refInitialized.current = false;
@@ -156,7 +156,7 @@ export const Dialog = ({
                 setIsAnimating(false);
                 if (!refInitialized.current) {
                     refInitialized.current = true;
-                    logEvent({ message: 'dialog shown', dialog: title });
+                    logEvent({ message: 'dialog shown', dialog: title, variant, safeAreaLeft, safeAreaRight });
                     EventLogger.setGlobalConfig('dialog', title);
                 }
             });
@@ -176,7 +176,7 @@ export const Dialog = ({
                 }
             });
         }
-    }, [visible, isModalActive, animPos, initialPos, variant, logEvent, title]);
+    }, [visible, isModalActive, animPos, initialPos, variant, logEvent, title, safeAreaLeft, safeAreaRight]);
 
     useUnmountEffect(() => {
         if (refInitialized.current) {
@@ -371,13 +371,14 @@ const getStyles = ({ width, height, minWidth, minHeight, variant = 'details', is
             height: isCompact ? 0 : '100%',
             width: isCompact ? '100%' : 0,
         },
+        // Left/right safe-area padding for the 'full' variant is already carried by `container`
+        // above - both land on the same BackgroundContainer element via the style array, and RN
+        // overrides rather than adds within one array, so declaring it here too was dead code.
         fullContentArea: {
             flex: 1,
             height: isCompact ? undefined : '100%',
             borderRadius: 0,
             maxHeight: '100%',
-            paddingLeft: safeAreaLeft,
-            paddingRight: safeAreaRight,
         },
     });
 };

--- a/src/components/ListPageShell/ListPageShell.test.tsx
+++ b/src/components/ListPageShell/ListPageShell.test.tsx
@@ -86,7 +86,7 @@ describe('ListPageShell', () => {
 
     // App is landscape-locked, so the notch sits on left/right (whichever edge the current
     // rotation puts it on) and the home indicator sits at the bottom.
-    it('pads the shell for the notch and home indicator on all four edges', () => {
+    it('pads the shell for the notch and home indicator on let and right edges', () => {
         jest.spyOn(SafeAreaContext, 'useSafeAreaInsets').mockReturnValue({ top: 5, left: 24, right: 0, bottom: 34 });
 
         const { UNSAFE_root } = render(
@@ -97,15 +97,13 @@ describe('ListPageShell', () => {
 
         const container = UNSAFE_root.findAllByType(View).find((v: any) => {
             const flat = StyleSheet.flatten(v.props.style);
-            return typeof flat?.paddingTop === 'number';
+            return typeof flat?.paddingLeft === 'number';
         });
 
         expect(container).toBeTruthy();
         const flat = StyleSheet.flatten(container!.props.style);
-        expect(flat.paddingTop).toBe(5);
         expect(flat.paddingLeft).toBe(24);
         expect(flat.paddingRight).toBe(0);
-        expect(flat.paddingBottom).toBe(34);
 
         jest.restoreAllMocks();
     });

--- a/src/components/ListPageShell/ListPageShell.tsx
+++ b/src/components/ListPageShell/ListPageShell.tsx
@@ -27,14 +27,14 @@ export const ListPageShell = ({
 }: ListPageShellProps) => {
     // App is landscape-locked, so the notch sits on left/right (whichever edge the current
     // rotation puts it on) and the home indicator sits at the bottom.
-    const { top, left, right, bottom } = useSafeAreaInsets();
+    const { left, right } = useSafeAreaInsets();
 
     return (
     <MainBackground>
         <View style={[
             styles.container,
             compact && styles.containerCompact,
-            { paddingTop: top, paddingLeft: left, paddingRight: right, paddingBottom: bottom },
+            { paddingLeft: left, paddingRight: right},
         ]}>
             <View style={[styles.navColumn, compact ? styles.navColumnCompact : styles.navColumnNormal]}>
                 <NavigationBar

--- a/src/components/ListPageShell/ListPageShell.tsx
+++ b/src/components/ListPageShell/ListPageShell.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MainBackground } from '../MainBackground';
 import { NavigationBar } from '../NavigationBar';
+import { COMPACT_NAV_HEIGHT } from '../NavigationBar/NavigationBarViewCompact';
 import { colors, textSizes } from '../../theme';
 import { ListPageShellProps } from './types';
 
@@ -78,7 +79,7 @@ const styles = StyleSheet.create({
         width: 150,
     },
     navColumnCompact: {
-        height: 56,
+        height: COMPACT_NAV_HEIGHT,
         width: '100%',
     },
     contentColumn: {

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -104,6 +104,10 @@ export const NavigationBar = (props: NavigationBarProps) => {
                     onClick={handleOnClick}
                     showExit={showExitIcon}
                     disabled={disabled}
+                    // ListPageShell's navColumnCompact wrapper gives this a definite height -
+                    // stretch to fill it rather than sizing to intrinsic content, which used to
+                    // leave unfilled transparent space below the visible bar.
+                    style={{ flex: 1 }}
                 />
             ) : (
                 <NavigationBarView

--- a/src/components/NavigationBar/NavigationBarViewCompact.tsx
+++ b/src/components/NavigationBar/NavigationBarViewCompact.tsx
@@ -12,7 +12,13 @@ import {
     ExitIcon,
 } from '../../assets/icons';
 
-export const COMPACT_NAV_HEIGHT = textSizes.smallText + 16;
+// Measured (onLayout, real device) content height of this bar - `textSizes.smallText + 16` looks
+// like the obvious formula but undercounts the icon+label row's real height once line-height is
+// included (28 vs the real 45.33), and was never actually wired up to anything until now. Anyone
+// consuming this (ListPageShell's navColumnCompact box, SettingsSlideIn's peek-through strip)
+// needs the real number, not a derivation that looks right but isn't - re-measure via onLayout
+// if this row's content ever changes rather than adjusting the formula blind.
+export const COMPACT_NAV_HEIGHT = 45.33;
 
 // Helper for rendering icons based on the TNavigationItem
 const renderIcon = (item: TNavigationItem, isSelected: boolean, disabled:boolean=false) => {
@@ -72,12 +78,12 @@ const leftItems: { item: TNavigationItem; label: string }[] = [
 
 
 export const NavigationBarViewCompact = (props: NavigationBarViewCompactProps) => {
-    const { selected, disabled=false, showExit, onClick } = props;
+    const { selected, disabled=false, showExit, onClick, style } = props;
 
     const rightItems: TNavigationItem[] = showExit ? ['exit','settings', 'user' ] : ['settings', 'user' ];
 
     return (
-        <View style={styles.container}>
+        <View style={[styles.container, style]}>
             <View style={styles.leftItemsContainer}>
                 {leftItems.map(({ item, label }) => (
                     <CompactNavItem

--- a/src/components/NavigationBar/types.ts
+++ b/src/components/NavigationBar/types.ts
@@ -1,3 +1,5 @@
+import { StyleProp, ViewStyle } from 'react-native';
+
 export type TNavigationItem =
     | 'user'
     | 'settings'
@@ -30,4 +32,8 @@ export interface NavigationBarViewCompactProps {
     disabled?: boolean;
     onClick: (item: TNavigationItem) => void;
     showExit: boolean;
+    // Lets a caller with a definite-height container (e.g. ListPageShell's navColumnCompact box)
+    // stretch this bar to fill it (style={{flex:1}}) instead of it sizing to its own intrinsic
+    // content - left undefined, standalone/Storybook usage keeps its natural size unchanged.
+    style?: StyleProp<ViewStyle>;
 }

--- a/src/components/RideDashboard/RideDashboardView.tsx
+++ b/src/components/RideDashboard/RideDashboardView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useWindowDimensions, View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, Dimensions } from 'react-native';
 import { Icon, IconName } from '../Icon';
 import { colors, textSizes } from '../../theme';
 import { METRIC_ICON, RideDashboardViewProps, getValueColor, ActivityDashboardItem, WorkoutDashboardLine } from './types';
@@ -8,7 +8,7 @@ const SEPARATOR_WIDTH = 1; // styles.separator's own width, below
 const CONTAINER_H_PADDING = 8; // styles.container's own paddingHorizontal, below — applies on both sides
 
 export const RideDashboardView = ({ items, layout = 'icon-top', compact = false, workoutShoutout = null }: RideDashboardViewProps) => {
-    const { width } = useWindowDimensions();
+    const {width} = Dimensions.get('screen')
     const showWorkoutShoutout = !!workoutShoutout;
 
     const minColWidth = 70; // Minimum column width for calculation in compact mode
@@ -60,9 +60,9 @@ export const RideDashboardView = ({ items, layout = 'icon-top', compact = false,
         // Determine effective layout
         const effectiveLayout = compact ? 'icon-left' : (layout ?? 'icon-top');
         
-        const currentColWidth = 
-            compact 
-                ? width / visibleItems.length 
+        const currentColWidth =
+            compact
+                ? width / visibleItems.length
                 : (effectiveLayout === 'icon-left' ? colWidthLeft : colWidthBase);
         const currentIconSize = (effectiveLayout === 'icon-left' && !compact) ? iconSizeLeft : iconSizeTop;
         

--- a/src/components/RideMenu/RideMenu.test.tsx
+++ b/src/components/RideMenu/RideMenu.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import { StyleSheet, View } from 'react-native';
+import * as SafeAreaContext from 'react-native-safe-area-context';
 import { RideMenuView } from './RideMenuView'; // Target the View component
 import { ActiveDialog } from './types'; // Import ActiveDialog type for clarity
 import { useIsTablet, useScreenLayout } from '../../hooks';
@@ -122,6 +124,47 @@ describe('RideMenuView', () => {
 
     it('renders with Step Forward disabled (last step)', () => {
         render(<RideMenuView {...workoutProps} visible={true} activeDialog={null} canStepForward={false} />);
+    });
+
+    // Not a Modal, so there's no OS-level window inset to lean on - this opaque, left-anchored
+    // panel is the only thing keeping the header/close button and every row clear of the
+    // notch/cutout. Applied once on the panel itself so header/content/footer inherit it via
+    // normal nested-padding stacking. Left-anchored, so safeAreaRight is never read - the right
+    // edge always sits mid-screen, never at a physical edge. The inset is added as extra width
+    // (not carved out of the existing panel width), so the usable content area doesn't shrink.
+    describe('safe-area insets', () => {
+        const findPanel = (root: ReturnType<typeof render>['UNSAFE_root']) =>
+            root.findAllByType(View).find((v: any) => {
+                const flat = StyleSheet.flatten(v.props.style);
+                return flat?.backgroundColor === 'rgba(0, 0, 0, 0.88)';
+            });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it('adds no padding or extra width when there is nothing to clear (safeAreaLeft=0)', () => {
+            jest.spyOn(SafeAreaContext, 'useSafeAreaInsets').mockReturnValue({ top: 0, left: 0, right: 40, bottom: 0 });
+
+            const { UNSAFE_root } = render(<RideMenuView {...mockProps} visible={true} activeDialog={null} />);
+
+            const flat = StyleSheet.flatten(findPanel(UNSAFE_root)!.props.style);
+            expect(flat.paddingLeft).toBe(0);
+        });
+
+        it('pads the content and widens the panel by the left inset, ignoring the right inset entirely', () => {
+            jest.spyOn(SafeAreaContext, 'useSafeAreaInsets').mockReturnValue({ top: 0, left: 0, right: 0, bottom: 0 });
+            const { UNSAFE_root: noInsetRoot } = render(<RideMenuView {...mockProps} visible={true} activeDialog={null} />);
+            const noInsetWidth = StyleSheet.flatten(findPanel(noInsetRoot)!.props.style).width;
+
+            jest.spyOn(SafeAreaContext, 'useSafeAreaInsets').mockReturnValue({ top: 0, left: 32, right: 99, bottom: 0 });
+            const { UNSAFE_root } = render(<RideMenuView {...mockProps} visible={true} activeDialog={null} />);
+
+            const flat = StyleSheet.flatten(findPanel(UNSAFE_root)!.props.style);
+            expect(flat.paddingLeft).toBe(32);
+            expect(flat.paddingRight).toBeUndefined();
+            expect(flat.width).toBe(noInsetWidth + 32);
+        });
     });
 
     it('calls onEndRide when End Ride is pressed', () => {

--- a/src/components/RideMenu/RideMenuView.tsx
+++ b/src/components/RideMenu/RideMenuView.tsx
@@ -11,6 +11,7 @@ import {
     ScrollView,
     LayoutChangeEvent
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { RideMenuViewProps } from './types';
 import { colors, textSizes } from '../../theme';
 import { useScreenLayout, useIsTablet, useLogging } from '../../hooks';
@@ -93,6 +94,14 @@ export const RideMenuView = ({
     // tablet-width screen is not compact, so this only changes anything for typical tablets.
     const useSingleColumnRows = isTablet && !isCompact;
     const { logEvent } = useLogging('RideMenu');
+    // Not a Modal, so there's no OS-level window inset to lean on (same reasoning as
+    // SettingsSlideIn) - this opaque, left-anchored panel is the only thing keeping the header/
+    // close button and every row/footer button clear of the notch/cutout. Applied once here on
+    // the panel itself (not on each row style) so header/content/footer all inherit it via
+    // normal nested-padding stacking, on top of whatever paddingHorizontal each already has.
+    // Right is never read - this panel is always left-anchored, so its right edge sits mid-screen
+    // rather than at a physical edge a cutout could ever be on.
+    const { left: safeAreaLeft } = useSafeAreaInsets();
 
     const maxPanelWidth = isTablet ? TABLET_MAX_PANEL_WIDTH : PHONE_MAX_PANEL_WIDTH;
     const panelWidth = isCompact
@@ -290,14 +299,26 @@ export const RideMenuView = ({
         pointerEvents: panelPointerEvents as 'box-none' | 'none',
     };
 
+    // Left-anchored panel, so safeAreaRight never applies - the right edge sits mid-screen, not
+    // at a physical edge. When there's nothing to clear (safeAreaLeft=0, the common case), add no
+    // padding at all. Otherwise the inset is added as extra width, not carved out of the existing
+    // panelWidth, so the usable content area stays the same size and just shifts right by the pad.
     const panelDynamicLayout = {
-        width: panelWidth,
+        width: panelWidth + safeAreaLeft,
         transform: [{ translateY: animTranslateY }],
+        paddingLeft: safeAreaLeft,
     };
 
     return (
         <View
-            style={StyleSheet.absoluteFill}
+            // `panel`'s own zIndex:1000 below only ranks it against its sibling within this
+            // subtree (backdrop) - it has no effect on RideDashboard, which is a sibling of THIS
+            // root view several levels up (GPX/View.tsx), with its own zIndex:10. Without a
+            // zIndex here too, this whole subtree rendered underneath the dashboard on Android,
+            // making the menu's top rows unreachable. elevation is the Android-specific
+            // equivalent RN needs alongside zIndex - same pairing GPX/View.tsx's own
+            // `mapOverlay` style already uses for the same reason.
+            style={[StyleSheet.absoluteFill, styles.root]}
             pointerEvents={rootContainerPointerEvents}
         >
             <TouchableWithoutFeedback
@@ -399,6 +420,9 @@ export const RideMenuView = ({
 };
 
 const styles = StyleSheet.create({
+    root: {
+        zIndex: 1000,
+    },
     backdrop: {
         ...StyleSheet.absoluteFill,
         backgroundColor: 'rgba(0,0,0,0.4)',

--- a/src/components/RideSettings/RideSettingsView.tsx
+++ b/src/components/RideSettings/RideSettingsView.tsx
@@ -36,7 +36,7 @@ export const RideSettingsView = ({
     return (
         <Dialog
             title="Ride View"
-            variant="details"
+            variant="full"
             onOutsideClick={onClose}
             buttons={[{ label: 'Close', primary: true, onClick: onClose }]}
         >

--- a/src/components/SettingsSlideIn/SettingsSlideIn.test.tsx
+++ b/src/components/SettingsSlideIn/SettingsSlideIn.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
+import * as SafeAreaContext from 'react-native-safe-area-context';
 import { SettingsSlideIn } from './SettingsSlideIn';
 import { SettingsSectionItem } from './types';
 
@@ -67,5 +69,31 @@ describe('SettingsSlideIn', () => {
 
         fireEvent.press(getByTestId('settings-backdrop'));
         expect(onClose).toHaveBeenCalled();
+    });
+
+    // This panel is always mounted inside ListPageShell's own tree (via NavigationBar), which
+    // already shifts everything clear of the notch/cutout via its own paddingLeft/paddingRight -
+    // adding a second safe-area inset here doubled it. Row padding is the fixed baseline only.
+    describe('safe-area insets', () => {
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it('does not add its own safe-area inset on top of the baseline row padding', () => {
+            jest.spyOn(SafeAreaContext, 'useSafeAreaInsets').mockReturnValue({ top: 0, left: 30, right: 0, bottom: 0 });
+
+            const { getByTestId } = render(
+                <SettingsSlideIn
+                    visible={true}
+                    sections={MOCK_SECTIONS}
+                    onClose={jest.fn()}
+                    onSectionPress={jest.fn()}
+                />
+            );
+
+            const row = getByTestId('section-Gear');
+            const flat = StyleSheet.flatten(row.props.style);
+            expect(flat.paddingHorizontal).toBe(20);
+        });
     });
 });

--- a/src/components/SettingsSlideIn/SettingsSlideIn.tsx
+++ b/src/components/SettingsSlideIn/SettingsSlideIn.tsx
@@ -8,11 +8,13 @@ import {
     useWindowDimensions,
     Platform,
     Text,
-    DimensionValue
+    DimensionValue,
+    Dimensions
 } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import { SettingsSlideInProps } from './types';
 import { colors, textSizes } from '../../theme';
+import { COMPACT_NAV_HEIGHT } from '../NavigationBar/NavigationBarViewCompact';
 import { useLogging, useScreenLayout } from '../../hooks';
 
 const gradientColors = colors.dialogBackground;
@@ -27,16 +29,19 @@ export const SettingsSlideIn = ({
     onClose,
     onSectionPress
 }: SettingsSlideInProps) => {
-    const { width: screenWidth, height: screenHeight } = useWindowDimensions();
+    const { width: screenWidth } = useWindowDimensions();
     const { logEvent } = useLogging('SettingsSlideIn');
     const layout = useScreenLayout();
     const isCompact = layout === 'compact';
-    const NAV_BAR_HEIGHT = 56;
-
     // Layout calculations
-    const stripSize = isCompact ? NAV_BAR_HEIGHT : 150;
+    const stripSize = isCompact ? COMPACT_NAV_HEIGHT : 150;
     const panelWidth = screenWidth * 0.35;
-    const totalSize = isCompact ? screenHeight : (stripSize + panelWidth);
+    // Dimensions.get('screen'), not useWindowDimensions() - confirmed on-device that the window
+    // height under-reports the true screen by ~15dp (the gesture-bar inset), even though the app
+    // actually renders behind it. Using the window value here left the compact panel short of
+    // the real bottom edge by exactly that amount.
+    const rawScreenHeight = Dimensions.get('screen').height;
+    const totalSize = isCompact ? rawScreenHeight : (stripSize + panelWidth);
     
     // Start off-screen
     const animPos = useRef(new Animated.Value(-totalSize)).current;
@@ -85,8 +90,8 @@ export const SettingsSlideIn = ({
     const backdropPointerEvents = visible ? 'auto' : 'none';
     const backdropOpacity = visible ? 1 : 0;
 
-    const dynamicContainerStyle = isCompact 
-        ? { height: totalSize, width: screenWidth, flexDirection: 'column' as const } 
+    const dynamicContainerStyle = isCompact
+        ? { height: totalSize, width: screenWidth, flexDirection: 'column' as const }
         : { width: totalSize, flexDirection: 'row' as const };
 
     const dynamicTransform = isCompact 
@@ -97,13 +102,13 @@ export const SettingsSlideIn = ({
         ? { height: stripSize, width: '100%' as DimensionValue } 
         : { width: stripSize, height: '100%' as DimensionValue };
 
-    const dynamicPanelStyle = isCompact 
-        ? { flex: 1, width: '100%' as DimensionValue } 
+    const dynamicPanelStyle = isCompact
+        ? { flex: 1, width: '100%' as DimensionValue }
         : { width: panelWidth, height: '100%' as DimensionValue };
 
     return (
-        <View 
-            style={StyleSheet.absoluteFill} 
+        <View
+            style={StyleSheet.absoluteFill}
             pointerEvents={visible || isAnimating ? 'box-none' : 'none'}
             testID="settings-slide-in"
         >
@@ -138,9 +143,9 @@ export const SettingsSlideIn = ({
                 >
                     <View style={styles.content}>
                         {sections.map((section) => (
-                            <TouchableOpacity 
+                            <TouchableOpacity
                                 key={section.label}
-                                style={styles.row} 
+                                style={styles.row}
                                 onPress={() => handleSectionPress(section.label)}
                                 testID={`section-${section.label}`}
                             >
@@ -179,6 +184,9 @@ const styles = StyleSheet.create({
         justifyContent: 'space-between',
         alignItems: 'center',
         paddingVertical: 20,
+        // No safe-area inset here: this panel is nested inside ListPageShell's own tree, which
+        // already shifts everything (including where this mounts) clear of the notch/cutout via
+        // its own paddingLeft/paddingRight - adding it again here doubled the inset.
         paddingHorizontal: 20,
         borderBottomWidth: 1,
         borderBottomColor: 'rgba(255,255,255,0.15)',

--- a/src/components/SettingsSlideIn/SettingsSlideIn.tsx
+++ b/src/components/SettingsSlideIn/SettingsSlideIn.tsx
@@ -91,7 +91,7 @@ export const SettingsSlideIn = ({
     const backdropOpacity = visible ? 1 : 0;
 
     const dynamicContainerStyle = isCompact
-        ? { height: totalSize, width: screenWidth, flexDirection: 'column' as const }
+        ? { height: totalSize, width: '100%' as DimensionValue , flexDirection: 'column' as const }
         : { width: totalSize, flexDirection: 'row' as const };
 
     const dynamicTransform = isCompact 

--- a/src/hooks/files/useFilePicker.test.ts
+++ b/src/hooks/files/useFilePicker.test.ts
@@ -249,9 +249,40 @@ describe('useFilePicker', () => {
         expect(mockPick).toHaveBeenCalledTimes(1)
     })
 
-    it('returns null when result has no name', async () => {
+    it('falls back to a uri-derived name and still attempts the copy when metadata has no name', async () => {
+        // Seen in production: the picker's metadata query intermittently fails (empty name,
+        // permission-flavored error) for files that keepLocalCopy can read moments later - the
+        // metadata query and the actual copy are separate native operations, so a failure in one
+        // shouldn't be treated as proof the file itself is unreadable.
         mockPick.mockResolvedValueOnce([
-            { name: undefined, uri: 'file:///path/to/test.gpx' },
+            { name: null, uri: 'file:///path/to/BarcelonaBike.gpx', error: 'permission error', nativeType: 'dyn.xyz' },
+        ])
+        mockKeepLocalCopy.mockResolvedValueOnce([
+            { status: 'success', localUri: 'file:///cache/BarcelonaBike.gpx', copyError: null },
+        ])
+
+        const { result } = renderHook(() => useFilePicker())
+        const fileInfo = await result.current.pickFile()
+
+        expect(mockLogEvent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'file picker returned no name, falling back to uri-derived name',
+                uri: 'file:///path/to/BarcelonaBike.gpx',
+                fileName: 'BarcelonaBike.gpx',
+                error: 'permission error',
+                nativeType: 'dyn.xyz',
+            })
+        )
+        expect(mockKeepLocalCopy).toHaveBeenCalledWith({
+            files: [{ uri: 'file:///path/to/BarcelonaBike.gpx', fileName: 'BarcelonaBike.gpx' }],
+            destination: 'cachesDirectory',
+        })
+        expect(fileInfo).not.toBeNull()
+    })
+
+    it('returns null when name is missing and no filename can be derived from the uri either', async () => {
+        mockPick.mockResolvedValueOnce([
+            { name: undefined, uri: 'file:///' },
         ])
 
         const { result } = renderHook(() => useFilePicker())
@@ -259,22 +290,9 @@ describe('useFilePicker', () => {
 
         expect(fileInfo).toBeNull()
         expect(mockKeepLocalCopy).not.toHaveBeenCalled()
-    })
-
-    it('logs the picker result when name is missing, surfacing any per-file error', async () => {
-        mockPick.mockResolvedValueOnce([
-            { name: null, uri: 'file:///path/to/test.gpx', error: 'sourceAccessError', nativeType: 'public.item' },
-        ])
-
-        const { result } = renderHook(() => useFilePicker())
-        await result.current.pickFile()
-
         expect(mockLogEvent).toHaveBeenCalledWith(
             expect.objectContaining({
-                message: 'file picker returned no name',
-                uri: 'file:///path/to/test.gpx',
-                error: 'sourceAccessError',
-                nativeType: 'public.item',
+                message: 'could not derive filename from uri either, giving up',
             })
         )
     })

--- a/src/hooks/files/useFilePicker.test.ts
+++ b/src/hooks/files/useFilePicker.test.ts
@@ -299,22 +299,31 @@ describe('useFilePicker', () => {
         )
     })
 
-    it('handles ios platform with decodeURIComponent', async () => {
+    it('on iOS, goes through keepLocalCopy like Android instead of requesting open-mode access', async () => {
+        // 'open' mode requires startAccessingSecurityScopedResource() to succeed, which fails
+        // silently-from-the-app's-perspective for files vended by some third-party File Provider
+        // extensions (seen in production: a permission error on a file picked from a custom
+        // iCloud folder). Import mode + keepLocalCopy sidesteps that entirely, matching Android.
         Platform.OS = 'ios'
 
         mockPick.mockResolvedValueOnce([
             { name: 'test.gpx', uri: 'file:///path/to/test.gpx' },
         ])
+        mockKeepLocalCopy.mockResolvedValueOnce([
+            { status: 'success', localUri: 'file:///cache/test.gpx', copyError: null },
+        ])
 
         const { result } = renderHook(() => useFilePicker())
         await result.current.pickFile()
 
-        // On iOS, it returns early after decoding the URI without calling keepLocalCopy
-        expect(mockKeepLocalCopy).not.toHaveBeenCalled()
+        expect(mockKeepLocalCopy).toHaveBeenCalledWith({
+            files: [{ uri: 'file:///path/to/test.gpx', fileName: 'test.gpx' }],
+            destination: 'cachesDirectory',
+        })
         expect(mockPick).toHaveBeenCalledWith(
-            expect.objectContaining({
-                mode: 'open',
-                requestLongTermAccess: false,
+            expect.not.objectContaining({
+                mode: expect.anything(),
+                requestLongTermAccess: expect.anything(),
             })
         )
     })

--- a/src/hooks/files/useFilePicker.test.ts
+++ b/src/hooks/files/useFilePicker.test.ts
@@ -261,6 +261,24 @@ describe('useFilePicker', () => {
         expect(mockKeepLocalCopy).not.toHaveBeenCalled()
     })
 
+    it('logs the picker result when name is missing, surfacing any per-file error', async () => {
+        mockPick.mockResolvedValueOnce([
+            { name: null, uri: 'file:///path/to/test.gpx', error: 'sourceAccessError', nativeType: 'public.item' },
+        ])
+
+        const { result } = renderHook(() => useFilePicker())
+        await result.current.pickFile()
+
+        expect(mockLogEvent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'file picker returned no name',
+                uri: 'file:///path/to/test.gpx',
+                error: 'sourceAccessError',
+                nativeType: 'public.item',
+            })
+        )
+    })
+
     it('returns null when local copy fails', async () => {
         mockPick.mockResolvedValueOnce([
             { name: 'test.gpx', uri: 'file:///path/to/test.gpx' },

--- a/src/hooks/files/useFilePicker.ts
+++ b/src/hooks/files/useFilePicker.ts
@@ -69,8 +69,14 @@ export const useFilePicker = (): UseFilePickerResult => {
 
             const [result] = await pick(props)
 
-            if (!result.name)
+            if (!result) {
+                logEvent({ message:'file picker returned no result' })
                 return null;
+            }
+            if (!result.name) {
+                logEvent({ message:'file picker returned no name', uri: result.uri, error: result.error, nativeType: result.nativeType })
+                return null;
+            }
 
             // const info = getPathBinding().parse(result.name)
             // return buildFileInfo(result.name,info.base)

--- a/src/hooks/files/useFilePicker.ts
+++ b/src/hooks/files/useFilePicker.ts
@@ -50,10 +50,6 @@ export const useFilePicker = (): UseFilePickerResult => {
                 type: [types.allFiles],
                 allowMultiSelection: false,
             }
-            if (Platform.OS === 'ios') {
-                props.mode = 'open'
-                props.requestLongTermAccess= false
-            }
 
             if (extensions?.length) {
                 props.types = []
@@ -78,19 +74,9 @@ export const useFilePicker = (): UseFilePickerResult => {
                 return null;
             }
 
-            // const info = getPathBinding().parse(result.name)
-            // return buildFileInfo(result.name,info.base)
             const fileName = result.name
 
-            if (Platform.OS === 'ios') {
-                const cleaned = decodeURIComponent(result.uri).replace('file://', '');
-                logEvent({ message:'File picked', fileName, uri: cleaned})  
-                return  buildFileInfo(cleaned,fileName)
-
-            }
-            else {
-                logEvent({ message:'File picked', fileName, uri: result.uri })  
-            }
+            logEvent({ message:'File picked', fileName, uri: result.uri })
 
             const [localCopy] = await keepLocalCopy({
                 files: [{ uri: result.uri, fileName: fileName }],

--- a/src/hooks/files/useFilePicker.ts
+++ b/src/hooks/files/useFilePicker.ts
@@ -69,12 +69,20 @@ export const useFilePicker = (): UseFilePickerResult => {
                 logEvent({ message:'file picker returned no result' })
                 return null;
             }
-            if (!result.name) {
-                logEvent({ message:'file picker returned no name', uri: result.uri, error: result.error, nativeType: result.nativeType })
-                return null;
+            // The picker's metadata query (name/size/type) and the actual file copy below are
+            // separate native operations. The metadata query intermittently fails (empty name,
+            // permission-flavored error) for files that are perfectly readable moments later via
+            // keepLocalCopy - so fall back to a URI-derived name and still attempt the copy,
+            // rather than giving up on a file we may well be able to read.
+            let fileName = result.name
+            if (!fileName) {
+                fileName = decodeURIComponent(result.uri).split('/').pop() || ''
+                logEvent({ message:'file picker returned no name, falling back to uri-derived name', uri: result.uri, fileName, error: result.error, nativeType: result.nativeType })
+                if (!fileName) {
+                    logEvent({ message:'could not derive filename from uri either, giving up', uri: result.uri })
+                    return null
+                }
             }
-
-            const fileName = result.name
 
             logEvent({ message:'File picked', fileName, uri: result.uri })
 


### PR DESCRIPTION
## Summary

### 1. Improve/Fix GPX Import and Video Library Import

iOS cannot enumerate directories on certain external volumes (SMB shares, encrypted folders, some File Provider backends) using plain, uncoordinated APIs. This fix ensures three things work correctly:

1. **Coordinated reads first.** What a File Provider expects, at zero cost on local paths.
2. **Entries preserved even when metadata fails.** react-native-fs drops entries whose attributes won't load; we keep them (dir defaults to false if unknown).
3. **Clear reporting when a volume won't enumerate.** A volume that legitimately can't be listed reports `ERR_LIST_EMPTY` with details, not a misleading "folder is empty."

The changes are scoped: the fallback only runs on iOS where an uncoordinated listing already returned nothing for a path outside the app sandbox (iCloud Drive, NAS share, etc.), so local and cached folders are untouched.

### 2. Improve SafeArea handling in Compact mode

## Test plan

- [ ] Scan a local folder with video routes → should work as before
- [ ] Scan an iCloud Drive folder with video routes → should work as before  
- [ ] (With a QNAP or Synology NAS mounted via Files app) scan that folder → reports clearly that enumeration failed, no misleading "no routes found"
- [ ] `npm test` in mobile/ → all 1368 tests pass
- [ ] `npx tsc --noEmit` → no type errors
- [ ] `npx eslint src/bindings/fs/` → no lint errors